### PR TITLE
Add pytest_report_header to print additional info

### DIFF
--- a/changelog.d/123.infra.rst
+++ b/changelog.d/123.infra.rst
@@ -1,0 +1,2 @@
+Add ``pytest_report_header`` from pytest to print additional information
+in the header.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,25 +1,35 @@
 """Pytest fixtures and global logging mock."""
 
 from collections.abc import Callable, Generator
+import os
 from pathlib import Path
 from typing import Any, NamedTuple
 from unittest.mock import MagicMock, Mock
-import os
-import pytest
 
 from click.testing import CliRunner
+import pytest
 
-# Import the module containing setup_logging for mocking
-import docbuild.logging 
 import docbuild.cli as cli_module
 import docbuild.cli.cmd_cli as cli
 from docbuild.cli.context import DocBuildContext
 from docbuild.config import load as load_mod
 from docbuild.constants import DEFAULT_ENV_CONFIG_FILENAME
+
+# Import the module containing setup_logging for mocking
+import docbuild.logging
 from tests.common import changedir
 
+
+# Adding info to test report header
+# https://docs.pytest.org/en/stable/example/simple.html#adding-info-to-test-report-header
+def pytest_report_header(config: pytest.Config):
+    from docbuild.__about__ import __version__
+
+    return f'DocBuild Version: {__version__}'
+
+
 # --- Global Fixture to Mute Logging Setup (Debugging Step) ---
-@pytest.fixture(autouse=True, scope="function") 
+@pytest.fixture(autouse=True, scope="function")
 def mock_setup_logging_globally(monkeypatch):
     """Mocks out the setup_logging call to prevent any initialization side-effects in tests."""
     mock_func = MagicMock()

--- a/tests/models/config/test_env.py
+++ b/tests/models/config/test_env.py
@@ -10,7 +10,7 @@ from pydantic import ValidationError, HttpUrl, IPvAnyAddress
 from ipaddress import IPv4Address
 
 from docbuild.models.config.env import EnvConfig, Env_Server
-import docbuild.config.app as config_app_mod 
+import docbuild.config.app as config_app_mod
 
 
 # --- Fixture Setup ---
