### PR TITLE
Implement `edit_json()` contextmanager

### DIFF
--- a/tests/utils/test_contextmgr.py
+++ b/tests/utils/test_contextmgr.py
@@ -1,5 +1,6 @@
-import math
 import asyncio
+import json
+import math
 from pathlib import Path
 import time
 from unittest.mock import patch
@@ -7,7 +8,7 @@ from unittest.mock import patch
 import pytest
 
 import docbuild.utils.contextmgr as contextmgr
-from docbuild.utils.contextmgr import PersistentOnErrorTemporaryDirectory, make_timer
+from docbuild.utils.contextmgr import PersistentOnErrorTemporaryDirectory, edit_json, make_timer
 
 
 def test_timer_has_correct_attributes():
@@ -175,3 +176,65 @@ async def test_async_temp_dir_deletion_failure_is_logged(fake_temp_path: str) ->
         mock_log_exception.assert_called_once_with(
             'Failed to delete temp dir %s: %s', fake_temp_path, mock_error
         )
+
+# ---
+
+def test_edit_json_modifies_file_correctly(tmp_path):
+    """Happy path: reads, updates, and saves changes."""
+    # Arrange
+    f = tmp_path / 'config.json'
+    f.write_text('{"value": 1}', encoding='utf-8')
+
+    # Act
+    with edit_json(f) as data:
+        data['value'] = 2
+        data['new'] = 'entry'
+
+    # Assert
+    content = json.loads(f.read_text(encoding='utf-8'))
+    assert content == {'value': 2, 'new': 'entry'}
+
+
+def test_edit_json_aborts_write_on_user_exception(tmp_path):
+    """If an error occurs inside the 'with' block, the file should not be touched."""
+    # Arrange
+    f = tmp_path / 'config.json'
+    original_content = '{"value": 1}'
+    f.write_text(original_content, encoding='utf-8')
+
+    # Act
+    with pytest.raises(ValueError):
+        with edit_json(f) as data:
+            data['value'] = 999
+            raise ValueError('Something went wrong!')
+
+    # Assert
+    # Verify the file content is exactly what it was before
+    assert f.read_text(encoding='utf-8') == original_content
+
+
+def test_edit_json_cleans_up_temp_file_on_dump_error(tmp_path, monkeypatch):
+    """If the write phase fails (e.g. disk error), the temp file must be deleted."""
+    # Arrange
+    f = tmp_path / 'config.json'
+    f.write_text('{"value": 1}', encoding='utf-8')
+
+    # Simulate json.dump crashing
+    def mock_dump(*args, **kwargs):
+        raise OSError('Disk full')
+
+    monkeypatch.setattr(json, 'dump', mock_dump)
+
+    # Act
+    with pytest.raises(OSError, match='Disk full'):
+        with edit_json(f) as data:
+            data['value'] = 2
+
+    # Assert
+    # 1. Original file is unchanged
+    assert json.loads(f.read_text()) == {'value': 1}
+
+    # 2. Verify NO temporary files were left behind
+    # We look for any file starting with ".json_tmp_" in the directory
+    temp_files = list(tmp_path.glob('.json_tmp_*.tmp'))
+    assert temp_files == [], f'Found leftover temp files: {temp_files}'


### PR DESCRIPTION
Context manager (`edit_json`) for safely and atomically editing a JSON file.

This function implements a "read-modify-write" cycle with ACID-like properties. It ensures that the file is either fully updated or remains strictly unchanged (no partial writes or corruption) if an error occurs during modification or saving.

The operation follows three phases:

1. **Read**: The file is parsed into a Python dictionary.
2. **Modify** (Yield): Control is handed to the caller to modify the dictionary.
3. **Write**:
   - If the block exits successfully, the data is written to a temporary file, fsync-ed to disk, and atomically renamed over the original file.
   - If an exception is raised within the block, the write phase is skipped entirely.