### PR TITLE
GHA: Trigger release workflow when tags are pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+  # discussions: write
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/changelog.d/+gha-release.infra.rst
+++ b/changelog.d/+gha-release.infra.rst
@@ -1,0 +1,1 @@
+GHA: Trigger release workflow when tags are pushed


### PR DESCRIPTION
The GHA workflow looks for semantic versioning tags in the format of `major.minor.patch`. Each part is a digit.