### PR TITLE
Enhance context manager with async

### DIFF
--- a/changelog.d/52.bugfix.rst
+++ b/changelog.d/52.bugfix.rst
@@ -1,0 +1,1 @@
+Correct ``log.error`` call with arguments

--- a/changelog.d/52.feature.rst
+++ b/changelog.d/52.feature.rst
@@ -1,0 +1,1 @@
+Implement async-aware context manager

--- a/docs/source/reference/_autoapi/docbuild/cli/cmd_metadata/index.rst
+++ b/docs/source/reference/_autoapi/docbuild/cli/cmd_metadata/index.rst
@@ -9,79 +9,25 @@ docbuild.cli.cmd_metadata
 
 
 
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 1
+
+   /reference/_autoapi/docbuild/cli/cmd_metadata/metaprocess/index
+
+
 Functions
 ---------
 
 .. autoapisummary::
 
-   docbuild.cli.cmd_metadata.get_deliverable_from_doctype
-   docbuild.cli.cmd_metadata.process_deliverable
-   docbuild.cli.cmd_metadata.process_doctype
-   docbuild.cli.cmd_metadata.process
    docbuild.cli.cmd_metadata.metadata
 
 
 Package Contents
 ----------------
-
-.. py:function:: get_deliverable_from_doctype(root: lxml.etree._ElementTree, context: docbuild.cli.context.DocBuildContext, doctype: docbuild.models.doctype.Doctype) -> list[docbuild.models.deliverable.Deliverable]
-
-   Get deliverable from doctype.
-
-   :param root: The stitched XML node containing configuration.
-   :param context: The DocBuildContext containing environment configuration.
-   :param doctype: The Doctype object to process.
-   :return: A list of deliverables for the given doctype.
-
-
-.. py:function:: process_deliverable(deliverable: docbuild.models.deliverable.Deliverable, *, repo_dir: pathlib.Path, temp_repo_dir: pathlib.Path, base_cache_dir: pathlib.Path, meta_cache_dir: pathlib.Path, dapstmpl: str) -> bool
-   :async:
-
-
-   Process a single deliverable.
-
-   This function creates a temporary clone of the deliverable's repository,
-   checks out the correct branch, and then executes the DAPS command to
-   generate metadata.
-
-   :param deliverable: The Deliverable object to process.
-   :param repo_dir: The permanent repo path taken from the env
-        config ``paths.repo_dir``
-   :param temp_repo_dir: The temporary repo path taken from the env
-        config ``paths.temp_repo_dir``
-   :param base_cache_dir: The base path of the cache directory taken
-        from the env config ``paths.base_cache_dir``
-   :param meta_cache_dir: The ath of the metadata directory taken
-        from the env config ``paths.meta_cache_dir``
-   :param dapstmp: A template string with the daps command and potential
-    placeholders
-   :return: True if successful, False otherwise.
-   :raises ValueError: If required configuration paths are missing.
-
-
-.. py:function:: process_doctype(root: lxml.etree._ElementTree, context: docbuild.cli.context.DocBuildContext, doctype: docbuild.models.doctype.Doctype) -> bool
-   :async:
-
-
-   Process the doctypes and create metadata files.
-
-   :param root: The stitched XML node containing configuration.
-   :param context: The DocBuildContext containing environment configuration.
-   :param doctypes: A tuple of Doctype objects to process.
-
-
-.. py:function:: process(context: docbuild.cli.context.DocBuildContext, doctypes: tuple[docbuild.models.doctype.Doctype]) -> int
-   :async:
-
-
-   Asynchronous function to process metadata retrieval.
-
-   :param context: The DocBuildContext containing environment configuration.
-   :param xmlfiles: A tuple or iterator of XML file paths to validate.
-   :raises ValueError: If no envconfig is found or if paths are not
-       configured correctly.
-   :return: 0 if all files passed validation, 1 if any failures occurred.
-
 
 .. py:function:: metadata(ctx: click.Context, doctypes: tuple[docbuild.models.doctype.Doctype]) -> None
 

