### PR TITLE
Fix #31 in Doctype.xpath with '*' for products

### DIFF
--- a/changelog.d/31.bugfix.rst
+++ b/changelog.d/31.bugfix.rst
@@ -1,0 +1,4 @@
+Correctly convert ``'*'`` for products in :func:`docbuild.model.doctype.Doctype.xpath`
+
+An XPath ``//*`` created a syntactically correct XPath, but with an
+additional and unnecessary ``[@productid='*']`` predicate.

--- a/src/docbuild/models/doctype.py
+++ b/src/docbuild/models/doctype.py
@@ -244,7 +244,10 @@ class Doctype(BaseModel):
             deliverables that match this Doctype.
         """
         # Example: /sles/15-SP6@supported/en-us,de-de
-        product = f"product[@productid={self.product.value!r}]"
+        product = "product"
+        if self.product != Product.ALL:
+            product += f'[@productid={self.product.value!r}]'
+
         setids = [f'@setid={d!r}' for d in self.docset if d != '*']
 
         setids_str = ' or '.join(setids)

--- a/tests/models/test_doctype.py
+++ b/tests/models/test_doctype.py
@@ -255,6 +255,10 @@ def test_sorted_langs_in_doctype_instantiation():
                 '/builddocs/language'
             ),
         ),
+        # 6: many products + many docsets + many lifecycles + English
+        ('//en-us', "product/docset/builddocs/language[@lang='en-us']"),
+        # 7: all products, docsets, lifecycles, and languages
+        ('//*', "product/docset/builddocs/language"),
     ],
 )
 def test_xpath_in_doctype(string, xpath):


### PR DESCRIPTION
The `.xpath()` method creates for `//*` an syntactically correct XPath, but with an additional, unnecessary `[@productid='*']` predicate.

This commit takes into account `Product.ALL` (='*').