### PR TITLE
Fix #16: Create metadata subcommand

### DIFF
--- a/changelog.d/16.feature.rst
+++ b/changelog.d/16.feature.rst
@@ -1,0 +1,1 @@
+Implement metadata from a ``daps metadata`` command.

--- a/docs/source/reference/_autoapi/docbuild/cli/cmd_metadata/index.rst
+++ b/docs/source/reference/_autoapi/docbuild/cli/cmd_metadata/index.rst
@@ -1,0 +1,92 @@
+docbuild.cli.cmd_metadata
+=========================
+
+.. py:module:: docbuild.cli.cmd_metadata
+
+.. autoapi-nested-parse::
+
+   Extracts metadata from deliverables.
+
+
+
+Functions
+---------
+
+.. autoapisummary::
+
+   docbuild.cli.cmd_metadata.get_deliverable_from_doctype
+   docbuild.cli.cmd_metadata.process_deliverable
+   docbuild.cli.cmd_metadata.process_doctype
+   docbuild.cli.cmd_metadata.process
+   docbuild.cli.cmd_metadata.metadata
+
+
+Package Contents
+----------------
+
+.. py:function:: get_deliverable_from_doctype(root: lxml.etree._ElementTree, context: docbuild.cli.context.DocBuildContext, doctype: docbuild.models.doctype.Doctype) -> list[docbuild.models.deliverable.Deliverable]
+
+   Get deliverable from doctype.
+
+   :param root: The stitched XML node containing configuration.
+   :param context: The DocBuildContext containing environment configuration.
+   :param doctype: The Doctype object to process.
+   :return: A list of deliverables for the given doctype.
+
+
+.. py:function:: process_deliverable(deliverable: docbuild.models.deliverable.Deliverable, *, repo_dir: pathlib.Path, temp_repo_dir: pathlib.Path, base_cache_dir: pathlib.Path, meta_cache_dir: pathlib.Path, dapstmpl: str) -> bool
+   :async:
+
+
+   Process a single deliverable.
+
+   This function creates a temporary clone of the deliverable's repository,
+   checks out the correct branch, and then executes the DAPS command to
+   generate metadata.
+
+   :param deliverable: The Deliverable object to process.
+   :param repo_dir: The permanent repo path taken from the env
+        config ``paths.repo_dir``
+   :param temp_repo_dir: The temporary repo path taken from the env
+        config ``paths.temp_repo_dir``
+   :param base_cache_dir: The base path of the cache directory taken
+        from the env config ``paths.base_cache_dir``
+   :param meta_cache_dir: The ath of the metadata directory taken
+        from the env config ``paths.meta_cache_dir``
+   :param dapstmp: A template string with the daps command and potential
+    placeholders
+   :return: True if successful, False otherwise.
+   :raises ValueError: If required configuration paths are missing.
+
+
+.. py:function:: process_doctype(root: lxml.etree._ElementTree, context: docbuild.cli.context.DocBuildContext, doctype: docbuild.models.doctype.Doctype) -> bool
+   :async:
+
+
+   Process the doctypes and create metadata files.
+
+   :param root: The stitched XML node containing configuration.
+   :param context: The DocBuildContext containing environment configuration.
+   :param doctypes: A tuple of Doctype objects to process.
+
+
+.. py:function:: process(context: docbuild.cli.context.DocBuildContext, doctypes: tuple[docbuild.models.doctype.Doctype]) -> int
+   :async:
+
+
+   Asynchronous function to process metadata retrieval.
+
+   :param context: The DocBuildContext containing environment configuration.
+   :param xmlfiles: A tuple or iterator of XML file paths to validate.
+   :raises ValueError: If no envconfig is found or if paths are not
+       configured correctly.
+   :return: 0 if all files passed validation, 1 if any failures occurred.
+
+
+.. py:function:: metadata(ctx: click.Context, doctypes: tuple[docbuild.models.doctype.Doctype]) -> None
+
+   Subcommand to create metadata files.
+
+   :param ctx: The Click context object.
+
+

--- a/docs/source/reference/_autoapi/docbuild/cli/index.rst
+++ b/docs/source/reference/_autoapi/docbuild/cli/index.rst
@@ -27,6 +27,7 @@ Submodules
    /reference/_autoapi/docbuild/cli/cmd_build/index
    /reference/_autoapi/docbuild/cli/cmd_c14n/index
    /reference/_autoapi/docbuild/cli/cmd_cli/index
+   /reference/_autoapi/docbuild/cli/cmd_metadata/index
    /reference/_autoapi/docbuild/cli/cmd_repo/index
    /reference/_autoapi/docbuild/cli/cmd_validate/index
    /reference/_autoapi/docbuild/cli/config/index

--- a/docs/source/reference/_autoapi/docbuild/utils/contextmgr/index.rst
+++ b/docs/source/reference/_autoapi/docbuild/utils/contextmgr/index.rst
@@ -33,7 +33,7 @@ Functions
 Module Contents
 ---------------
 
-.. py:function:: make_timer(name: str, method: collections.abc.Callable = time.perf_counter)
+.. py:function:: make_timer(name: str, method: collections.abc.Callable[[], float] = time.perf_counter) -> collections.abc.Callable[[], contextlib.AbstractContextManager[TimerData]]
 
    Create independant context managers to measure elapsed time.
 
@@ -41,10 +41,10 @@ Module Contents
    The name is used to identify the timer.
 
    :param name: Name of the timer.