--- a/docs/source/reference/_autoapi/docbuild/cli/cmd_metadata/metaprocess/index.rst
+++ b/docs/source/reference/_autoapi/docbuild/cli/cmd_metadata/metaprocess/index.rst
@@ -1,0 +1,84 @@
+docbuild.cli.cmd_metadata.metaprocess
+=====================================
+
+.. py:module:: docbuild.cli.cmd_metadata.metaprocess
+
+.. autoapi-nested-parse::
+
+   Defines the handling of metadata extraction from deliverables.
+
+
+
+Functions
+---------
+
+.. autoapisummary::
+
+   docbuild.cli.cmd_metadata.metaprocess.get_deliverable_from_doctype
+   docbuild.cli.cmd_metadata.metaprocess.process_deliverable
+   docbuild.cli.cmd_metadata.metaprocess.process_doctype
+   docbuild.cli.cmd_metadata.metaprocess.process
+
+
+Module Contents
+---------------
+
+.. py:function:: get_deliverable_from_doctype(root: lxml.etree._ElementTree, context: docbuild.cli.context.DocBuildContext, doctype: docbuild.models.doctype.Doctype) -> list[docbuild.models.deliverable.Deliverable]
+
+   Get deliverable from doctype.
+
+   :param root: The stitched XML node containing configuration.
+   :param context: The DocBuildContext containing environment configuration.
+   :param doctype: The Doctype object to process.
+   :return: A list of deliverables for the given doctype.
+
+
+.. py:function:: process_deliverable(deliverable: docbuild.models.deliverable.Deliverable, *, repo_dir: pathlib.Path, temp_repo_dir: pathlib.Path, base_cache_dir: pathlib.Path, meta_cache_dir: pathlib.Path, dapstmpl: str) -> bool
+   :async:
+
+
+   Process a single deliverable.
+
+   This function creates a temporary clone of the deliverable's repository,
+   checks out the correct branch, and then executes the DAPS command to
+   generate metadata.
+
+   :param deliverable: The Deliverable object to process.
+   :param repo_dir: The permanent repo path taken from the env
+        config ``paths.repo_dir``
+   :param temp_repo_dir: The temporary repo path taken from the env
+        config ``paths.temp_repo_dir``
+   :param base_cache_dir: The base path of the cache directory taken
+        from the env config ``paths.base_cache_dir``
+   :param meta_cache_dir: The ath of the metadata directory taken
+        from the env config ``paths.meta_cache_dir``
+   :param dapstmp: A template string with the daps command and potential
+    placeholders
+   :return: True if successful, False otherwise.
+   :raises ValueError: If required configuration paths are missing.
+
+
+.. py:function:: process_doctype(root: lxml.etree._ElementTree, context: docbuild.cli.context.DocBuildContext, doctype: docbuild.models.doctype.Doctype) -> bool
+   :async:
+
+
+   Process the doctypes and create metadata files.
+
+   :param root: The stitched XML node containing configuration.
+   :param context: The DocBuildContext containing environment configuration.
+   :param doctypes: A tuple of Doctype objects to process.
+
+
+.. py:function:: process(context: docbuild.cli.context.DocBuildContext, doctypes: tuple[docbuild.models.doctype.Doctype]) -> int
+   :async:
+
+
+   Asynchronous function to process metadata retrieval.
+
+   :param context: The DocBuildContext containing environment configuration.
+   :param xmlfiles: A tuple or iterator of XML file paths to validate.
+   :raises ValueError: If no envconfig is found or if paths are not
+       configured correctly.
+   :return: 0 if all files passed validation, 1 if any failures occurred.
+
+

