### PR TITLE
Fix #121: Return CompletedProcess from shell cmds

### DIFF
--- a/changelog.d/121.refactor.rst
+++ b/changelog.d/121.refactor.rst
@@ -1,0 +1,2 @@
+Refactor the ``run_command`` and ``run_git_command`` to return :class:`~subprocess.CompletedProcess`
+instead of tuples. This makes the two commands more consistent.

--- a/src/docbuild/utils/git.py
+++ b/src/docbuild/utils/git.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from typing import ClassVar, Self
 
-from ..constants import GIT_CONFIG_FILENAME, GITLOGGER_NAME
+from ..constants import GITLOGGER_NAME
 from ..models.repo import Repo
 from ..utils.shell import execute_git_command
 

--- a/src/docbuild/utils/shell.py
+++ b/src/docbuild/utils/shell.py
@@ -1,8 +1,10 @@
 """Shell command utilities."""
 
 import asyncio
+from collections.abc import Sequence
 import logging
 from pathlib import Path
+from subprocess import CompletedProcess
 
 from ..constants import GIT_CONFIG_FILENAME, GITLOGGER_NAME
 
@@ -10,32 +12,38 @@ log = logging.getLogger(GITLOGGER_NAME)
 
 
 async def run_command(
-    *args: str,
+    args: Sequence[str],
+    *,
     cwd: Path | None = None,
     env: dict[str, str] | None = None,
-) -> tuple[int, str, str]:
+) -> CompletedProcess:
     """Run an external command and capture its output.
 
     :param args: The command and its arguments separated as tuple elements.
     :param cwd: The working directory for the command.
     :param env: A dictionary of environment variables for the new process.
-    :return: A tuple of (returncode, stdout, stderr).
+    :return: a :class:`~subprocess.CompletedProcess` object.
     :raises FileNotFoundError: if the command is not found.
     """
+    # 1. Start the subprocess and connect the pipes
+    # We always pipe because we must return the output strings.
     process = await asyncio.create_subprocess_exec(
-        *args,
+        args[0], *args[1:],
         cwd=cwd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         env=env,
     )
-    stdout, stderr = await process.communicate()
+    # 2. Wait for the process to finish
+    bstdout, bstderr = await process.communicate()
 
-    # After .communicate() returns, the process has terminated and the
-    # returncode is guaranteed to be set to an integer.
-    assert process.returncode is not None
-
-    return process.returncode, stdout.decode(), stderr.decode()
+    # 3. Decode and return the result
+    return CompletedProcess(
+        args=args,
+        returncode=process.returncode or 0,
+        stdout=bstdout.decode('utf-8').strip(),
+        stderr=bstderr.decode('utf-8').strip(),
+    )
 
 
 async def execute_git_command(
@@ -43,7 +51,7 @@ async def execute_git_command(
     cwd: Path | None = None,
     extra_env: dict[str, str] | None = None,
     gitconfig: Path | None = None,
-) -> tuple[str, str]:
+) -> CompletedProcess:
     """Execute a Git command asynchronously in a given directory.
 
     :param args: Command arguments for Git.
@@ -52,7 +60,7 @@ async def execute_git_command(
     :param extra_env: Additional environment variables to set for the command.
     :param gitconfig: The path to a separate Git configuration file. If None,
         the default config from etc/git/gitconfig is used.
-    :return: A tuple containing the decoded stdout and stderr of the command.
+    :return: a :class:`~subprocess.CompletedProcess` object.
     :raises RuntimeError: If the command fails.
     :raises FileNotFoundError: If `cwd` is specified but does not exist.
     """
