### PR TITLE
Fix #118: Provide project Git config file

### DIFF
--- a/changelog.d/118.bugfix.rst
+++ b/changelog.d/118.bugfix.rst
@@ -1,0 +1,1 @@
+Provide a project-defined Git config to prevent issues with user Git config.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,9 @@ docbuild = "docbuild.__main__:cli"
 package-dir = {"" = "src"}
 package-data = { "docbuild" = ["py.typed",
                                "config/xml/data/*.rnc",
-                               "config/xml/data/*.xsl"]}
+                               "config/xml/data/*.xsl",
+                               "etc/git/*"
+                               ]}
 include-package-data = true
 
 [tool.setuptools.dynamic]

--- a/src/docbuild/constants.py
+++ b/src/docbuild/constants.py
@@ -145,6 +145,9 @@ DEFAULT_ENV_CONFIG_FILENAME = ENV_CONFIG_FILENAME.format(role='production')
 """The default filename for the environment's config file, typically
 used in production."""
 
+GIT_CONFIG_FILENAME = Path(__file__).parent / 'etc/git/gitconfig'
+"""The project-specific Git configuration file (relative to this project)"""
+
 # --- State and Logging Constants (Refactored) ---
 
 BASE_STATE_DIR = Path.home() / '.local' / 'state' / APP_NAME

--- a/src/docbuild/etc/git/gitconfig
+++ b/src/docbuild/etc/git/gitconfig
@@ -1,0 +1,2 @@
+[docbuild]
+  name = docbuild-project

--- a/tests/utils/test_git.py
+++ b/tests/utils/test_git.py
@@ -60,6 +60,7 @@ async def test_managed_repo_clone_bare_new(
         'http://a.b/c.git',
         str(repo.bare_repo_path),
         cwd=tmp_path,
+        gitconfig=None,
     )
 
 
@@ -73,7 +74,12 @@ async def test_managed_repo_clone_bare_exists(
 
     result = await repo.clone_bare()
 
-    mock_execute_git.assert_awaited_once_with('fetch', '--all', cwd=repo.bare_repo_path)
+    mock_execute_git.assert_awaited_once_with(
+        'fetch',
+        '--all',
+        cwd=repo.bare_repo_path,
+        gitconfig=None,
+    )
 
 
 async def test_managed_repo_clone_bare_failure(
@@ -109,6 +115,7 @@ async def test_managed_repo_create_worktree_success(
         str(repo.bare_repo_path),
         str(target_dir),
         cwd=target_dir.parent,
+        gitconfig=None,
     )
 
 
@@ -133,6 +140,7 @@ async def test_managed_repo_create_worktree_with_options(
         str(repo.bare_repo_path),
         str(target_dir),
         cwd=target_dir.parent,
+        gitconfig=None,
     )
 
 
@@ -170,6 +178,7 @@ async def test_managed_repo_create_worktree_not_local(
         str(repo.bare_repo_path),
         str(target_dir),
         cwd=target_dir.parent,
+        gitconfig=None,
     )
 
 
@@ -222,7 +231,9 @@ async def test_fetch_updates_success(
     result = await repo.fetch_updates()
 
     assert result is True
-    mock_execute_git.assert_awaited_once_with('fetch', '--all', cwd=repo.bare_repo_path)
+    mock_execute_git.assert_awaited_once_with(
+        'fetch', '--all', cwd=repo.bare_repo_path, gitconfig=None
+    )
 
 
 async def test_fetch_updates_no_repo(
@@ -272,6 +283,7 @@ async def test_managed_repo_clone_bare_already_processed(
         'http://a.b/c.git',
         str(repo.bare_repo_path),
         cwd=tmp_path,
+        gitconfig=None,
     )
 
     # Second call, should do nothing because it's already processed

--- a/tests/utils/test_shell.py
+++ b/tests/utils/test_shell.py
@@ -1,0 +1,62 @@
+"""Tests for shell command utilities."""
+
+from pathlib import Path
+
+import pytest
+
+from docbuild.constants import GIT_CONFIG_FILENAME
+from docbuild.utils.shell import execute_git_command
+
+
+async def test_execute_git_command_with_gitconfig(tmp_path):
+    """Verify that execute_git_command uses the config file provided in the
+    `gitconfig` parameter to replace the user's configuration.
+    """
+    # The tmp_path fixture provides a temporary directory as a Path object
+    repo_path = tmp_path
+
+    # Initialize a Git repository in the temporary directory
+    await execute_git_command("init", cwd=repo_path)
+
+    # Create a project-specific gitconfig file
+    config_content = "[user]\n    name = Test User From Project Config\n"
+    project_config_path = repo_path / ".gitconfig"
+    project_config_path.write_text(config_content)
+
+    # Execute 'git config' to read the value, passing the project config
+    stdout, _ = await execute_git_command(
+        "config", "--get", "user.name", cwd=repo_path, gitconfig=project_config_path
+    )
+
+    # Assert that the output matches the value from our project-specific config
+    assert stdout == "Test User From Project Config"
+
+
+async def test_execute_git_command_without_gitconfig(tmp_path):
+    """
+    Verify that execute_git_command falls back to the default GIT_CONFIG_FILENAME
+    when the `gitconfig` parameter is not provided.
+    """
+    repo_path = tmp_path
+
+    # Execute 'git config' to read the value from our default config file.
+    # We call it without the `gitconfig` parameter to test the default behavior.
+    stdout, _ = await execute_git_command(
+        "config", "--get", "docbuild.name", cwd=repo_path
+    )
+
+    # This asserts that the value from 'etc/git/gitconfig' is read correctly.
+    assert stdout == "docbuild-project"
+
+
+async def test_execute_git_command_with_nonexistent_cwd():
+    with pytest.raises(FileNotFoundError):
+        stdout, _ = await execute_git_command(
+            'config', '--get', 'docbuild.name', cwd=Path("does-not-exist")
+        )
+
+async def test_execute_git_command_with_failed_command():
+    with pytest.raises(RuntimeError):
+        stdout, _ = await execute_git_command(
+            'foo',  # wrong git command
+        )


### PR DESCRIPTION
To create a reproducable build environment, we can't rely on the system or user config.  Depending on the options, it may let Git behave slightly different than we expect.

For this reason, we need to ensure that we use project Git config that is used whenever we call "git"