-   :param method: Method to use for measuring time, defaults
-       to :func:`time.perf_counter`.
-   :return: A context manager that yields a dictionary with start, end,
-       and elapsed time.
+   :param method: A callable that returns a float, used for measuring time.
+       Defaults to :func:`time.perf_counter`.
+   :return: A callable that returns a context manager. The context manager
+       yields a :class:`TimerData` object.
 
    .. code-block:: python
 

--- a/docs/source/user/config.rst
+++ b/docs/source/user/config.rst
@@ -1,4 +1,4 @@
-.. _configuring-docbuild:
+.. _config-docbuild:
 
 Configuring the Tool
 ---------------------

--- a/docs/source/user/index.rst
+++ b/docs/source/user/index.rst
@@ -12,3 +12,4 @@ User Guide
    build
    validate
    clone
+   metadata

--- a/docs/source/user/install.rst
+++ b/docs/source/user/install.rst
@@ -9,7 +9,7 @@ To install the docbuild tool, follow these steps:
 
 #. :ref:`get-xml-config` - Get the XML configuration files required for building documentation.
 
-#. :ref:`configuring-docbuild` - Configure the docbuild tool to suit your needs.
+#. :ref:`config-docbuild` - Configure the docbuild tool to suit your needs.
 
 
 .. _prepare-installation:

--- a/docs/source/user/metadata.rst
+++ b/docs/source/user/metadata.rst
@@ -1,0 +1,17 @@
+Creating Metadata
+=================
+
+The :command:`docbuild metadata` subcommand is used to create metadata from a :command:`daps metadata` call. 
+
+
+.. code-block:: shell
+   :caption: Synopsis of :command:`docbuild metadata`
+
+   docbuild metadata [OPTIONS] [DOCTYPES]...
+
+The process does this:
+
+#. Determine the :term:`doctypes <Doctype>` from the command line.
+#. Iterate over all :term:`deliverables <Deliverable>` of the doctypes.
+#. For each deliverable, call :command:`daps metadata` to create the metadata.
+#. Store the metadata in the cache directory of the deliverable. The cache directory is defined in the env configuration file under ``paths.meta_cache_dir``, see also section :ref:`config-docbuild`.

--- a/src/docbuild/cli/callback.py
+++ b/src/docbuild/cli/callback.py
@@ -1,9 +1,13 @@
-# --- Callback Function ---
+import logging
+
 import click
 from pydantic import Field, ValidationError
 
 from ..models.doctype import Doctype
 from ..utils.merge import merge_doctypes
