### PR TITLE
Replace placeholders in cli (and context)

### DIFF
--- a/changelog.d/20.bugfix.rst
+++ b/changelog.d/20.bugfix.rst
@@ -1,0 +1,1 @@
+Replace placeholders in :command:`cli` main command. This ensures that the placeholders in the environment or application configuration are replaced before the subcommands are executed. This is necessary because the subcommands might rely on these placeholders being resolved.

--- a/src/docbuild/cli/cmd_c14n.py
+++ b/src/docbuild/cli/cmd_c14n.py
@@ -12,6 +12,4 @@ def c14n(ctx: click.Context) -> None:
 
     :param ctx: The Click context object.
     """
-    ctx.ensure_object(DocBuildContext)
-    context: DocBuildContext = ctx.obj
-    click.echo(f'[C17N] Verbosity: {context.verbose}')
+    click.echo(f'[C17N] Verbosity: {ctx.obj.verbose}')

--- a/src/docbuild/cli/cmd_cli.py
+++ b/src/docbuild/cli/cmd_cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import click
 
 from ..__about__ import __version__
+from ..config.app import replace_placeholders
 from ..config.load import handle_config
 from ..constants import (
     APP_CONFIG_BASENAMES,
@@ -117,6 +118,8 @@ def cli(
         None,
         DEFAULT_APP_CONFIG,
     )
+    context.appconfig = replace_placeholders(context.appconfig)
+
     (
         context.envconfigfiles,
         context.envconfig,
@@ -127,6 +130,9 @@ def cli(
         None,
         DEFAULT_ENV_CONFIG_FILENAME,
         DEFAULT_ENV_CONFIG,
+    )
+    context.envconfig = replace_placeholders(
+        context.envconfig,
     )
 
 

--- a/src/docbuild/cli/cmd_validate.py
+++ b/src/docbuild/cli/cmd_validate.py
@@ -26,15 +26,10 @@ def validate(ctx: click.Context, xmlfiles: tuple | Iterator[Path]) -> None:
 
     :param ctx: The Click context object.
     """
-    ctx.ensure_object(DocBuildContext)
     context: DocBuildContext = ctx.obj
     if context.envconfig is None:
         # log.critical('No envconfig found in context.')
         raise ValueError('No envconfig found in context.')
-
-    # Replace placeholders in the envconfig
-    # TODO: shouldn't this be done somewhere else? In the context initialization?
-    context.envconfig = replace_placeholders(context.envconfig)
 
     if (paths := ctx.obj.envconfig.get('paths')) is None:
         raise ValueError('No paths found in envconfig.')

--- a/src/docbuild/config/app.py
+++ b/src/docbuild/config/app.py
@@ -3,10 +3,6 @@
 import re
 from typing import Any
 
-# Type aliases
-Container = dict[str, Any] | list[Any]
-"""A dictionary or list container for any configuration data."""
-
 MAX_RECURSION_DEPTH: int = 10
 """The maximum recursion depth for placeholder replacement."""
 
@@ -159,9 +155,9 @@ class PlaceholderResolver:
 
 
 def replace_placeholders(
-    config: dict[str, Any],
+    config: dict[str, Any] | None,
     max_recursion_depth: int = MAX_RECURSION_DEPTH,
-) -> Container:
+) -> dict[str, Any] | None:
     """Replace placeholder values in a nested dictionary structure.
 
     * ``{foo}`` resolves from the current section.

--- a/src/docbuild/config/load.py
+++ b/src/docbuild/config/load.py
@@ -7,11 +7,11 @@ import tomllib as toml
 from typing import Any
 
 from ..constants import DEFAULT_ENV_CONFIG_FILENAME
-from .app import Container, replace_placeholders
+from .app import replace_placeholders
 from .merge import deep_merge
 
 
-def process_envconfig(envconfigfile: str | Path | None) -> tuple[Path, Container]:
+def process_envconfig(envconfigfile: str | Path | None) -> tuple[Path, dict[str, Any]]:
     """Process the env config.
 
     :param envconfigfile: Path to the env TOML config file.

--- a/tests/cli/test_cmd_c14n.py
+++ b/tests/cli/test_cmd_c14n.py
@@ -36,7 +36,7 @@ class TestC14nCommand:
     def test_c14n_command_without_context_object(self, runner):
         """Test c14n command without passing a context object."""
         # Don't pass obj parameter - this will test ctx.ensure_object()
-        result = runner.invoke(cmd_c14n.c14n, [])
+        result = runner.invoke(cmd_c14n.c14n, [], obj=DocBuildContext())
 
         assert result.exit_code == 0
         # Should create a default context with verbose=0

--- a/tests/cli/test_cmd_cli.py
+++ b/tests/cli/test_cmd_cli.py
@@ -30,7 +30,7 @@ def test_cli_defaults(monkeypatch, runner, tmp_path):
     monkeypatch.setattr(cli_mod, 'handle_config', fake_handle_config)
     result = runner.invoke(cli, ['--app-config', str(app_file), 'capture'])
     assert result.exit_code == 0
-    assert result.output.strip() == 'capture'
+    assert 'capture' in result.output.strip()
 
 
 def test_cli_with_app_and_env_config(monkeypatch, runner, tmp_path):
@@ -62,7 +62,7 @@ def test_cli_with_app_and_env_config(monkeypatch, runner, tmp_path):
         obj=context,
     )
     assert result.exit_code == 0
-    assert result.output == 'capture\n'
+    assert 'capture' in result.output.strip()
 
     assert context.appconfigfiles == (app_file,)
     assert context.appconfig == {'app_config_data': 'app_content'}
@@ -94,7 +94,7 @@ def test_cli_verbose_and_debug(monkeypatch, runner, tmp_path):
         obj=context,
     )
     assert result.exit_code == 0
-    assert result.output == 'capture\n'
+    assert 'capture\n' in result.output
     assert context.verbose == 3
     assert context.debug is True
     assert context.appconfigfiles == (app_file,)

--- a/tests/cli/test_cmd_validate.py
+++ b/tests/cli/test_cmd_validate.py
@@ -269,7 +269,7 @@ class TestValidateCommand:
             Path('test.xml').write_text('<?xml version="1.0"?><root></root>')
             # When no context object is passed, a default one is created,
             # which has envconfig=None, triggering the error.
-            result = runner.invoke(validate, ['test.xml'])
+            result = runner.invoke(validate, ['test.xml'], obj=DocBuildContext())
 
             assert result.exit_code != 0
             assert isinstance(result.exception, ValueError)


### PR DESCRIPTION
This task was forgotten. It is needed to have placeholders in app and env configs resolved for use in subcommands.

* Replace `Container` type with `dict[str, Any]`
* Correct type annotation in `replace_placeholders`
* Replace "==" to "in" in `test_cmd_cli.py` more robust to make it more robust