@@ -19,10 +19,10 @@ def _mock_successful_placeholder_resolver(data: dict[str, Any]) -> dict[str, Any
     """Mocks the placeholder resolver to return a guaranteed clean, resolved dictionary."""
 
     resolved_data = data.copy()
-    
+
     # Define resolved paths based on the EnvConfig structure
     tmp_general = '/var/tmp/docbuild/doc-example-com'
-    
+
     resolved_data['paths']['config_dir'] = '/etc/docbuild'
     resolved_data['paths']['root_config_dir'] = '/etc/docbuild'
     resolved_data['paths']['jinja_dir'] = '/etc/docbuild/jinja-doc-suse-com'
@@ -43,10 +43,10 @@ def _mock_successful_placeholder_resolver(data: dict[str, Any]) -> dict[str, Any
     resolved_data['paths']['tmp']['tmp_deliverable_name'] = '{{product}}_{{docset}}_{{lang}}_XXXXXX'
     resolved_data['paths']['target']['target_path'] = 'doc@10.100.100.100:/srv/docs'
     resolved_data['paths']['target']['backup_path'] = Path('/data/docbuild/external-builds/')
-    
-    # Ensure mandatory top-level fields (like 'build') are present 
+
+    # Ensure mandatory top-level fields (like 'build') are present
     resolved_data.setdefault(
-        'build', 
+        'build',
         {'daps': {'command': 'daps', 'meta': 'daps meta'}, 'container': {'container': 'registry.example.com/container'}}
     )
 
@@ -59,7 +59,7 @@ def mock_placeholder_resolution(monkeypatch):
 
     monkeypatch.setattr(
         config_app_mod,
-        'replace_placeholders', 
+        'replace_placeholders',
         _mock_successful_placeholder_resolver
     )
 
@@ -79,7 +79,7 @@ def mock_valid_raw_env_data(tmp_path: Path) -> dict[str, Any]:
         'search': {'description': {'length': 118}},
         'socialmedia': {'description': {'length': 65}},
     }
-    
+
     return {
         'server': {
             'name': 'doc-example-com',
@@ -103,15 +103,15 @@ def mock_valid_raw_env_data(tmp_path: Path) -> dict[str, Any]:
             'temp_repo_dir': '/var/cache/docbuild/repos/temporary-branches/',
             'base_cache_dir': '/var/cache/docserv',
             'meta_cache_dir': '/var/cache/docbuild/doc-example-com/meta',
-            
+
             'tmp': {
                 'tmp_base_dir': '/var/tmp/docbuild',
-                'tmp_dir': '{tmp_base_dir}/doc-example-com', 
+                'tmp_dir': '{tmp_base_dir}/doc-example-com',
                 'tmp_deliverable_dir': '{tmp_dir}/deliverable/',
                 'tmp_build_dir': '{tmp_dir}/build/{{product}}-{{docset}}-{{lang}}',
                 'tmp_out_dir': '{tmp_dir}/out/',
                 'log_dir': '{tmp_dir}/log',
-                'tmp_metadata_dir': '{tmp_dir}/metadata', 
+                'tmp_metadata_dir': '{tmp_dir}/metadata',
                 'tmp_deliverable_name': '{{product}}_{{docset}}_{{lang}}_XXXXXX',
             },
             'target': {
@@ -134,14 +134,14 @@ def test_envconfig_full_success(mock_valid_raw_env_data: dict[str, Any]):
 
     config = EnvConfig.from_dict(mock_valid_raw_env_data)
 
-    assert isinstance(config, dict) # EnvConfig)
+    assert isinstance(config, EnvConfig)
 
     # Check type coercion for core types
     assert isinstance(config.paths.base_cache_dir, Path)
-    
+
     assert config.paths.tmp.tmp_path.is_absolute()
     assert config.paths.tmp.tmp_path.name == 'doc-example-com'
-    
+
     # Check that the field with runtime placeholders is correctly handled as a string
     assert isinstance(config.paths.tmp.tmp_build_dir, str)
 
@@ -156,10 +156,10 @@ def test_envconfig_type_coercion_ip_host(mock_valid_raw_env_data: dict[str, Any]
 
     data = mock_valid_raw_env_data.copy()
     data['server']['host'] = '192.168.1.1'
-    
+
     config = EnvConfig.from_dict(data)
-    
-    assert isinstance(config.server.host, IPv4Address) 
+
+    assert isinstance(config.server.host, IPv4Address)
     assert str(config.server.host) == '192.168.1.1'
 
 
@@ -173,56 +173,56 @@ def test_envconfig_strictness_extra_field_forbid(tmp_path: Path):
         },
         'server': {'name': 'D', 'role': 'production', 'host': '1.1.1.1', 'enable_mail': True},
         'config': {
-            'default_lang': 'en-us', 
+            'default_lang': 'en-us',
             'languages': ['en-us'],
             'canonical_url_domain': 'https://a.b'
         },
         'paths': {
-            'config_dir': str(tmp_path / 'config'), 
+            'config_dir': str(tmp_path / 'config'),
             'root_config_dir': '/tmp',
             'jinja_dir': '/tmp',
             'server_rootfiles_dir': '/tmp',
             'base_server_cache_dir': '/tmp',
             'base_tmp_dir': '/tmp',
-            'repo_dir': '/tmp', 
-            'temp_repo_dir': '/tmp', 
+            'repo_dir': '/tmp',
+            'temp_repo_dir': '/tmp',
             'base_cache_dir': '/tmp',
             'meta_cache_dir': '/tmp',
-            
+
             'tmp': {
-                'tmp_base_dir': '/tmp', 
+                'tmp_base_dir': '/tmp',
                 'tmp_dir': '/tmp',
-                'tmp_deliverable_dir': '/tmp/deliverable', 
+                'tmp_deliverable_dir': '/tmp/deliverable',
                 'tmp_metadata_dir': '/tmp/metadata',
-                'tmp_build_dir': '/tmp/build/{{product}}', 
-                'tmp_out_dir': '/tmp/out', 
-                'log_dir': '/tmp/log', 
+                'tmp_build_dir': '/tmp/build/{{product}}',
+                'tmp_out_dir': '/tmp/out',
+                'log_dir': '/tmp/log',
                 'tmp_deliverable_name': 'main',
             },
             'target': {
-                'target_dir': '/srv', 
-                'backup_dir': '/mnt' 
+                'target_dir': '/srv',
+                'backup_dir': '/mnt'
             },
         },
-        'xslt-params': {'test': 1}, 
+        'xslt-params': {'test': 1},
         'typo_section': {'key': 'value'}
     }
-    
+
     with pytest.raises(ValidationError) as excinfo:
         EnvConfig.from_dict(raw_data)
-        
+
     locs = excinfo.value.errors()[0]['loc']
     assert ('typo_section',) == tuple(locs)
 
 
 def test_envconfig_invalid_role_fails(mock_valid_raw_env_data: dict[str, Any]):
     """Test that an invalid role string is rejected by ServerRole enum."""
-    
+
     data = mock_valid_raw_env_data.copy()
     data['server']['role'] = 'testing_invalid'
-    
+
     with pytest.raises(ValidationError) as excinfo:
         EnvConfig.from_dict(data)
-        
+
     locs = excinfo.value.errors()[0]['loc']
     assert ('server', 'role') == tuple(locs)


### PR DESCRIPTION
This can be useful to print additional information (like DocBuild version, dependencies etc.) in the pytest header.

Especially when investigating a test session in a CI environment can be helpful.

Currently, it only prints the DocBuild version.