--- a/docs/source/reference/_autoapi/docbuild/utils/contextmgr/PersistentOnErrorTemporaryDirectory.rst
+++ b/docs/source/reference/_autoapi/docbuild/utils/contextmgr/PersistentOnErrorTemporaryDirectory.rst
@@ -1,0 +1,80 @@
+docbuild.utils.contextmgr.PersistentOnErrorTemporaryDirectory
+=============================================================
+
+.. py:class:: docbuild.utils.contextmgr.PersistentOnErrorTemporaryDirectory(suffix: str | None = None, prefix: str | None = None, dir: str | pathlib.Path | None = None)
+
+   Bases: :py:obj:`tempfile.TemporaryDirectory`
+
+   .. autoapi-inheritance-diagram:: docbuild.utils.contextmgr.PersistentOnErrorTemporaryDirectory
+      :parts: 1
+
+
+   A temporary directory that supports both sync and async usage.
+
+   It deletes the temporary directory only if no exception occurs within the
+   context block. This is useful for debugging, as it preserves the directory
+   and its contents for inspection after an error.
+
+   It is a subclass of :class:`tempfile.TemporaryDirectory` and mimics its
+   initializer.
+
+   .. code-block:: python
+
+       # Synchronous usage
+       with PersistentOnErrorTemporaryDirectory() as temp_dir:
+           # temp_dir is a Path object
+           ...
+
+       # Asynchronous usage
+       async with PersistentOnErrorTemporaryDirectory() as temp_dir:
+           # temp_dir is a Path object
+           ...
+
+   Optional arguments:
+   :param suffix: A str suffix for the directory name.  (see mkdtemp)
+   :param prefix: A str prefix for the directory name.  (see mkdtemp)
+   :param dir: A directory to create this temp dir in.  (see mkdtemp)
+
+
+   .. py:method:: __enter__() -> pathlib.Path
+
+      Enter the runtime context and create the temporary directory.
+
+      :returns: Path to the created temporary directory.
+
+
+
+   .. py:method:: __aenter__() -> pathlib.Path
+      :async:
+
+
+      Enter the async runtime context and create the temporary directory.
+
+      :returns: Path to the created temporary directory.
+
+
+
+   .. py:method:: __exit__(exc_type: ExcType, exc_val: ExcVal, exc_tb: ExcTback) -> None
+
+      Exit the runtime context and delete the directory if no exception occurred.
+
+      :param exc_type: Exception type, if any.
+      :param exc_val: Exception instance, if any.
+      :param exc_tb: Traceback, if any.
+
+
+
+   .. py:method:: __aexit__(exc_type: ExcType, exc_val: ExcVal, exc_tb: ExcTback) -> None
+      :async:
+
+
+      Asynchronously clean up the directory on successful exit.
+
+      Async exit the runtime context and delete the directory if no
+      exception occurred.
+
+      :param exc_type: Exception type, if any.
+      :param exc_val: Exception instance, if any.
+      :param exc_tb: Traceback, if any.
+
+

--- a/docs/source/reference/_autoapi/docbuild/utils/contextmgr/index.rst
+++ b/docs/source/reference/_autoapi/docbuild/utils/contextmgr/index.rst
@@ -16,10 +16,12 @@ Classes
    :hidden:
 
    /reference/_autoapi/docbuild/utils/contextmgr/TimerData
+   /reference/_autoapi/docbuild/utils/contextmgr/PersistentOnErrorTemporaryDirectory
 
 .. autoapisummary::
 
    docbuild.utils.contextmgr.TimerData
+   docbuild.utils.contextmgr.PersistentOnErrorTemporaryDirectory
 
 
 Functions

--- a/src/docbuild/constants.py
+++ b/src/docbuild/constants.py
@@ -16,6 +16,8 @@ ALLOWED_LANGUAGES = frozenset(
 )
 """The languages supported by the documentation portal."""
 
+DEFAULT_DELIVERABLES = '*/@supported/en-us'
+"""The default deliverables when no specific doctype is provided."""
 
 # SERVER_ROLES = (
 #     "production", "prod", "p",

--- a/tests/cli/cmd_metadata/test_cmd_metadata.py
+++ b/tests/cli/cmd_metadata/test_cmd_metadata.py
@@ -1,3 +1,4 @@
+from docbuild.constants import DEFAULT_DELIVERABLES
 """Unit tests for metadata command helper functions."""
 
 from collections.abc import Iterator
@@ -551,7 +552,7 @@ class TestProcessEmptyDoctypes:
         # Assert
         assert result == 0
         mock_create_stitchfile.assert_awaited_once()
-        default_doctype = Doctype.from_str('//en-us')
+        default_doctype = Doctype.from_str(DEFAULT_DELIVERABLES)
         mock_process_doctype.assert_awaited_once_with(
             mock_stitch_node, context, default_doctype
         )


### PR DESCRIPTION
* Make `PersistentOnErrorTemporaryDirectory` async-aware
* Use async context manager in process_deliverable Use `PersistentOnErrorTemporaryDirectory` and wrap it in try..except block Exit the context manager block with RuntimeError and catch it.
* Correct `log.error` call with arguments
* Add autoapi files