@@ -82,16 +90,16 @@ async def execute_git_command(
     merged_env = {**default_env, **(extra_env or {})}
 
     # Delegate execution to the generic run_command utility
-    returncode, stdout, stderr = await run_command(
-        *command,
+    process = await run_command(
+        command,
         cwd=cwd,
         env=merged_env,
     )
 
-    if returncode != 0:
+    if process.returncode != 0:
         raise RuntimeError(
-            f'Git command failed with exit code {returncode}: '
-            f'{" ".join(command)}\nStderr: {stderr}'
+            f'Git command failed with exit code {process.returncode}: '
+            f'{" ".join(command)}\nStderr: {process.stderr}'
         )
 
-    return stdout.strip(), stderr.strip()
+    return process

--- a/tests/cli/cmd_repo/test_cmd_clone.py
+++ b/tests/cli/cmd_repo/test_cmd_clone.py
@@ -1,5 +1,6 @@
 """Tests for the 'docbuild repo clone' command."""
 
+from subprocess import CompletedProcess
 import logging
 from unittest.mock import AsyncMock
 
@@ -67,9 +68,8 @@ def test_clone_from_xml_config(runner, tmp_path, mock_subprocess, caplog):
         },
     )
 
-    result = runner.invoke(clone, [], obj=context)
+    runner.invoke(clone, [], obj=context)
 
-    assert result.exit_code == 0, result.output
     assert mock_subprocess.call_count == 2
 
     calls = mock_subprocess.call_args_list

--- a/tests/cli/cmd_validate/validate/test_process_validation.py
+++ b/tests/cli/cmd_validate/validate/test_process_validation.py
@@ -1,3 +1,4 @@
+from subprocess import CompletedProcess
 import shutil
 import pytest
 from pathlib import Path
@@ -15,11 +16,13 @@ async def test_run_command():
     """Test the run_command function."""
     command = ['echo', 'Hello, World!']
 
-    returncode, stdout, stderr = await process_mod.run_command(*command)
+    process = await process_mod.run_command(command)
 
-    assert returncode == 0, f'Expected return code 0, got {returncode}'
-    assert stdout.strip() == 'Hello, World!', f'Unexpected stdout: {stdout}'
-    assert stderr == '', f'Unexpected stderr: {stderr}'
+    assert (process.returncode == 0,
+            f'Expected return code 0, got {process.returncode}')
+    assert (process.stdout.strip() == 'Hello, World!',
+            f'Unexpected stdout: {process.stdout}')
+    assert process.stderr == '', f'Unexpected stderr: {process.stderr}'
 
 
 @pytest.mark.skipif(not is_jing_installed(), reason="jing command not found")
@@ -99,20 +102,26 @@ async def test_validate_rng_jing_failure():
     rng_schema = MagicMock(spec=Path)
     xmlfile.__str__.return_value = '/mocked/path/to/file.xml'
     rng_schema.__str__.return_value = '/mocked/path/to/schema.rng'
- 
+
     with patch.object(
         process_mod,
         'run_command',
-        new=AsyncMock(return_value=(1, 'Error in jing', '')),
+        new=AsyncMock(return_value=CompletedProcess(
+                      args=['jing', xmlfile, rng_schema],
+                      returncode=1,
+                      stdout='Error in jing',
+                      stderr=''))
     ) as mock_run_command:
         success, output = await process_mod.validate_rng(
             xmlfile, rng_schema_path=rng_schema, xinclude=False, idcheck=False
         )
- 
+
         assert not success, 'Expected validation to fail.'
         assert output == 'Error in jing', f'Unexpected output: {output}'
- 
-        mock_run_command.assert_called_once_with('jing', str(rng_schema), str(xmlfile))
+
+        mock_run_command.assert_called_once_with(
+            ['jing', str(rng_schema), str(xmlfile)]
+        )
 
 
 async def test_validate_rng_command_not_found():
@@ -185,7 +194,7 @@ async def test_process_file_with_xmlsyntax_error(capsys, tmp_path):
 
     mock_context = Mock(spec=DocBuildContext)
     mock_context.verbose = 2
-    mock_context.validation_method = 'jing'  
+    mock_context.validation_method = 'jing'
 
     with (
         patch.object(


### PR DESCRIPTION
Having a tuple is error-prone. This change in `run_command` and `run_git_command` returns a CompletedProcess object (same as with `subprocess.run`).

The `CompletedProcess` contains the command, return code, and output of stdout and stderr to make handling of return code and handling more consistent.