+
+#
+log = logging.getLogger(__name__)
 
 
 def validate_doctypes(
@@ -32,8 +36,15 @@ def validate_doctypes(
     for doctype_str in doctypes:
         try:
             doctype = Doctype.from_str(doctype_str)
-            click.echo(f'Got {doctype}')
             processed_data.append(doctype)
+
+        except ValueError as err:
+            click.secho(
+                f"ERROR: Invalid doctype string '{doctype_str}': {err}",
+                fg='red',
+                err=True,
+            )
+            raise click.Abort(err) from err
 
         except ValidationError as err:
             for error in err.errors():

--- a/src/docbuild/cli/cmd_cli.py
+++ b/src/docbuild/cli/cmd_cli.py
@@ -18,6 +18,7 @@ from ..constants import (
 from ..logging import setup_logging
 from .cmd_build import build
 from .cmd_c14n import c14n
+from .cmd_metadata import metadata
 from .cmd_repo import repo
 from .cmd_validate import validate
 from .config import config
@@ -142,4 +143,5 @@ cli.add_command(build)
 cli.add_command(c14n)
 cli.add_command(config)
 cli.add_command(repo)
+cli.add_command(metadata)
 cli.add_command(validate)

--- a/src/docbuild/cli/cmd_metadata/__init__.py
+++ b/src/docbuild/cli/cmd_metadata/__init__.py
@@ -1,0 +1,52 @@
+"""Extracts metadata from deliverables."""
+
+import asyncio
+import math
+
+import click
+from rich.console import Console
+
+from ...models.doctype import Doctype
+from ...utils.contextmgr import make_timer
+from ..callback import validate_doctypes
+from ..context import DocBuildContext
+from .metaprocess import process
+
+# Set up rich consoles for output
+console_out = Console()
+
+
+@click.command(help=__doc__)
+@click.argument(
+    'doctypes',
+    nargs=-1,
+    callback=validate_doctypes,
+)
+@click.pass_context
+def metadata(
+    ctx: click.Context,
+    doctypes: tuple[Doctype],
+) -> None:
+    """Subcommand to create metadata files.
+
+    :param ctx: The Click context object.
+    """
+    context: DocBuildContext = ctx.obj
+    if context.envconfig is None:
+        # log.critical('No envconfig found in context.')
+        raise ValueError('No envconfig found in context.')
+
+    timer = make_timer('metadata')
+    result = 1  # Default exit code for interruption or error
+
+    # The timer data object 't' will be populated by the context manager.
+    # We define it here so it's accessible in the 'finally' block.
+    t = None
+    try:
+        with timer() as t:
+            result = asyncio.run(process(context, doctypes))
+    finally:
+        if t and not math.isnan(t.elapsed):
+            console_out.print(f'Elapsed time {t.elapsed:0.2f}s')
+
+    ctx.exit(result)

--- a/src/docbuild/cli/cmd_metadata/metaprocess.py
+++ b/src/docbuild/cli/cmd_metadata/metaprocess.py
@@ -1,0 +1,249 @@
+"""Defines the handling of metadata extraction from deliverables."""
+
+import asyncio
+import logging
+from pathlib import Path
+import shlex
+import tempfile
+
+from lxml import etree
+from rich.console import Console
+
+from ...config.xml.stitch import create_stitchfile
+from ...models.deliverable import Deliverable
+from ...models.doctype import Doctype
+from ..context import DocBuildContext
+
+# Set up rich consoles for output
+console_out = Console()
+console_err = Console(stderr=True)
+
+# Set up logging
+log = logging.getLogger(__name__)
+
+
+def get_deliverable_from_doctype(
+    root: etree._ElementTree,
+    context: DocBuildContext,
+    doctype: Doctype,
+) -> list[Deliverable]:
+    """Get deliverable from doctype.
+
+    :param root: The stitched XML node containing configuration.
+    :param context: The DocBuildContext containing environment configuration.
+    :param doctype: The Doctype object to process.
+    :return: A list of deliverables for the given doctype.
+    """
+    console_out.print(f'Getting deliverable for doctype: {doctype}')
+    console_out.print(f'XPath for {doctype}: {doctype.xpath()}')
+    languages = root.getroot().xpath(f'./{doctype.xpath()}')
+
+    return [
+        Deliverable(node)
+        for language in languages
+        for node in language.findall('deliverable')
+    ]
+
+
+async def process_deliverable(
+    deliverable: Deliverable,
+    *,
+    repo_dir: Path,
+    temp_repo_dir: Path,
+    base_cache_dir: Path,
+    meta_cache_dir: Path,
+    dapstmpl: str,
+) -> bool:
+    """Process a single deliverable.
+
+    This function creates a temporary clone of the deliverable's repository,
+    checks out the correct branch, and then executes the DAPS command to
+    generate metadata.
+
+    :param deliverable: The Deliverable object to process.
+    :param repo_dir: The permanent repo path taken from the env
+         config ``paths.repo_dir``
+    :param temp_repo_dir: The temporary repo path taken from the env
+         config ``paths.temp_repo_dir``
+    :param base_cache_dir: The base path of the cache directory taken
+         from the env config ``paths.base_cache_dir``
+    :param meta_cache_dir: The ath of the metadata directory taken
+         from the env config ``paths.meta_cache_dir``
+    :param dapstmp: A template string with the daps command and potential
+     placeholders
+    :return: True if successful, False otherwise.
+    :raises ValueError: If required configuration paths are missing.
+    """
+    console_out.print(f'> Processing deliverable: {deliverable.full_id}')
+
+    meta_cache_dir = Path(meta_cache_dir)
+
+    bare_repo_path = repo_dir / deliverable.git.slug
+    if not bare_repo_path.is_dir():
+        log.error(
+            f'Bare repository not found for {deliverable.git.name} at {bare_repo_path}'
+        )
+        return False
+
+    outputdir = meta_cache_dir / deliverable.relpath
+    outputdir.mkdir(parents=True, exist_ok=True)
+
+    prefix = f'{deliverable.productid}-{deliverable.docsetid}-{deliverable.lang}'
+
+    with tempfile.TemporaryDirectory(
+        dir=str(temp_repo_dir), prefix=f'clone-{prefix}_', delete=False
+    ) as worktree_dir_str:
+        worktree_dir = Path(worktree_dir_str)
+
+        # 1. Create a temporary clone from the bare repo and checkout a branch.
+        clone_cmd = [
+            'git',
+            'clone',
+            '--local',
+            f'--branch={deliverable.branch}',
+            str(bare_repo_path),
+            worktree_dir_str,
+        ]
+        clone_process = await asyncio.create_subprocess_exec(
+            *clone_cmd, stderr=asyncio.subprocess.PIPE
+        )
+        _, stderr = await clone_process.communicate()
+        if clone_process.returncode != 0:
+            log.fatal(f'Failed to clone {bare_repo_path}: {stderr.decode().strip()}')
+            return False
+
+        # The source file for daps might be in a subdirectory
+        dcfile_path = Path(deliverable.subdir) / deliverable.dcfile
+
+        # 2. Run the daps command
+        cmd = shlex.split(
+            dapstmpl.format(
+                builddir=worktree_dir_str,
+                dcfile=str(worktree_dir / dcfile_path),
+                output=str(outputdir / deliverable.dcfile),
+            )
+        )
+        console_out.print(f'  command: {cmd}')
+        daps_process = await asyncio.create_subprocess_exec(
+            *cmd,
+            # cwd=worktree_dir,  # Run daps from inside the cloned repo
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await daps_process.communicate()
+        if daps_process.returncode != 0:
+            log.error(
+                'DAPS command failed for %s: %s',
+                deliverable.full_id,
+                stderr.decode().strip(),
+            )
+            return False
+
+    console_out.print(f'> Processed deliverable: {deliverable.pdlangdc}')
+    return True
+
+
+async def process_doctype(
+    root: etree._ElementTree,
+    context: DocBuildContext,
+    doctype: Doctype,
+) -> bool:
+    """Process the doctypes and create metadata files.
+
+    :param root: The stitched XML node containing configuration.
+    :param context: The DocBuildContext containing environment configuration.
+    :param doctypes: A tuple of Doctype objects to process.
+    """
+    # Here you would implement the logic to process the doctypes
+    # and create metadata files based on the stitchnode and context.
+    # This is a placeholder for the actual implementation.
+    console_out.print(f'Processing doctypes: {doctype}')
+    # xpath = doctype.xpath()
+    # print("XPath: ", xpath)
+    console_out.print(f'XPath: {doctype.xpath()}', markup=False)
+
+    deliverables = await asyncio.to_thread(
+        get_deliverable_from_doctype,
+        root,
+        context,
+        doctype,
+    )
+    console_out.print(f'Found deliverables: {len(deliverables)}')
+    dapsmetatmpl = context.envconfig.get('build', {}).get('daps', {}).get('meta', None)
+
+    console_out.print(f'daps command: {dapsmetatmpl}', markup=False)
+
+    repo_dir = context.envconfig.get('paths', {}).get('repo_dir', None)
+    base_cache_dir = context.envconfig.get('paths', {}).get('base_cache_dir', None)
+    # We retrieve the path.meta_cache_dir and fall back to path.base_cache_dir
+    # if not available:
+    meta_cache_dir = context.envconfig.get('paths', {}).get(
+        'meta_cache_dir', base_cache_dir
+    )
+    # Cloned temporary repo:
+    temp_repo_dir = context.envconfig.get('paths', {}).get('temp_repo_dir', None)
+
+    # Check all paths:
+    if not all((repo_dir, base_cache_dir, temp_repo_dir, meta_cache_dir)):
+        raise ValueError(
+            'Missing required paths in configuration: '
+            f'{repo_dir=}, {base_cache_dir=}, {temp_repo_dir=}, {meta_cache_dir=}'
+        )
+
+    # Ensure base directories exist
+    temp_repo_dir = Path(temp_repo_dir)
+    meta_cache_dir = Path(meta_cache_dir)
+    base_cache_dir = Path(base_cache_dir)
+    repo_dir = Path(repo_dir)
+    temp_repo_dir.mkdir(parents=True, exist_ok=True)
+    meta_cache_dir.mkdir(parents=True, exist_ok=True)
+    base_cache_dir.mkdir(parents=True, exist_ok=True)
+    repo_dir.mkdir(parents=True, exist_ok=True)
+
+    tasks = [
+        process_deliverable(
+            deliverable,
+            repo_dir=repo_dir,
+            temp_repo_dir=temp_repo_dir,
+            base_cache_dir=base_cache_dir,
+            meta_cache_dir=meta_cache_dir,
+            dapstmpl=dapsmetatmpl,
+        )
+        for deliverable in deliverables
+    ]
+    results = await asyncio.gather(*tasks)
+
+    return True
+
+
+async def process(
+    context: DocBuildContext,
+    doctypes: tuple[Doctype],
+) -> int:
+    """Asynchronous function to process metadata retrieval.
+
+    :param context: The DocBuildContext containing environment configuration.
+    :param xmlfiles: A tuple or iterator of XML file paths to validate.
+    :raises ValueError: If no envconfig is found or if paths are not
+        configured correctly.
+    :return: 0 if all files passed validation, 1 if any failures occurred.
+    """
+    if context.envconfig is None:
+        raise ValueError('No envconfig found in context.')
+
+    configdir = context.envconfig.get('paths', {}).get('config_dir', None)
+    if configdir is None:
+        raise ValueError('Could not get a value from envconfig.paths.config_dir')
+    configdir = Path(configdir).expanduser()
+    console_out.print(f'Config path: {configdir}')
+    xmlconfigs = tuple(configdir.rglob('[a-z]*.xml'))
+    stitchnode = await create_stitchfile(xmlconfigs)
+    console_out.print(f'Stitch node: {stitchnode.getroot().tag}')
+    console_out.print(f'Deliverables: {len(stitchnode.xpath(".//deliverable"))}')
+
+    if not doctypes:
+        doctypes = [Doctype.from_str('//en-us')]
+
+    tasks = [process_doctype(stitchnode, context, dt) for dt in doctypes]
+    results = await asyncio.gather(*tasks)
+    console_out.print(f'Results: {results}')
+    return 0

--- a/tests/cli/build/test_cmd_build.py
+++ b/tests/cli/build/test_cmd_build.py
@@ -42,6 +42,9 @@ def test_validate_doctypes_abort(monkeypatch):
 class DummyDoctype:
     def __init__(self, value):
         self.value = value
+        parts = value.split('/')
+        self.product = parts[0]
+        self.version = parts[1]
 
     def __eq__(self, other):
         return isinstance(other, DummyDoctype) and self.value == other.value
@@ -218,13 +221,12 @@ def test_validate_doctypes_merge_called(monkeypatch, ctx):
     ]
 
 
-def test_validate_doctypes_echo_outputs(ctx, capsys):
+def test_validate_doctypes_echo_outputs(ctx):
     """Test the echo statements in validate_doctypes."""
-    context = ctx(SimpleNamespace())
-    validate_doctypes(context, None, ('sles/15/en-us',))
+    context = ctx(SimpleNamespace(verbose=1))
+    result = validate_doctypes(context, None, ('sles/15/en-us',))
 
-    captured = capsys.readouterr()
-    assert 'Got sles/15' in captured.out
+    assert result[0].value == 'sles/15/en-us'
 
 
 def test_validate_doctypes_full_error_message(monkeypatch, capsys):
@@ -265,9 +267,8 @@ def test_validate_doctypes_full_error_message(monkeypatch, capsys):
     captured = capsys.readouterr()
 
     # assert exc_info.value.title == "Mock validation error"
-    assert "ERROR in 'product'" in captured.err or captured.out
-    assert 'Hint' in captured.out
-    assert 'Examples' in captured.out
+    assert "Invalid doctype string" in captured.err
+    assert "'foo/bar'" in captured.err
 
 
 def test_validate_doctypes_only_hint_error_message(monkeypatch, capsys):
@@ -310,9 +311,8 @@ def test_validate_doctypes_only_hint_error_message(monkeypatch, capsys):
     # Capture output after the function call
     captured = capsys.readouterr()
 
-    assert "ERROR in 'product'" in captured.err or captured.out
-    assert 'Hint' in captured.out
-    assert 'Examples' not in captured.out  # No examples provided
+    assert "Invalid doctype string" in captured.err
+    assert "'foo/bar'" in captured.err
 
 
 def test_validate_doctypes_only_description_error_message(monkeypatch, capsys):
@@ -356,6 +356,5 @@ def test_validate_doctypes_only_description_error_message(monkeypatch, capsys):
     captured = capsys.readouterr()
 
     # assert exc_info.value.title == "Mock validation error"
-    assert "ERROR in 'product'" in captured.err or captured.out
-    assert 'Hint' not in captured.out  # No description provided
-    assert 'Examples' in captured.out
+    assert "Invalid doctype string" in captured.err or captured.out
+    assert "'foo/bar'" in captured.err

--- a/tests/cli/cmd_metadata/test_cmd_metadata.py
+++ b/tests/cli/cmd_metadata/test_cmd_metadata.py
@@ -1,0 +1,557 @@
+"""Unit tests for metadata command helper functions."""
+
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+from lxml import etree
+import pytest
+
+from docbuild.cli.cmd_metadata import metaprocess as metaprocess_pkg
+from docbuild.cli.cmd_metadata.metaprocess import (
+    get_deliverable_from_doctype,
+    process,
+    process_deliverable,
+    process_doctype,
+)
+from docbuild.cli.context import DocBuildContext
+from docbuild.models.deliverable import Deliverable
+from docbuild.models.doctype import Doctype
+
+
+@pytest.fixture
+def xmlconfig(request) -> etree.ElementTree:
+    """Parse an XML string into an ElementTree.
+
+    Can be used with or without @pytest.mark.parametrize.
+    If used with parametrize, it expects the XML string as the parameter.
+    If used without, it provides a default empty <config/> tree.
+    """
+    xml_string = None
+    if hasattr(request, 'param'):
+        xml_string = request.param
+
+    if not xml_string:
+        xml_string = '<docservconfig/>'
+    root = etree.fromstring(xml_string)
+    return etree.ElementTree(root)
+
+
+@pytest.fixture
+def mock_context_with_config_dir(tmp_path: Path) -> DocBuildContext:
+    """Provide a mock DocBuildContext with a valid config_dir."""
+    context = Mock(spec=DocBuildContext)
+    config_dir = tmp_path / 'config'
+    config_dir.mkdir()
+    (config_dir / 'dummy.xml').write_text(
+        '<docservconfig/>'
+    )  # Ensure at least one XML file exists
+    context.envconfig = {'paths': {'config_dir': str(config_dir)}}
+    return context
+
+
+# @pytest.mark.parametrize(
+#     'xmlconfig',
+#     [None],
+#     ids=['empty'],
+#     indirect=True,
+# )
+def test_for_xmlconfig(xmlconfig):
+    """Verify the xmlconfig fixture parses XML correctly."""
+    print('>>> xmlconfig:', xmlconfig.getroot().tag)
+
+
+@pytest.mark.parametrize(
+    'xmlconfig',
+    [
+        # Verify deliverables are correctly extracted for a specific doctype.
+        """
+    <docservconfig>
+      <product productid="sles">
+        <docset setid="15-SP7" lifecycle="supported">
+          <version>15-SP7</version>
+          <builddocs>
+             <git remote="https://github.com/SUSE/doc-sle.git"/>
+             <language default="1" lang="en-us">
+                <branch>main</branch>
+                <deliverable category="installation-upgrade">
+                    <dc>DC-SLES-deployment</dc>
+                    <format epub="0" html="0" pdf="1" single-html="1"/>
+               </deliverable>
+             </language>
+            <language lang="de-de">
+                <branch>main</branch>
+                <subdir>l10n/sles/de-de</subdir>
+                <deliverable>
+                    <dc>DC-SLES-deployment</dc>
+                </deliverable>
+            </language>
+          </builddocs>
+        </docset>
+      </product>
+    </docservconfig>
+    """
+    ],
+    ids=['xmldata'],
+    indirect=True,
+)
+def test_get_deliverable_from_doctype_success(xmlconfig):
+    """Verify deliverables are correctly extracted for a specific doctype."""
+    # Arrange
+    mock_context = Mock(spec=DocBuildContext)
+    doctype = Doctype.from_str('sles/15-SP7/en-us')
+
+    # Act
+    deliverables = get_deliverable_from_doctype(xmlconfig, mock_context, doctype)
+
+    # Assert
+    assert len(deliverables) == 1
+    assert all(isinstance(d, Deliverable) for d in deliverables)
+
+
+def test_xmlconfig_no_param_provides_default(xmlconfig):
+    """Verify the xmlconfig fixture works without being parametrized."""
+    assert xmlconfig is not None
+    root = xmlconfig.getroot()
+    assert root.tag == 'docservconfig'
+    assert len(root) == 0
+
+
+@pytest.mark.parametrize(
+    'xmlconfig',
+    [None, ''],
+    ids=['none-param', 'empty-string-param'],
+    indirect=True,
+)
+def test_xmlconfig_falsy_params_provide_default(xmlconfig):
+    """Verify the xmlconfig fixture provides a default for falsy params."""
+    assert xmlconfig is not None
+    root = xmlconfig.getroot()
+    assert root.tag == 'docservconfig'
+    assert len(root) == 0
+
+
+@pytest.mark.parametrize(
+    'xmlconfig',
+    [
+        """
+    <docservconfig>
+      <product productid="sles">
+        <docset setid="15-sp6">
+          <builddocs>
+            <language lang="en-us">
+              <!-- No deliverables here -->
+            </language>
+          </builddocs>
+        </docset>
+      </product>
+    </docservconfig>
+    """
+    ],
+    indirect=True,
+)
+def test_get_deliverable_from_doctype_no_deliverables(xmlconfig):
+    """Verify an empty list is returned when a language has no deliverables."""
+    # Arrange
+    mock_context = Mock(spec=DocBuildContext)
+    doctype = Doctype.from_str('sles/15-sp6/en-us')
+
+    # Act
+    with patch('docbuild.cli.cmd_metadata.console_out'):
+        deliverables = get_deliverable_from_doctype(xmlconfig, mock_context, doctype)
+
+    # Assert
+    assert deliverables == []
+
+
+@pytest.mark.parametrize(
+    'xmlconfig',
+    [
+        """
+    <docservconfig>
+      <product productid="sles">
+        <docset setid="15-sp6">
+          <builddocs>
+            <language lang="en-us">
+              <deliverable id="d1" git_name="repo1" dc_file="file1.xml" />
+            </language>
+          </builddocs>
+        </docset>
+      </product>
+    </docservconfig>
+    """
+    ],
+    indirect=True,
+)
+def test_get_deliverable_from_doctype_no_match(xmlconfig):
+    """Verify an empty list is returned when the doctype doesn't match any node."""
+    # Arrange
+    mock_context = Mock(spec=DocBuildContext)
+    # This doctype does not exist in the XML
+    doctype = Doctype.from_str('sles/1.0/en-us')
+
+    # Act
+    with patch('docbuild.cli.cmd_metadata.console_out'):
+        # with patch.object(cmd_metadata, 'console_out')
+        deliverables = get_deliverable_from_doctype(xmlconfig, mock_context, doctype)
+
+    # Assert
+    assert deliverables == []
+
+
+@pytest.mark.parametrize(
+    'xmlconfig',
+    [
+        """
+    <docservconfig>
+      <product productid="sles">
+        <docset setid="15-sp6">
+          <builddocs>
+            <language lang="en-us">
+              <deliverable>
+                <dc>DC-SLE-Micro-5.5-admin</dc>
+                <format html="1" pdf="1" single-html="0"/>
+              </deliverable>
+            </language>
+          </builddocs>
+        </docset>
+      </product>
+      <product productid="other">
+        <docset setid="1.0">
+          <builddocs>
+            <language lang="en-us">
+              <deliverable>
+                 <dc>DC-Micro-5.4-cockpit</dc>
+                 <format html="1" pdf="1" single-html="0"/>
+              </deliverable>
+              <deliverable>
+                <dc>DC-Micro-5.5-cockpit</dc>
+                <format html="1" pdf="1" single-html="0"/>
+              </deliverable>
+            </language>
+          </builddocs>
+        </docset>
+      </product>
+    </docservconfig>
+    """
+    ],
+    indirect=True,
+)
+def test_get_deliverable_from_doctype_with_wildcard(xmlconfig):
+    """Verify deliverables are correctly extracted using a wildcard doctype."""
+    # Arrange
+    mock_context = Mock(spec=DocBuildContext)
+    doctype = Doctype.from_str('//en-us')  # Wildcard for product and docset
+
+    # Act
+    deliverables = get_deliverable_from_doctype(xmlconfig, mock_context, doctype)
+
+    # Assert
+    assert len(deliverables) == 3
+    deliverable_ids = {d.docsuite for d in deliverables}
+    assert deliverable_ids == {
+        'other/1.0/en-us:DC-Micro-5.4-cockpit',
+        'other/1.0/en-us:DC-Micro-5.5-cockpit',
+        'sles/15-sp6/en-us:DC-SLE-Micro-5.5-admin',
+    }
+
+
+@pytest.fixture
+def deliverable() -> Deliverable:
+    """Provide a mock Deliverable object for testing."""
+    xml_string = """
+    <docservconfig>
+      <product productid="sles">
+        <docset setid="15-SP7">
+          <builddocs>
+             <git remote="https://github.com/SUSE/doc-sle.git"/>
+             <language default="1" lang="en-us">
+                <branch>main</branch>
+                <subdir>l10n/sles/en-us</subdir>
+                <deliverable>
+                    <dc>DC-SLES-deployment</dc>
+                </deliverable>
+             </language>
+          </builddocs>
+        </docset>
+      </product>
+    </docservconfig>
+    """
+    root = etree.fromstring(xml_string)
+    deliverable_node = root.find('.//deliverable')
+    return Deliverable(deliverable_node)
+
+
+async def test_metadata_process_empty_context_envconfig():
+    context = Mock(spec=DocBuildContext)
+    context.envconfig = None
+
+    with pytest.raises(ValueError):
+        await process(context, doctypes=tuple())
+
+
+@pytest.mark.asyncio
+class TestProcessDeliverable:
+    """Tests for the process_deliverable function."""
+
+    @pytest.fixture
+    def mock_subprocess(self) -> Iterator[AsyncMock]:
+        """Fixture to mock asyncio.create_subprocess_exec."""
+        with patch(
+            'docbuild.cli.cmd_metadata.asyncio.create_subprocess_exec',
+            new_callable=AsyncMock,
+        ) as mock:
+            yield mock
+
+    @pytest.fixture
+    def setup_paths(self, tmp_path: Path, deliverable: Deliverable) -> dict:
+        """Set up common paths and directories for tests."""
+        paths = {
+            'repo_dir': tmp_path / 'repos',
+            'temp_repo_dir': tmp_path / 'temp_repos',
+            'base_cache_dir': tmp_path / 'cache',
+            'meta_cache_dir': tmp_path / 'cache' / 'metadata',
+        }
+        for path in paths.values():
+            path.mkdir(parents=True, exist_ok=True)
+
+        # Create a fake bare repo for the success/failure paths
+        (paths['repo_dir'] / deliverable.git.slug).mkdir()
+        return paths
+
+    async def test_success(
+        self, deliverable: Deliverable, setup_paths: dict, mock_subprocess: AsyncMock
+    ):
+        """Test successful processing of a deliverable."""
+        # Arrange
+        clone_proc = AsyncMock(returncode=0)
+        clone_proc.communicate.return_value = (b'', b'')
+        daps_proc = AsyncMock(returncode=0)
+        daps_proc.communicate.return_value = (b'', b'')
+        mock_subprocess.side_effect = [clone_proc, daps_proc]
+
+        dapstmpl = 'daps --dc-file={dcfile} --output-file={output}'
+
+        # Act
+        result = await process_deliverable(
+            deliverable=deliverable, dapstmpl=dapstmpl, **setup_paths
+        )
+
+        # Assert
+        assert result is True
+        assert mock_subprocess.call_count == 2
+
+    async def test_bare_repo_not_found(
+        self, deliverable: Deliverable, tmp_path: Path, caplog
+    ):
+        """Test failure when the bare repository does not exist."""
+        # Arrange
+        paths = {
+            'repo_dir': tmp_path / 'repos',  # Don't create the slug subdir
+            'temp_repo_dir': tmp_path / 'temp_repos',
+            'base_cache_dir': tmp_path / 'cache',
+            'meta_cache_dir': tmp_path / 'cache' / 'metadata',
+        }
+        for path in paths.values():
+            path.mkdir(parents=True, exist_ok=True)
+
+        # Act
+        result = await process_deliverable(
+            deliverable=deliverable, dapstmpl='', **paths
+        )
+
+        # Assert
+        assert result is False
+        # assert "Bare repository not found" in caplog.text
+
+    async def test_git_clone_fails(
+        self,
+        deliverable: Deliverable,
+        setup_paths: dict,
+        mock_subprocess: AsyncMock,
+        caplog,
+    ):
+        """Test failure when the git clone command fails."""
+        clone_proc = AsyncMock(returncode=128)
+        clone_proc.communicate.return_value = (b'', b'fatal: repository not found')
+        mock_subprocess.return_value = clone_proc
+
+        result = await process_deliverable(
+            deliverable=deliverable, dapstmpl='', **setup_paths
+        )
+
+        assert result is False
+        # assert "Failed to clone" in caplog.text
+        # assert "fatal: repository not found" in caplog.text
+
+    async def test_daps_command_fails(
+        self,
+        deliverable: Deliverable,
+        setup_paths: dict,
+        mock_subprocess: AsyncMock,
+        caplog,
+    ):
+        """Test failure when the DAPS command fails."""
+        clone_proc = AsyncMock(returncode=0)
+        clone_proc.communicate.return_value = (b'', b'')
+        daps_proc = AsyncMock(returncode=1)
+        daps_proc.communicate.return_value = (b'', b'DAPS error: file not found')
+        mock_subprocess.side_effect = [clone_proc, daps_proc]
+
+        result = await process_deliverable(
+            deliverable=deliverable, dapstmpl='daps', **setup_paths
+        )
+
+        assert result is False
+        # assert "DAPS command failed" in caplog.text
+        # assert "DAPS error: file not found" in caplog.text
+
+
+@pytest.mark.asyncio
+class TestProcessDoctype:
+    """Tests for the process_doctype function."""
+
+    @pytest.fixture
+    def mock_context(self, tmp_path: Path) -> DocBuildContext:
+        """Provide a mock DocBuildContext with necessary paths."""
+        context = Mock(spec=DocBuildContext)
+        context.envconfig = {
+            'build': {'daps': {'meta': 'daps-command-template'}},
+            'paths': {
+                'repo_dir': tmp_path / 'repos',
+                'base_cache_dir': tmp_path / 'cache',
+                'meta_cache_dir': tmp_path / 'cache' / 'metadata',
+                'temp_repo_dir': tmp_path / 'temp_repos',
+            },
+        }
+        return context
+
+    @pytest.fixture
+    def mock_root(self) -> etree._ElementTree:
+        """Provide a mock XML root element for testing."""
+        return etree.ElementTree(etree.fromstring('<docservconfig/>'))
+
+    @patch.object(metaprocess_pkg, 'process_deliverable', new_callable=AsyncMock)
+    @patch.object(metaprocess_pkg, 'get_deliverable_from_doctype')
+    async def test_success_with_deliverables(
+        self,
+        mock_get_deliverables: Mock,
+        mock_process_deliverable: AsyncMock,
+        mock_root: etree._ElementTree,
+        mock_context: DocBuildContext,
+    ):
+        """Test successful processing when deliverables are found."""
+        doctype = Doctype.from_str('sles/15/en-us')
+        mock_deliverables = [Mock(spec=Deliverable), Mock(spec=Deliverable)]
+        mock_get_deliverables.return_value = mock_deliverables
+        mock_process_deliverable.return_value = True
+
+        result = await process_doctype(mock_root, mock_context, doctype)
+
+        assert result is True
+        mock_get_deliverables.assert_called_once_with(mock_root, mock_context, doctype)
+        assert mock_process_deliverable.call_count == 2
+
+    @patch.object(metaprocess_pkg, 'process_deliverable', new_callable=AsyncMock)
+    @patch.object(metaprocess_pkg, 'get_deliverable_from_doctype')
+    async def test_no_deliverables_found(
+        self,
+        mock_get_deliverables: Mock,
+        mock_process_deliverable: AsyncMock,
+        mock_root: etree._ElementTree,
+        mock_context: DocBuildContext,
+    ):
+        """Test behavior when no deliverables are found for the doctype."""
+        doctype = Doctype.from_str('sles/15/en-us')
+        mock_get_deliverables.return_value = []
+
+        result = await process_doctype(mock_root, mock_context, doctype)
+
+        assert result is True
+        mock_get_deliverables.assert_called_once_with(mock_root, mock_context, doctype)
+        mock_process_deliverable.assert_not_called()
+
+    @patch.object(metaprocess_pkg, 'get_deliverable_from_doctype')
+    async def test_missing_paths_in_config_raises_error(
+        self, mock_get_deliverables: Mock, mock_root: etree._ElementTree
+    ):
+        """Test that a ValueError is raised if required paths are missing."""
+        doctype = Doctype.from_str('sles/15/en-us')
+        mock_get_deliverables.return_value = [Mock(spec=Deliverable)]
+        context_missing_path = Mock(spec=DocBuildContext)
+        context_missing_path.envconfig = {
+            'build': {'daps': {'meta': 'daps-command'}},
+            'paths': {'base_cache_dir': '/fake/cache'},  # Missing other paths
+        }
+
+        with pytest.raises(ValueError, match='Missing required paths in configuration'):
+            await process_doctype(mock_root, context_missing_path, doctype)
+
+
+@pytest.mark.asyncio
+class TestProcessEmptyDoctypes:
+    """Tests for the case when no doctypes are passed to process."""
+
+    @patch.object(metaprocess_pkg, 'create_stitchfile', new_callable=AsyncMock)
+    @patch.object(metaprocess_pkg, 'process_doctype', new_callable=AsyncMock)
+    async def test_process_empty_doctypes(
+        self,
+        mock_process_doctype: AsyncMock,
+        mock_create_stitchfile: AsyncMock,
+        mock_context_with_config_dir: DocBuildContext,
+    ):
+        """Test process function with an empty tuple of doctypes."""
+        mock_stitch_node = etree.ElementTree(etree.Element('docservconfig'))
+        mock_create_stitchfile.return_value = mock_stitch_node
+
+        await process(mock_context_with_config_dir, doctypes=())
+
+        # Assert that create_stitchfile was called
+        mock_create_stitchfile.assert_called_once()
+        # Assert that process_doctype was called with the default doctype
+        mock_process_doctype.assert_called()
+
+    async def test_no_config_dir_raises_error(self):
+        """Test process raises ValueError if config_dir is missing from paths."""
+        context = Mock(spec=DocBuildContext)
+        context.envconfig = {'paths': {}}  # No config_dir in paths
+
+        with pytest.raises(
+            ValueError, match='Could not get a value from envconfig.paths.config_dir'
+        ):
+            await process(context, doctypes=tuple())
+
+    @patch.object(metaprocess_pkg, 'create_stitchfile', new_callable=AsyncMock)
+    @patch.object(metaprocess_pkg, 'process_doctype', new_callable=AsyncMock)
+    async def test_no_doctypes_uses_default(
+        self,
+        mock_process_doctype: AsyncMock,
+        mock_create_stitchfile: AsyncMock,
+        tmp_path: Path,
+    ):
+        """Test process uses a default doctype when none are provided.
+
+        This test covers the successful execution path and the logic for handling
+        an empty doctypes tuple.
+        """
+        # Arrange
+        context = Mock(spec=DocBuildContext)
+        config_dir = tmp_path / 'config'
+        config_dir.mkdir()
+        context.envconfig = {'paths': {'config_dir': str(config_dir)}}
+
+        mock_stitch_node = etree.ElementTree(etree.Element('docservconfig'))
+        mock_create_stitchfile.return_value = mock_stitch_node
+        mock_process_doctype.return_value = True
+
+        # Act and suppress console output during the test
+        with patch.object(metaprocess_pkg, 'console_out'):
+            result = await process(context, doctypes=tuple())
+
+        # Assert
+        assert result == 0
+        mock_create_stitchfile.assert_awaited_once()
+        default_doctype = Doctype.from_str('//en-us')
+        mock_process_doctype.assert_awaited_once_with(
+            mock_stitch_node, context, default_doctype
+        )


### PR DESCRIPTION
* Implement "docbuild metadata"
* Add more tests
* Catch `ValueError` in `validate_doctypes` callback
  Fix test case due to ValueError
* Document subcommand `docbuild metadata`