### PR TITLE
GHA: Add workflow for Ruff (code formatting check)

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,19 @@
+---
+name: Ruff
+on: [ pull_request ]
+
+permissions:
+  contents: read
+  pull-requests: write # Required for posting comments
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Check for formatting errors (but don't fix them)
+
+      - uses: astral-sh/ruff-action@v3
+        with:
+          github-token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          args: "check"

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -3,30 +3,12 @@ target-version = "py312"
 
 # Max line length (matches Black's default)
 line-length = 88
+indent-width = 4
 
-# Exclude a variety of commonly ignored directories.
-exclude = [
-    ".direnv",
-    ".eggs",
-    ".git",
-    ".mypy_cache",
-    ".nox",
-    ".pants.d",
-    ".pyenv",
-    ".pytest_cache",
-    ".pytype",
-    ".ruff_cache",
-    ".svn",
-    ".tox",
-    ".venv",
-    ".vscode",
-    "__pypackages__",
-    "_build",
-    "build",
+# Amend exclude list in addtion to "exclude".
+# See https://docs.astral.sh/ruff/configuration/
+extend-exclude = [
     "contrib",
-    "dist",
-    "site-packages",
-    "venv",
 ]
 
 
@@ -44,7 +26,6 @@ select = [
     "C90",  # mccabe complexity
     "B",    # flake8-bugbear
     "A",    # flake8-builtins
-    "COM",  # flake8-commas
     "RUF",  # Ruff-specific rules
 ]
 
@@ -54,8 +35,7 @@ ignore = [
     "D107",    # Missing docstring in __init__
     "D203",    # Conflicts with D211 (one blank line before class docstring)
     "D213",    # Conflicts with D212 (multi-line docstring start convention)
-    # "D401",    # First line of docstring should be in imperative mood
-    "COM812",  #
+    "E501",    # Line too long (Let the formatter handle this)
 ]
 
 # Allow autofix for everything except complexity and annotations
@@ -85,17 +65,9 @@ quote-style = "double"
     "D301"  # Use `r"""` if any backslashes in a docstring
 ]
 "tests/**/test_*.py" = [
-    "ANN001", # Missing type annotation for function argument
-    "ANN002", # Missing type annotation for variable
-    "ANN003", # Missing type annotation for class attribute
-    "ANN201", # Missing return type annotation
-    "ANN202", # Missing return type annotation for private function
-    "ANN204", # Missing return type annotation for special method `__init__`
-    "ANN401", # Missing type annotation for self in method
-    "D100",   # Missing docstring in public module
-    "D101",   # Missing docstring in public class
-    "D103",   # Missing docstring in public function
-    "D105",   # Missing docstring in magic method
+    "ANN",    # Ignore ALL annotations in tests (simpler than listing specific codes)
+    "D",      # Ignore ALL docstrings in tests
+    "S101",   # (Optional) If you add flake8-bandit, this allows "assert" in tests
 ]
 # Ignore unused imports in all __init__.py files
 "__init__.py" = ["F401"]

--- a/changelog.d/127.infra.rst
+++ b/changelog.d/127.infra.rst
@@ -1,0 +1,1 @@
+Add a new GitHub Action for code formatting issues using Ruff.


### PR DESCRIPTION
First implementation of GitHub Action.

Failed Ruff action is expected (no formatting the code yet). At the moment the GitHub Action does:

* Calls `ruff check --statistics` to get a nice overview.
* Reports the stats, but not fixes any issue. That's the responsibility of the author. :wink: 
* Reads the `.ruff.toml` config file. I simplified it as some values are already defined in the default. No need to repeat them.
* Adds a news fragment file.

Plan:
* Finish other important issues.
* Reformat the code.
* Create a new release.
* Rebase this branch and merge it to main, if everything is fine.