### PR TITLE
Reduce coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,11 @@ omit =
 
 [report]
 precision = 1
+fail_under = 90.0
+# Sort the report by missing coverage, descending
+sort = -Cover
+#
+skip_covered = true
 exclude_lines =
    pragma: no cover
    raise NotImplementedError


### PR DESCRIPTION
A lengthy coverage report were most files are 100% aren't easy to read. Adding the respective options in `.coveragerc` leads to a condensed form.

Additionally, the coverage report is sorted in descending order of the coverage percentage value. See coverage report below.