### PR TITLE
Reformat source code with Ruff

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -55,7 +55,7 @@ ignore = [
     "D203",    # Conflicts with D211 (one blank line before class docstring)
     "D213",    # Conflicts with D212 (multi-line docstring start convention)
     # "D401",    # First line of docstring should be in imperative mood
-    "COM812",  # 
+    "COM812",  #
 ]
 
 # Allow autofix for everything except complexity and annotations
@@ -77,7 +77,7 @@ max-complexity = 10
 
 [format]
 # 5. Use single quotes in `ruff format`.
-quote-style = "single"
+quote-style = "double"
 
 
 [lint.per-file-ignores]
@@ -91,8 +91,11 @@ quote-style = "single"
     "ANN201", # Missing return type annotation
     "ANN202", # Missing return type annotation for private function
     "ANN204", # Missing return type annotation for special method `__init__`
+    "ANN401", # Missing type annotation for self in method
     "D100",   # Missing docstring in public module
     "D101",   # Missing docstring in public class
     "D103",   # Missing docstring in public function
     "D105",   # Missing docstring in magic method
 ]
+# Ignore unused imports in all __init__.py files
+"__init__.py" = ["F401"]

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,20 @@
+# Project: Docbuild
+
+Docbuild is a project to build documentation either from DocBook or ADoc code. It maintains a set of XML configuration files, clones the repositories, calls the `daps` executable, takes care of metadata and syncs the result deliverables to its target directory.
+
+## General instructions
+
+- Make minimal changes
+- Leave the code base untouched as much as possible
+
+## Coding Standards
+
+Ensure the generated code conforms to these points:
+
+- Python Version: Use Python 3.12 or higher. Adapt code style, type hints, and docstrings accordingly.
+
+- Type Hints: Use type hints for functions and variables where feasible.
+
+- Docstrings: Add Sphinx-style docstrings. Document the purpose of the code in a short line, followed by the arguments and their purpose.
+
+- Clarity & Maintainability: Focus on clean, maintainable code. Adhere to the single responsibility principle (one function, one purpose).

--- a/changelog.d/135.infra.rst
+++ b/changelog.d/135.infra.rst
@@ -1,0 +1,1 @@
+Reformat the source code with Ruff. Removed unused imports and variables, fix docstrings, and use double quotes in strings.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,17 +8,17 @@
 
 from docbuild.__about__ import __version__
 
-project = 'docbuild'
-copyright = '2025, Tom Schraitle'  # noqa: A001
-author = 'Tom Schraitle'
+project = "docbuild"
+copyright = "2025, Tom Schraitle"  # noqa: A001
+author = "Tom Schraitle"
 release = __version__
 
-gh_user = 'openSUSE'
-gh_repo_url = f'https://github.com/{gh_user}/{project}'
-gh_repo_slug = f'{gh_user}/{project}'
+gh_user = "openSUSE"
+gh_repo_url = f"https://github.com/{gh_user}/{project}"
+gh_repo_slug = f"{gh_user}/{project}"
 
-xml_config_repo = 'https://gitlab.suse.de/susedoc/docserv-config'
-xml_config_slug = '/'.join(xml_config_repo.rsplit('/', 2)[-2:])
+xml_config_repo = "https://gitlab.suse.de/susedoc/docserv-config"
+xml_config_slug = "/".join(xml_config_repo.rsplit("/", 2)[-2:])
 
 # --- Prolog configuration
 rst_prolog = f"""
@@ -39,50 +39,50 @@ rst_prolog = f"""
 extensions = [
     # Include documentation from docstrings
     # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
-    'sphinx.ext.autodoc',
+    "sphinx.ext.autodoc",
     #
     # Link to other projects' documentation
     # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
-    'sphinx.ext.intersphinx',
+    "sphinx.ext.intersphinx",
     #
     # Test code snippets in the documentation
     # https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html
-    'sphinx.ext.doctest',
+    "sphinx.ext.doctest",
     #
     # Create short aliases for external links
     # https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html
-    'sphinx.ext.extlinks',
+    "sphinx.ext.extlinks",
     #
     # Embed Graphviz graphs
     # https://www.sphinx-doc.org/en/master/usage/extensions/graphviz.html
-    'sphinx.ext.graphviz',
+    "sphinx.ext.graphviz",
     #
     # Document Click command-line interfaces
     # https://sphinx-click.readthedocs.io/en/latest/
-    'sphinx_click',
+    "sphinx_click",
     #
     # Add a "copy" button to code blocks
     # https://sphinx-copybutton.readthedocs.io/en/latest/
-    'sphinx_copybutton',
+    "sphinx_copybutton",
     #
     # Render type hints in signatures
     # https://github.com/tox-dev/sphinx-autodoc-typehints
-    'sphinx_autodoc_typehints',
+    "sphinx_autodoc_typehints",
     #
     # Generate API documentation from source code
     # https://sphinx-autoapi.readthedocs.io/en/latest/
-    'autoapi.extension',
+    "autoapi.extension",
 ]
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 exclude_patterns = []
 
-language = 'en'
+language = "en"
 
 # -- Options for autoapi extension
 # https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html
 autoapi_modules = {
-    'docbuild': None,
+    "docbuild": None,
     # {
     #     # "output": "reference/_autoapi",
     #     # "prune": True|False,
@@ -90,36 +90,36 @@ autoapi_modules = {
     #     # "template":
     # }
 }
-autoapi_root = 'reference/_autoapi'
-autoapi_dirs = ['../../src/']
-autoapi_type = 'python'
+autoapi_root = "reference/_autoapi"
+autoapi_dirs = ["../../src/"]
+autoapi_type = "python"
 autoapi_add_toctree_entry = False
 # autoapi_template_dir = "_templates/autoapi"
 autoapi_options = [
-    'members',
+    "members",
     # "undoc-members",
     # 'inherited-members',
-    'show-inheritance',
-    'show-module-summary',
+    "show-inheritance",
+    "show-module-summary",
     # 'imported-members',
-    'special-members',
-    'show-inheritance-diagram',  # needs sphinx.ext.inheritance_diagram & graphviz
+    "special-members",
+    "show-inheritance-diagram",  # needs sphinx.ext.inheritance_diagram & graphviz
     # "private-members",
 ]
 autoapi_keep_files = True
-autodoc_typehints = 'signature'
-autoapi_own_page_level = 'class'
-#autoapi_python_use_implicit_namespaces = True
+autodoc_typehints = "signature"
+autoapi_own_page_level = "class"
+# autoapi_python_use_implicit_namespaces = True
 
 # -- Options for extlinks extension ------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html
 extlinks = {
     # Example for linking to a specific file/path in the repo:
-    'gh_path': (f'{gh_repo_url}/blob/main/%s', '%s'),
+    "gh_path": (f"{gh_repo_url}/blob/main/%s", "%s"),
     # Example for linking to a specific directory in the repo:
-    'gh_tree': (f'{gh_repo_url}/tree/main/%s', '%s'),
+    "gh_tree": (f"{gh_repo_url}/tree/main/%s", "%s"),
     # Linking to the GH issue tracker:
-    'gh': (f'{gh_repo_url}/issues/%s', 'GH #%s'),
+    "gh": (f"{gh_repo_url}/issues/%s", "GH #%s"),
 }
 
 
@@ -129,75 +129,75 @@ extlinks = {
 
 autosummary_generate = False
 autodoc_default_options = {
-    'members': True,
-    'undoc-members': False,
-    'show-inheritance': True,
-    'inherited-members': False,
-    'private-members': True,
+    "members": True,
+    "undoc-members": False,
+    "show-inheritance": True,
+    "inherited-members": False,
+    "private-members": True,
 }
 
-html_theme = 'pydata_sphinx_theme'
+html_theme = "pydata_sphinx_theme"
 # html_theme = "alabaster"
 
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 html_css_files = [
-    'css/custom.css',
+    "css/custom.css",
 ]
 
 html_context = {
-    'github_user': gh_user,
-    'github_repo': project,
-    'github_version': 'main',
-    'doc_path': 'docs/source/',
+    "github_user": gh_user,
+    "github_repo": project,
+    "github_version": "main",
+    "doc_path": "docs/source/",
 }
 
 html_theme_options = {
-    'announcement': 'Documentation is under construction.',
-    'show_prev_next': True,
+    "announcement": "Documentation is under construction.",
+    "show_prev_next": True,
     # "html_last_updated_fmt": "%b %d, %Y",
-    'content_footer_items': ['last-updated'],
-    'github_url': gh_repo_url,
+    "content_footer_items": ["last-updated"],
+    "github_url": gh_repo_url,
     #   "external_links": [
     #       {"name": "link-one-name", "url": "https://<link-one>"},
     #   ],
     #
-    'icon_links': [
+    "icon_links": [
         {
-            'name': 'GitLab susedoc/docserv-config',
-            'url': xml_config_repo,
-            'icon': 'fa-brands fa-square-gitlab',
-            'type': 'fontawesome',
+            "name": "GitLab susedoc/docserv-config",
+            "url": xml_config_repo,
+            "icon": "fa-brands fa-square-gitlab",
+            "type": "fontawesome",
         },
         {
-            'name': 'Kanban board',
-            'url': 'https://github.com/orgs/openSUSE/projects/27/',
-            'icon': 'fa-solid fa-table-columns',
-            'type': 'fontawesome',
+            "name": "Kanban board",
+            "url": "https://github.com/orgs/openSUSE/projects/27/",
+            "icon": "fa-solid fa-table-columns",
+            "type": "fontawesome",
         },
     ],
     #
-    'use_edit_page_button': True,
-    'back_to_top_button': True,
-    'logo': {
-        'text': 'Docbuild Documentation',
+    "use_edit_page_button": True,
+    "back_to_top_button": True,
+    "logo": {
+        "text": "Docbuild Documentation",
         # "image_light": "_static/logo-light.png",
         # "image_dark": "_static/logo-dark.png",
     },
 }
 
-html_logo = '_static/logo.png'
+html_logo = "_static/logo.png"
 
-html_favicon = '_static/favicon.ico'
+html_favicon = "_static/favicon.ico"
 
 # -- Options for intersphinx extension ---------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3', None),
-    'pydantic': ('https://docs.pydantic.dev/latest/', None),
-    'click': ('https://click.palletsprojects.com/en/latest/', None),
-    'jinja2': ('https://jinja.palletsprojects.com/en/latest/', None),
+    "python": ("https://docs.python.org/3", None),
+    "pydantic": ("https://docs.pydantic.dev/latest/", None),
+    "click": ("https://click.palletsprojects.com/en/latest/", None),
+    "jinja2": ("https://jinja.palletsprojects.com/en/latest/", None),
 }
 
 # -- Options for linkcheck builder --------------------------------------------
@@ -205,14 +205,14 @@ intersphinx_mapping = {
 
 linkcheck_ignore = [
     # Ignore links to the internal GitLab server, which may require a VPN or login.
-    r'https://gitlab\.suse\.de/.*',
+    r"https://gitlab\.suse\.de/.*",
     # Ignore links to local development servers.
-    r'http://127\.0\.0\.1:\d+/',
-    r'http://localhost:\d+/',
+    r"http://127\.0\.0\.1:\d+/",
+    r"http://localhost:\d+/",
     # Ignore mailto links
-    r'mailto:.*',
+    r"mailto:.*",
     # Ignore settings page as only admins have access
-    rf'https://github\.com/{gh_user}/{project}/settings/rules',
+    rf"https://github\.com/{gh_user}/{project}/settings/rules",
     # Just ignore useless example URLs
-    r'https://github\.com/org/repo',
+    r"https://github\.com/org/repo",
 ]

--- a/src/docbuild/__about__.py
+++ b/src/docbuild/__about__.py
@@ -3,7 +3,7 @@
 This module contains metadata about the package, including its version and authors.
 """
 
-__version__ = '0.14.0'
+__version__ = "0.14.0"
 __authors__ = [
-    'Tom Schraitle <toms@suse.de>',
+    "Tom Schraitle <toms@suse.de>",
 ]

--- a/src/docbuild/__main__.py
+++ b/src/docbuild/__main__.py
@@ -2,5 +2,5 @@
 
 from .cli.cmd_cli import cli
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()

--- a/src/docbuild/cli/callback.py
+++ b/src/docbuild/cli/callback.py
@@ -1,3 +1,5 @@
+"""Click callback to validate doctype strings."""
+
 import logging
 
 import click
@@ -40,39 +42,39 @@ def validate_doctypes(
         except ValueError as err:
             click.secho(
                 f"ERROR: Invalid doctype string '{doctype_str}': {err}",
-                fg='red',
+                fg="red",
                 err=True,
             )
             raise click.Abort(err) from err
 
         except ValidationError as err:
             for error in err.errors():
-                field = error['loc'][0]
+                field = error["loc"][0]
                 # Convert to string to ensure it works as dictionary key
                 field_name = str(field)
-                msg = error['msg']
+                msg = error["msg"]
                 # Make accessing of .description and .examples safe(r) if
                 # the definition in Doctype is not present
                 safe_field = Field(description=None, examples=None)
                 hint = getattr(
                     Doctype.model_fields.get(field_name, safe_field),
-                    'description',
+                    "description",
                     None,
                 )
                 examples = getattr(
                     Doctype.model_fields.get(field_name, safe_field),
-                    'examples',
+                    "examples",
                     None,
                 )
                 click.secho(
                     f"ERROR in '{field}': {msg}",
-                    fg='red',
+                    fg="red",
                     err=True,
                 )
                 if hint:
-                    click.echo(f'  → Hint: {hint}')
+                    click.echo(f"  → Hint: {hint}")
                 if examples:
-                    click.echo(f'  → Examples: {", ".join(examples)}')
+                    click.echo(f"  → Examples: {', '.join(examples)}")
                 click.echo()
             raise click.Abort(err) from err
 

--- a/src/docbuild/cli/cmd_build/__init__.py
+++ b/src/docbuild/cli/cmd_build/__init__.py
@@ -42,10 +42,10 @@ from ..context import DocBuildContext
 
 
 @click.command(
-    help=__doc__.replace('\b\n\n', '\b\n').replace('``', ''),  # type: ignore
+    help=__doc__.replace("\b\n\n", "\b\n").replace("``", ""),  # type: ignore
 )
 @click.argument(
-    'doctypes',
+    "doctypes",
     nargs=-1,
     callback=validate_doctypes,
 )
@@ -59,6 +59,6 @@ def build(ctx: click.Context, doctypes: tuple[Doctype]) -> None:
     ctx.ensure_object(DocBuildContext)
     context: DocBuildContext = ctx.obj
 
-    click.echo(f'[BUILD] Verbosity: {context.verbose}')
-    click.echo(f'{context=}')
-    click.echo(f'{context.appconfigfiles=}')
+    click.echo(f"[BUILD] Verbosity: {context.verbose}")
+    click.echo(f"{context=}")
+    click.echo(f"{context.appconfigfiles=}")

--- a/src/docbuild/cli/cmd_c14n/__init__.py
+++ b/src/docbuild/cli/cmd_c14n/__init__.py
@@ -10,4 +10,4 @@ def c14n(ctx: click.Context) -> None:
 
     :param ctx: The Click context object.
     """
-    click.echo(f'[C17N] Verbosity: {ctx.obj.verbose}')
+    click.echo(f"[C17N] Verbosity: {ctx.obj.verbose}")

--- a/src/docbuild/cli/cmd_config/__init__.py
+++ b/src/docbuild/cli/cmd_config/__init__.py
@@ -7,7 +7,7 @@ from .environment import env
 
 
 @click.group(
-    name='config',
+    name="config",
     help=__doc__,
 )
 @click.pass_context

--- a/src/docbuild/cli/cmd_config/application.py
+++ b/src/docbuild/cli/cmd_config/application.py
@@ -15,9 +15,9 @@ def app(ctx: click.Context) -> None:
     :param ctx: The Click context object.
     """
     if ctx.obj.appconfigfiles:
-        files = ', '.join(str(f) for f in ctx.obj.appconfigfiles)
-        click.secho(f"# Application config files '{files}'", fg='blue')
+        files = ", ".join(str(f) for f in ctx.obj.appconfigfiles)
+        click.secho(f"# Application config files '{files}'", fg="blue")
         print(Pretty(ctx.obj.appconfig, expand_all=True))
     else:
-        click.secho('# No application config files provided', fg='yellow')
+        click.secho("# No application config files provided", fg="yellow")
         print(Pretty(ctx.obj.appconfig, expand_all=True))

--- a/src/docbuild/cli/cmd_config/environment.py
+++ b/src/docbuild/cli/cmd_config/environment.py
@@ -1,8 +1,6 @@
 """CLI interface to showsthe configuration of the environment files."""
 
 import click
-from rich import print 
-from rich.pretty import Pretty
 from rich import print_json
 
 
@@ -15,15 +13,14 @@ def env(ctx: click.Context) -> None:
 
     :param ctx: The Click context object.
     """
-
     # Check if envconfigfiles is None (which it is when the default config is used)
     if ctx.obj.envconfigfiles is None:
-        path = '(Default configuration used)'
+        path = "(Default configuration used)"
     else:
-        path = ', '.join(str(path) for path in ctx.obj.envconfigfiles)
-        
-    click.secho(f"# ENV Config file '{path}'", fg='blue')
-    
+        path = ", ".join(str(path) for path in ctx.obj.envconfigfiles)
+
+    click.secho(f"# ENV Config file '{path}'", fg="blue")
+
     serialized_config = ctx.obj.envconfig.model_dump_json()
 
     print_json(serialized_config)

--- a/src/docbuild/cli/cmd_metadata/__init__.py
+++ b/src/docbuild/cli/cmd_metadata/__init__.py
@@ -14,28 +14,30 @@ from .metaprocess import process
 
 # Set up rich consoles for output
 stdout = Console()
-console_err = Console(stderr=True, style='red')
+console_err = Console(stderr=True, style="red")
 
 
 @click.command(help=__doc__)
 @click.argument(
-    'doctypes',
+    "doctypes",
     nargs=-1,
     callback=validate_doctypes,
 )
 @click.option(
-    '-E', '--exitfirst',
+    "-E",
+    "--exitfirst",
     is_flag=True,
     default=False,
     show_default=True,
-    help='Exit on first failed deliverable.',
+    help="Exit on first failed deliverable.",
 )
 @click.option(
-    '-S', '--skip-repo-update',
+    "-S",
+    "--skip-repo-update",
     is_flag=True,
     default=False,
     show_default=True,
-    help='Skip updating git repositories before processing.',
+    help="Skip updating git repositories before processing.",
 )
 @click.pass_context
 def metadata(
@@ -49,7 +51,7 @@ def metadata(
     :param ctx: The Click context object.
     """
     context: DocBuildContext = ctx.obj
-    timer = make_timer('metadata')
+    timer = make_timer("metadata")
     result = 1  # Default exit code for interruption or error
 
     # The timer data object 't' will be populated by the context manager.
@@ -58,11 +60,15 @@ def metadata(
     try:
         with timer() as t:
             result = asyncio.run(
-                process(context, doctypes,
-                        exitfirst=exitfirst, skip_repo_update=skip_repo_update)
+                process(
+                    context,
+                    doctypes,
+                    exitfirst=exitfirst,
+                    skip_repo_update=skip_repo_update,
+                )
             )
     finally:
         if t and not math.isnan(t.elapsed):
-            stdout.print(f'Elapsed time {t.elapsed:0.2f}s')
+            stdout.print(f"Elapsed time {t.elapsed:0.2f}s")
 
     ctx.exit(result)

--- a/src/docbuild/cli/cmd_repo/cmd_clone.py
+++ b/src/docbuild/cli/cmd_repo/cmd_clone.py
@@ -14,16 +14,17 @@ import logging
 import click
 
 from ...cli.context import DocBuildContext
-from .process import process
 from ...constants import GITLOGGER_NAME
+from .process import process
 
 log = logging.getLogger(__name__)
 
 git_logger = logging.getLogger(GITLOGGER_NAME)
 
+
 @click.command(help=__doc__)
 @click.argument(
-    'repos',
+    "repos",
     nargs=-1,
 )
 @click.pass_context
@@ -35,8 +36,8 @@ def clone(ctx: click.Context, repos: tuple[str, ...]) -> None:
     """
     context: DocBuildContext = ctx.obj
     if context.envconfig is None:
-        raise ValueError('No envconfig found in context.')
+        raise ValueError("No envconfig found in context.")
 
     result = asyncio.run(process(context, repos))
-    log.info(f'Clone process completed with exit code: {result}')
+    log.info(f"Clone process completed with exit code: {result}")
     ctx.exit(result)

--- a/src/docbuild/cli/cmd_repo/cmd_dir.py
+++ b/src/docbuild/cli/cmd_repo/cmd_dir.py
@@ -5,7 +5,7 @@ import click
 from ...cli.context import DocBuildContext
 
 
-@click.command(help=__doc__, name='dir')
+@click.command(help=__doc__, name="dir")
 @click.pass_context
 def cmd_dir(ctx: click.Context) -> None:
     """Show the directory path for permanent repositories.
@@ -17,8 +17,8 @@ def cmd_dir(ctx: click.Context) -> None:
     """
     context: DocBuildContext = ctx.obj
     if context.envconfig is None:
-        raise ValueError('No envconfig found in context.')
+        raise ValueError("No envconfig found in context.")
 
-    repo_dir = context.envconfig.get('paths', {}).get('repo_dir', None)
+    repo_dir = context.envconfig.get("paths", {}).get("repo_dir", None)
     print(repo_dir)
     ctx.exit(0)

--- a/src/docbuild/cli/cmd_repo/cmd_list.py
+++ b/src/docbuild/cli/cmd_repo/cmd_list.py
@@ -11,7 +11,7 @@ console = Console()
 console_err = Console(stderr=True)
 
 
-@click.command(help=__doc__, name='list')
+@click.command(help=__doc__, name="list")
 @click.pass_context
 def cmd_list(ctx: click.Context) -> None:
     """List the available permanent repositories.
@@ -25,24 +25,24 @@ def cmd_list(ctx: click.Context) -> None:
     """
     context: DocBuildContext = ctx.obj
     if context.envconfig is None:
-        raise ValueError('No envconfig found in context.')
+        raise ValueError("No envconfig found in context.")
 
-    repo_dir = context.envconfig.get('paths', {}).get('repo_dir', None)
+    repo_dir = context.envconfig.get("paths", {}).get("repo_dir", None)
     if repo_dir is None:
         raise ValueError(
-            'No permanent repositories defined, neither with '
-            '--env-config nor as default.'
+            "No permanent repositories defined, neither with "
+            "--env-config nor as default."
         )
     repo_dir = Path(repo_dir).resolve()
     if not repo_dir.exists():
         console_err.print(
-            f'[red]ERROR:[/] No permanent repositories found in {repo_dir}.',
+            f"[red]ERROR:[/] No permanent repositories found in {repo_dir}.",
         )
         ctx.exit(1)
 
-    console.print(f'Available permanent repositories in {repo_dir}:')
+    console.print(f"Available permanent repositories in {repo_dir}:")
     for path in Path(repo_dir).iterdir():
-        if path.is_dir() and not path.name.startswith('.'):
-            console.print(f'  - {path}')
+        if path.is_dir() and not path.name.startswith("."):
+            console.print(f"  - {path}")
 
     ctx.exit(0)

--- a/src/docbuild/cli/cmd_validate/__init__.py
+++ b/src/docbuild/cli/cmd_validate/__init__.py
@@ -15,18 +15,20 @@ log = logging.getLogger(__name__)
 
 @click.command(help=__doc__)
 @click.argument(
-    'xmlfiles',
+    "xmlfiles",
     nargs=-1,
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
 )
 @click.option(
-    '--validation-method',
-    type=click.Choice(['jing', 'lxml'], case_sensitive=False),
-    default='jing',
+    "--validation-method",
+    type=click.Choice(["jing", "lxml"], case_sensitive=False),
+    default="jing",
     help="Choose validation method: 'jing' or 'lxml'",
 )
 @click.pass_context
-def validate(ctx: click.Context, xmlfiles: tuple | Iterator[Path], validation_method: str) -> None:
+def validate(
+    ctx: click.Context, xmlfiles: tuple | Iterator[Path], validation_method: str
+) -> None:
     """Subcommand to validate XML configuration files.
 
     :param ctx: The Click context object.
@@ -39,23 +41,23 @@ def validate(ctx: click.Context, xmlfiles: tuple | Iterator[Path], validation_me
     context.validation_method = validation_method.lower()
 
     if context.envconfig is None:
-        raise ValueError('No envconfig found in context.')
+        raise ValueError("No envconfig found in context.")
 
-    if (paths := ctx.obj.envconfig.get('paths')) is None:
-        raise ValueError('No paths found in envconfig.')
+    if (paths := ctx.obj.envconfig.get("paths")) is None:
+        raise ValueError("No paths found in envconfig.")
 
-    configdir = paths.get('config_dir', None)
+    configdir = paths.get("config_dir", None)
     if configdir is None:
-        raise ValueError('Could not get a value from envconfig.paths.config_dir')
+        raise ValueError("Could not get a value from envconfig.paths.config_dir")
 
     configdir_path = Path(configdir).expanduser()
 
     if not xmlfiles:
-        xml_files_to_process = tuple(configdir_path.rglob('[a-z]*.xml'))
+        xml_files_to_process = tuple(configdir_path.rglob("[a-z]*.xml"))
     else:
         xml_files_to_process = xmlfiles
 
-    log.info(f'Validating XML configuration files using {validation_method} method')
+    log.info(f"Validating XML configuration files using {validation_method} method")
 
     result = asyncio.run(process_mod.process(context, xmlfiles=xml_files_to_process))
 

--- a/src/docbuild/cli/cmd_validate/process.py
+++ b/src/docbuild/cli/cmd_validate/process.py
@@ -5,11 +5,11 @@ from collections.abc import Iterator
 from datetime import date
 import logging
 from pathlib import Path
+from subprocess import CompletedProcess
 import tempfile
 
 from lxml import etree
 from rich.console import Console
-from subprocess import CompletedProcess
 
 from ...config.xml.checks import CheckResult, register_check
 from ...config.xml.stitch import create_stitchfile
@@ -31,7 +31,7 @@ console_err = Console(stderr=True)
 
 
 # Default RELAX NG schema file for product configuration
-PRODUCT_CONFIG_SCHEMA = XMLDATADIR / 'product-config-schema.rnc'
+PRODUCT_CONFIG_SCHEMA = XMLDATADIR / "product-config-schema.rnc"
 
 
 def display_results(
@@ -56,26 +56,26 @@ def display_results(
 
     for check_name, result in check_results:
         if result.success:
-            symbols.append('[green].[/green]')
+            symbols.append("[green].[/green]")
         else:
-            symbols.append('[red]F[/red]')
+            symbols.append("[red]F[/red]")
             overall_success = False
             failed_checks.append((check_name, result))
 
-    status = '[green]success[/green]' if overall_success else '[red]failed[/red]'
+    status = "[green]success[/green]" if overall_success else "[red]failed[/red]"
 
     if verbose == 1:
-        console_out.print(f'{shortname:<{max_len}}: {status}')
+        console_out.print(f"{shortname:<{max_len}}: {status}")
     else:
-        dots = ''.join(symbols)
-        console_out.print(f'{shortname:<{max_len}}: {dots} => {status}')
+        dots = "".join(symbols)
+        console_out.print(f"{shortname:<{max_len}}: {dots} => {status}")
 
         # Show detailed error messages if any failures
         if failed_checks and verbose > 2:
             for check_name, result in failed_checks:
-                console_err.print(f'    [bold red]✗ {check_name}:[/bold red]')
+                console_err.print(f"    [bold red]✗ {check_name}:[/bold red]")
                 for message in result.messages:
-                    console_err.print(f'      {message}')
+                    console_err.print(f"      {message}")
 
 
 async def validate_rng(
@@ -83,7 +83,7 @@ async def validate_rng(
     rng_schema_path: Path = PRODUCT_CONFIG_SCHEMA,
     *,
     xinclude: bool = True,
-    idcheck: bool = True
+    idcheck: bool = True,
 ) -> CompletedProcess:
     """Validate an XML file against a RELAX NG schema using jing.
 
@@ -98,36 +98,42 @@ async def validate_rng(
     :param idcheck: If True, perform ID uniqueness checks.
     :return: A tuple containing a boolean success status and any output message.
     """
-    jing_cmd = ['jing']
+    jing_cmd = ["jing"]
     if idcheck:
-        jing_cmd.append('-i')
-    if rng_schema_path.suffix == '.rnc':
-        jing_cmd.append('-c')
+        jing_cmd.append("-i")
+    if rng_schema_path.suffix == ".rnc":
+        jing_cmd.append("-c")
     jing_cmd.append(str(rng_schema_path))
 
     try:
         if xinclude:
             # Use a temporary file to store the output of xmllint.
             with tempfile.NamedTemporaryFile(
-                prefix='jing-validation',
-                suffix='.xml',
-                mode='w',
+                prefix="jing-validation",
+                suffix=".xml",
+                mode="w",
                 delete=True,
-                encoding='utf-8',
+                encoding="utf-8",
             ) as tmp_file:
                 tmp_filepath = Path(tmp_file.name)
 
                 # 1. Run xmllint to resolve XIncludes and save to temp file
                 xmllint_proc = await run_command(
-                    ['xmllint', '--xinclude', '--output', str(tmp_filepath), str(xmlfile)]
+                    [
+                        "xmllint",
+                        "--xinclude",
+                        "--output",
+                        str(tmp_filepath),
+                        str(xmlfile),
+                    ]
                 )
                 if xmllint_proc.returncode != 0:
                     # Construct a CompletedProcess representing failure from xmllint
                     return CompletedProcess(
-                        args=['xmllint', str(xmlfile)],
+                        args=["xmllint", str(xmlfile)],
                         returncode=xmllint_proc.returncode,
                         stdout=xmllint_proc.stdout,
-                        stderr=f'xmllint failed: {xmllint_proc.stderr}',
+                        stderr=f"xmllint failed: {xmllint_proc.stderr}",
                     )
 
                 # 2. Run jing on the resolved temporary file
@@ -139,12 +145,12 @@ async def validate_rng(
             return await run_command(jing_cmd)
 
     except FileNotFoundError as e:
-        tool = e.filename or 'xmllint/jing'
+        tool = e.filename or "xmllint/jing"
         return CompletedProcess(
             args=[tool],
             returncode=1,
-            stdout='',
-            stderr=f'{tool} command not found. Please install it to run validation.',
+            stdout="",
+            stderr=f"{tool} command not found. Please install it to run validation.",
         )
 
 
@@ -172,7 +178,7 @@ def validate_rng_lxml(
         # Perform validation
         is_valid = relaxng.validate(xml_doc)
         if is_valid:
-            return True, ''
+            return True, ""
         else:
             # Return validation error log as string
             return False, str(relaxng.error_log)
@@ -180,13 +186,13 @@ def validate_rng_lxml(
     # Catch specific exceptions for better error handling
     except etree.XMLSyntaxError as e:
         # This handles syntax errors in either the XML or the RNG file
-        return False, f'XML or RNG syntax error: {e}'
+        return False, f"XML or RNG syntax error: {e}"
     except etree.RelaxNGParseError as e:
         # This handles errors in parsing the RNG schema itself
-        return False, f'RELAX NG schema parsing error: {e}'
+        return False, f"RELAX NG schema parsing error: {e}"
     except Exception as e:
         # This catch-all is a fallback for any other unexpected issues
-        return False, f'An unexpected error occurred during validation: {e}'
+        return False, f"An unexpected error occurred during validation: {e}"
 
 
 async def run_python_checks(
@@ -204,7 +210,7 @@ async def run_python_checks(
             check_results.append((check.__name__, result))
 
         except Exception as e:
-            error_result = CheckResult(success=False, messages=[f'error: {e}'])
+            error_result = CheckResult(success=False, messages=[f"error: {e}"])
             check_results.append((check.__name__, error_result))
     return check_results
 
@@ -225,7 +231,7 @@ async def process_file(
     # Shorten the filename to last two parts for display
     path_obj = Path(filepath)
     shortname = (
-        '/'.join(path_obj.parts[-2:]) if len(path_obj.parts) >= 2 else str(filepath)
+        "/".join(path_obj.parts[-2:]) if len(path_obj.parts) >= 2 else str(filepath)
     )
 
     # IDEA: Should we replace jing and validate with etree.RelaxNG?
@@ -233,42 +239,44 @@ async def process_file(
     # 1. RNG Validation
     validation_method = context.validation_method
 
-    if validation_method == 'lxml':
+    if validation_method == "lxml":
         # Use lxml-based validator (requires .rng schema)
         rng_success, rng_output = await asyncio.to_thread(
             validate_rng_lxml,
             path_obj,
-            XMLDATADIR / 'product-config-schema.rng',
+            XMLDATADIR / "product-config-schema.rng",
         )
-    elif validation_method == 'jing':
+    elif validation_method == "jing":
         # Use existing jing-based validator (.rnc or .rng)
         jing_result = await validate_rng(path_obj, idcheck=True)
     else:
         console_err.print(
-            f'{shortname:<{max_len}}: RNG validation => [red]failed[/red]'
+            f"{shortname:<{max_len}}: RNG validation => [red]failed[/red]"
         )
-        console_err.print(f'  [bold red]Error:[/] Unknown validation method: {validation_method}')
+        console_err.print(
+            f"  [bold red]Error:[/] Unknown validation method: {validation_method}"
+        )
         return 11  # Custom error code for unknown validation method
 
     # Handle validation result for jing
-    if validation_method == 'jing':
+    if validation_method == "jing":
         if jing_result.returncode != 0:
             console_err.print(
-                f'{shortname:<{max_len}}: RNG validation => [red]failed[/red]'
+                f"{shortname:<{max_len}}: RNG validation => [red]failed[/red]"
             )
-            output = (jing_result.stdout or '') + (jing_result.stderr or '')
+            output = (jing_result.stdout or "") + (jing_result.stderr or "")
             if output:
-                console_err.print(f'  [bold red]Error:[/] {output.strip()}')
+                console_err.print(f"  [bold red]Error:[/] {output.strip()}")
             return 10  # Specific error code for RNG failure
 
     # Handle validation result for lxml
-    if validation_method == 'lxml':
+    if validation_method == "lxml":
         if not rng_success:
             console_err.print(
-                f'{shortname:<{max_len}}: RNG validation => [red]failed[/red]'
+                f"{shortname:<{max_len}}: RNG validation => [red]failed[/red]"
             )
             if rng_output:
-                console_err.print(f'  [bold red]Error:[/] {rng_output}')
+                console_err.print(f"  [bold red]Error:[/] {rng_output}")
             return 10
 
     # 2. Python-based checks
@@ -278,13 +286,13 @@ async def process_file(
     except etree.XMLSyntaxError as err:
         # This can happen if xmllint passes but lxml's parser is stricter.
         console_err.print(
-            f'{shortname:<{max_len}}: XML Syntax Error => [red]failed[/red]'
+            f"{shortname:<{max_len}}: XML Syntax Error => [red]failed[/red]"
         )
-        console_err.print(f'  [bold red]Error:[/] {err}')
+        console_err.print(f"  [bold red]Error:[/] {err}")
         return 20
 
     except Exception as err:
-        console_err.print(f'  [bold red]Error:[/] {err}')
+        console_err.print(f"  [bold red]Error:[/] {err}")
         return 200
 
     # Run all checks for this file
@@ -311,22 +319,22 @@ async def process(
     """
     # Prepare the context and validate environment configuration
     if context.envconfig is None:
-        raise ValueError('No envconfig found in context.')
+        raise ValueError("No envconfig found in context.")
 
-    paths = context.envconfig.get('paths', {})
+    paths = context.envconfig.get("paths", {})
     if not isinstance(paths, dict):
         raise ValueError("'paths.config' must be a dictionary.")
 
-    configdir = paths.get('config_dir', None)
-    log.debug(f'Async Processing validation with {configdir=}...')
-    log.debug(f'Registry has {len(registry.registry)} checks registered')
+    configdir = paths.get("config_dir", None)
+    log.debug(f"Async Processing validation with {configdir=}...")
+    log.debug(f"Registry has {len(registry.registry)} checks registered")
 
     # Convert iterator to tuple if needed to get total count
     if isinstance(xmlfiles, Iterator):
         xmlfiles = tuple(xmlfiles)
 
     if not xmlfiles:
-        log.warning('No XML files found to validate.')
+        log.warning("No XML files found to validate.")
         return 0
 
     total_files = len(xmlfiles)
@@ -338,7 +346,8 @@ async def process(
 
     # Filter for files that passed the initial validation
     successful_files_paths = [
-        xmlfile for xmlfile, result in zip(xmlfiles, results, strict=False)
+        xmlfile
+        for xmlfile, result in zip(xmlfiles, results, strict=False)
         if result == 0
     ]
 
@@ -347,21 +356,21 @@ async def process(
     stitch_success = True
     if successful_files_paths:
         try:
-            log.info('Performing stitch-file validation...')
-            cachedir = paths.get('base_server_cache_dir', None)
+            log.info("Performing stitch-file validation...")
+            cachedir = paths.get("base_server_cache_dir", None)
             tree = await create_stitchfile(successful_files_paths)
             if cachedir is not None:
                 stitchfile = (
-                    Path(cachedir) / f'stitchfile-{date.today().isoformat()}.xml'
+                    Path(cachedir) / f"stitchfile-{date.today().isoformat()}.xml"
                 )
-                stitchfile.write_text(etree.tostring(tree, encoding='unicode'))
+                stitchfile.write_text(etree.tostring(tree, encoding="unicode"))
                 log.debug("Wrote stitchfile to %s", str(stitchfile))
 
-            log.info('Stitch-file validation successful.')
+            log.info("Stitch-file validation successful.")
 
         except ValueError as e:
             # Using rich for better visibility of this critical error
-            console_err.print(f'[bold red]Stitch-file validation failed:[/] {e}')
+            console_err.print(f"[bold red]Stitch-file validation failed:[/] {e}")
             stitch_success = False
 
     # Calculate summary statistics
@@ -369,16 +378,16 @@ async def process(
     failed_files = total_files - successful_files
 
     # Display summary
-    successful_part = f'[green]{successful_files}/{total_files} files(s)[/green]'
-    failed_part = f'[red]{failed_files} file(s)[/red]'
+    successful_part = f"[green]{successful_files}/{total_files} files(s)[/green]"
+    failed_part = f"[red]{failed_files} file(s)[/red]"
     summary_msg = (
-        f'{successful_part} successfully validated, {failed_part} failed. '
-        f'Stitch validation [blue]{stitch_success}[/blue]'
+        f"{successful_part} successfully validated, {failed_part} failed. "
+        f"Stitch validation [blue]{stitch_success}[/blue]"
     )
 
     final_success = (failed_files == 0) and stitch_success
 
     if context.verbose > 0:  # pragma: no cover
-        console_out.print(f'Result: {summary_msg}')
+        console_out.print(f"Result: {summary_msg}")
 
     return 0 if final_success else 1

--- a/src/docbuild/cli/defaults.py
+++ b/src/docbuild/cli/defaults.py
@@ -9,18 +9,17 @@ They can be overridden by the user through configuration files or command-line o
 
 from ..constants import APP_NAME
 
-
 DEFAULT_APP_CONFIG = {
-    'debug': False,
-    'role': 'production',
-    'paths': {
-        'config_dir': '/etc/docbuild',
-        'repo_dir': '/data/docserv/repos/permanent-full/',
-        'temp_repo_dir': '/data/docserv/repos/temporary-branches/',
+    "debug": False,
+    "role": "production",
+    "paths": {
+        "config_dir": "/etc/docbuild",
+        "repo_dir": "/data/docserv/repos/permanent-full/",
+        "temp_repo_dir": "/data/docserv/repos/temporary-branches/",
     },
-    'paths.tmp': {
-        'tmp_base_dir': '/tmp',
-        'tmp_dir': '{tmp_base_dir}/doc-example-com',
+    "paths.tmp": {
+        "tmp_base_dir": "/tmp",
+        "tmp_dir": "{tmp_base_dir}/doc-example-com",
     },
 }
 """Default configuration for the application."""
@@ -28,53 +27,52 @@ DEFAULT_APP_CONFIG = {
 # --- FIXED DEFAULT_ENV_CONFIG ---
 DEFAULT_ENV_CONFIG = {
     # 1. ROOT SECTIONS MUST BE PRESENT AND VALIDATED AGAINST EnvConfig
-    'server': {
-        'name': 'default-local-env',
-        'role': 'production',
-        'host': '127.0.0.1',
-        'enable_mail': False,
+    "server": {
+        "name": "default-local-env",
+        "role": "production",
+        "host": "127.0.0.1",
+        "enable_mail": False,
     },
-    'config': {
-        'default_lang': 'en-us',
-        'languages': ['en-us'],
-        'canonical_url_domain': 'http://localhost/',
+    "config": {
+        "default_lang": "en-us",
+        "languages": ["en-us"],
+        "canonical_url_domain": "http://localhost/",
     },
-    'paths': {
-        'config_dir': '/etc/docbuild',
-        'root_config_dir': '/etc/docbuild',
-        'jinja_dir': '/etc/docbuild/jinja',
-        'server_rootfiles_dir': '/etc/docbuild/root-files',
-        'repo_dir': '/data/docserv/repos/permanent-full/',
-        'temp_repo_dir': '/data/docserv/repos/temporary-branches/',
-        'base_cache_dir': '/var/cache/docserv',
-        'base_server_cache_dir': '/var/cache/docserv/default',
-        'meta_cache_dir': '/var/cache/docserv/default/meta',
-        'base_tmp_dir': f'/var/tmp/{APP_NAME}',
-
-        'tmp': {
-            'tmp_base_dir': f'/var/tmp/{APP_NAME}',
-            'tmp_dir': '{tmp_base_dir}/default-local',
-            'tmp_deliverable_dir': '{tmp_dir}/deliverable',
-            'tmp_metadata_dir': '{tmp_dir}/metadata',
-            'tmp_build_dir': '{tmp_dir}/build/default', 
-            'tmp_out_dir': '{tmp_dir}/out',
-            'log_dir': '{tmp_dir}/log',
-            'tmp_deliverable_name': 'default_deliverable', 
+    "paths": {
+        "config_dir": "/etc/docbuild",
+        "root_config_dir": "/etc/docbuild",
+        "jinja_dir": "/etc/docbuild/jinja",
+        "server_rootfiles_dir": "/etc/docbuild/root-files",
+        "repo_dir": "/data/docserv/repos/permanent-full/",
+        "temp_repo_dir": "/data/docserv/repos/temporary-branches/",
+        "base_cache_dir": "/var/cache/docserv",
+        "base_server_cache_dir": "/var/cache/docserv/default",
+        "meta_cache_dir": "/var/cache/docserv/default/meta",
+        "base_tmp_dir": f"/var/tmp/{APP_NAME}",
+        "tmp": {
+            "tmp_base_dir": f"/var/tmp/{APP_NAME}",
+            "tmp_dir": "{tmp_base_dir}/default-local",
+            "tmp_deliverable_dir": "{tmp_dir}/deliverable",
+            "tmp_metadata_dir": "{tmp_dir}/metadata",
+            "tmp_build_dir": "{tmp_dir}/build/default",
+            "tmp_out_dir": "{tmp_dir}/out",
+            "log_dir": "{tmp_dir}/log",
+            "tmp_deliverable_name": "default_deliverable",
         },
-        'target': {
-            'target_dir': 'file:///tmp/docbuild/target',
-            'backup_dir': '/tmp/docbuild/backup',
-        }
-    },
-    'build': {
-        'daps': {
-            'command': 'daps',
-            'meta': 'daps metadata',
-        },
-        'container': {
-            'container': 'none',
+        "target": {
+            "target_dir": "file:///tmp/docbuild/target",
+            "backup_dir": "/tmp/docbuild/backup",
         },
     },
-    'xslt-params': {},
+    "build": {
+        "daps": {
+            "command": "daps",
+            "meta": "daps metadata",
+        },
+        "container": {
+            "container": "none",
+        },
+    },
+    "xslt-params": {},
 }
 """Default configuration for the environment."""

--- a/src/docbuild/config/load.py
+++ b/src/docbuild/config/load.py
@@ -6,9 +6,7 @@ from pathlib import Path
 import tomllib as toml
 from typing import Any
 
-from ..constants import DEFAULT_ENV_CONFIG_FILENAME
 from .merge import deep_merge
-
 
 # --- REMOVED THE OBSOLETE `process_envconfig` FUNCTION ---
 
@@ -22,7 +20,7 @@ def load_single_config(configfile: str | Path) -> dict[str, Any]:
     :raise tomllib.TOMLDecodeError: If the config file is not a valid TOML file
         or cannot be decoded.
     """
-    with Path(configfile).open('rb') as f:
+    with Path(configfile).open("rb") as f:
         return toml.load(f)
 
 
@@ -48,8 +46,8 @@ def load_and_merge_configs(
     # If no paths are provided, raise an error:
     if not paths:
         raise ValueError(
-            'No paths provided. '
-            'Please provide at least one path to load the config files.',
+            "No paths provided. "
+            "Please provide at least one path to load the config files.",
         )
 
     # Create a cartesian product of paths and default filenames:

--- a/src/docbuild/config/xml/checks.py
+++ b/src/docbuild/config/xml/checks.py
@@ -50,19 +50,19 @@ def check_dc_in_language(tree: etree._Element | etree._ElementTree) -> CheckResu
     :return: CheckResult with success status and any error messages.
     """
     messages = []
-    for language in tree.findall('.//language', namespaces=None):
-        dc_values = [d.findtext('dc') for d in language.findall('deliverable')]
+    for language in tree.findall(".//language", namespaces=None):
+        dc_values = [d.findtext("dc") for d in language.findall("deliverable")]
         if len(dc_values) != len(set(dc_values)):
             duplicates = [
                 item for item, count in Counter(dc_values).items() if count > 1
             ]
-            setid = language.getparent().getparent().get('setid', 'n/a')
-            langcode = language.get('lang', 'n/a')
+            setid = language.getparent().getparent().get("setid", "n/a")
+            langcode = language.get("lang", "n/a")
             message = (
-                f'Some dc elements within a language have non-unique values. '
-                f'Check for occurrences of the following duplicated dc '
-                f'elements in docset={setid} language={langcode}: '
-                f'{", ".join(duplicates)}'
+                f"Some dc elements within a language have non-unique values. "
+                f"Check for occurrences of the following duplicated dc "
+                f"elements in docset={setid} language={langcode}: "
+                f"{', '.join(duplicates)}"
             )
             messages.append(message)
             # log.critical(message)
@@ -85,13 +85,13 @@ def check_duplicated_categoryid(
     :return: CheckResult with success status and any error messages.
     """
     categoryids = [
-        cat.get('categoryid') for cat in tree.findall('.//category', namespaces=None)
+        cat.get("categoryid") for cat in tree.findall(".//category", namespaces=None)
     ]
     if len(categoryids) != len(set(categoryids)):
         duplicates = [item for item, count in Counter(categoryids).items() if count > 1]
         message = (
-            'Some category elements have non-unique categoryid values: '
-            f'{", ".join(duplicates)}'
+            "Some category elements have non-unique categoryid values: "
+            f"{', '.join(duplicates)}"
         )
         # log.critical(message)
         return CheckResult(success=False, messages=[message])
@@ -121,15 +121,15 @@ def check_duplicated_format_in_extralinks(
     :return: CheckResult with success status and any error messages.
     """
     messages = []
-    for language in tree.findall('./docset/external/link/language', namespaces=None):
-        formats = language.xpath('./url/@format')
-        docset = language.xpath('ancestor::docset/@setid')[0]
+    for language in tree.findall("./docset/external/link/language", namespaces=None):
+        formats = language.xpath("./url/@format")
+        docset = language.xpath("ancestor::docset/@setid")[0]
         duplicates = [item for item, count in Counter(formats).items() if count > 1]
 
         if duplicates:
             message = (
-                f'Duplicated format attributes found in external/link/language/url '
-                f'in docset={docset}: {", ".join(duplicates)}'
+                f"Duplicated format attributes found in external/link/language/url "
+                f"in docset={docset}: {', '.join(duplicates)}"
             )
             messages.append(message)
             # log.critical(message)
@@ -162,19 +162,19 @@ def check_duplicated_linkid(tree: etree._Element | etree._ElementTree) -> CheckR
     messages = []
 
     # Check each docset separately
-    for docset in tree.findall('.//docset', namespaces=None):
-        setid = docset.get('setid', 'unknown')
+    for docset in tree.findall(".//docset", namespaces=None):
+        setid = docset.get("setid", "unknown")
         linkids = [
-            link.get('linkid')
-            for link in docset.findall('./external/link', namespaces=None)
-            if link.get('linkid') is not None
+            link.get("linkid")
+            for link in docset.findall("./external/link", namespaces=None)
+            if link.get("linkid") is not None
         ]
 
         duplicates = [item for item, count in Counter(linkids).items() if count > 1]
         if duplicates:
             message = (
-                f'Some link elements have non-unique linkid values in '
-                f'docset={setid}: {", ".join(duplicates)}'
+                f"Some link elements have non-unique linkid values in "
+                f"docset={setid}: {', '.join(duplicates)}"
             )
             messages.append(message)
 
@@ -211,20 +211,20 @@ def check_duplicated_url_in_extralinks(
     messages = []
 
     # Group URLs by language
-    for language in tree.findall('.//external/link/language', namespaces=None):
-        lang_code = language.get('lang', 'unknown')
-        urls = [url.get('href') for url in language.findall('url', namespaces=None)]
+    for language in tree.findall(".//external/link/language", namespaces=None):
+        lang_code = language.get("lang", "unknown")
+        urls = [url.get("href") for url in language.findall("url", namespaces=None)]
 
         duplicates = [item for item, count in Counter(urls).items() if count > 1]
         if duplicates:
             docset = (
-                language.xpath('ancestor::docset/@setid')[0]
-                if language.xpath('ancestor::docset/@setid')
-                else 'unknown'
+                language.xpath("ancestor::docset/@setid")[0]
+                if language.xpath("ancestor::docset/@setid")
+                else "unknown"
             )
             message = (
-                'Some url elements have non-unique href values in '
-                f'language={lang_code} for docset={docset}: {", ".join(duplicates)}'
+                "Some url elements have non-unique href values in "
+                f"language={lang_code} for docset={docset}: {', '.join(duplicates)}"
             )
             messages.append(message)
 
@@ -247,15 +247,15 @@ def check_enabled_format(tree: etree._Element | etree._ElementTree) -> CheckResu
     :return: CheckResult with success status and any error messages.
     """
     messages = []
-    for fmt in tree.findall('.//deliverable/format', namespaces=None):
+    for fmt in tree.findall(".//deliverable/format", namespaces=None):
         format_issues = [convert2bool(value) for value in fmt.attrib.values()]
         if not any(format_issues):
-            docset = fmt.xpath('ancestor::docset/@setid')[0]
-            deli = fmt.find('../dc')
+            docset = fmt.xpath("ancestor::docset/@setid")[0]
+            deli = fmt.find("../dc")
             deli_text = deli.text  # if deli is not None else 'n/a'
             message = (
-                f'No enabled format found in docset={docset} '
-                f'for deliverable={deli_text}'
+                f"No enabled format found in docset={docset} "
+                f"for deliverable={deli_text}"
             )
             messages.append(message)
 
@@ -282,26 +282,26 @@ def check_format_subdeliverable(
         False otherwise.
     """
     messages = []
-    for deli in tree.findall('.//deliverable', namespaces=None):
-        subdeli = deli.find('subdeliverable')
+    for deli in tree.findall(".//deliverable", namespaces=None):
+        subdeli = deli.find("subdeliverable")
         if subdeli is not None:
-            formats = deli.find('format')
+            formats = deli.find("format")
             if formats is None:
                 # Create "fake" <format> element if it doesn't exist:
-                formats = etree.Element('format', attrib=None, nsmap=None)
+                formats = etree.Element("format", attrib=None, nsmap=None)
 
-            pdf = convert2bool(formats.attrib.get('pdf', False))
-            epub = convert2bool(formats.attrib.get('epub', False))
+            pdf = convert2bool(formats.attrib.get("pdf", False))
+            epub = convert2bool(formats.attrib.get("epub", False))
 
             if any([pdf, epub]):
-                setid = deli.xpath('ancestor::docset/@setid')[0]
-                dc = deli.findtext('dc', default='n/a')
-                language = deli.xpath('ancestor::language/@lang')[0]
+                setid = deli.xpath("ancestor::docset/@setid")[0]
+                dc = deli.findtext("dc", default="n/a")
+                language = deli.xpath("ancestor::language/@lang")[0]
                 message = (
-                    'A deliverable that has subdeliverables has PDF or EPUB '
-                    'enabled as a format: '
-                    f'docset={setid}/language={language}/deliverable={dc} '
-                    'but no enabled format is present'
+                    "A deliverable that has subdeliverables has PDF or EPUB "
+                    "enabled as a format: "
+                    f"docset={setid}/language={language}/deliverable={dc} "
+                    "but no enabled format is present"
                 )
                 messages.append(message)
 
@@ -325,16 +325,16 @@ def check_lang_code_in_category(
     :return: True if all lang attributes in categories are valid, False otherwise.
     """
     messages = []
-    for category in tree.findall('.//category', namespaces=None):
-        langs = [lng.attrib.get('lang') for lng in category.iterchildren('language')]
+    for category in tree.findall(".//category", namespaces=None):
+        langs = [lng.attrib.get("lang") for lng in category.iterchildren("language")]
         duplicates = [item for item, count in Counter(langs).items() if count > 1]
 
         if duplicates:
-            catid = category.get('categoryid', 'n/a')
+            catid = category.get("categoryid", "n/a")
             message = (
-                f'Some of the name translation of category {catid!r} '
-                'have non-unique lang attributes. '
-                f'Found duplicates: {", ".join(duplicates)}'
+                f"Some of the name translation of category {catid!r} "
+                "have non-unique lang attributes. "
+                f"Found duplicates: {', '.join(duplicates)}"
             )
             messages.append(message)
 
@@ -359,17 +359,17 @@ def check_lang_code_in_desc(
     :return: True if all lang attributes in desc are valid, False otherwise.
     """
     langs = [
-        desc.attrib.get('lang') for desc in tree.findall('./desc', namespaces=None)
+        desc.attrib.get("lang") for desc in tree.findall("./desc", namespaces=None)
     ]
     duplicates = [item for item, count in Counter(langs).items() if count > 1]
 
     if duplicates:
-        xpath_lang = ' or '.join([f'@lang="{lang}"' for lang in duplicates])
-        titles = tree.xpath(f'.//desc[{xpath_lang}]/@title')
+        xpath_lang = " or ".join([f'@lang="{lang}"' for lang in duplicates])
+        titles = tree.xpath(f".//desc[{xpath_lang}]/@title")
         message: str = (
-            'Some <desc> elements have non-unique lang attributes. '
-            f'Found duplicates: {", ".join(duplicates)} for titles: '
-            f'{", ".join(titles)}'
+            "Some <desc> elements have non-unique lang attributes. "
+            f"Found duplicates: {', '.join(duplicates)} for titles: "
+            f"{', '.join(titles)}"
         )
         return CheckResult(success=False, messages=[message])
 
@@ -397,19 +397,19 @@ def check_lang_code_in_docset(
     :return: True if all lang attributes in extralinks are valid, False otherwise.
     """
     messages = []
-    for docset in tree.findall('.//docset', namespaces=None):
+    for docset in tree.findall(".//docset", namespaces=None):
         langs = [
-            lng.attrib.get('lang')
-            for lng in docset.findall('./builddocs/language', namespaces=None)
+            lng.attrib.get("lang")
+            for lng in docset.findall("./builddocs/language", namespaces=None)
         ]
         duplicates = [item for item, count in Counter(langs).items() if count > 1]
 
         if duplicates:
-            setid = docset.get('setid', 'n/a')
+            setid = docset.get("setid", "n/a")
             message = (
-                'Some language elements within a set have non-unique lang attributes '
-                f'In docset={setid}, check for duplicate builddocs/language. '
-                f'Found duplicates: {", ".join(duplicates)}'
+                "Some language elements within a set have non-unique lang attributes "
+                f"In docset={setid}, check for duplicate builddocs/language. "
+                f"Found duplicates: {', '.join(duplicates)}"
             )
             messages.append(message)
 
@@ -435,16 +435,16 @@ def check_lang_code_in_extralinks(
     :return: True if all lang attributes in extralinks are valid, False otherwise.
     """
     messages = []
-    for link in tree.findall('.//external/link', namespaces=None):
-        langs = [lng.attrib.get('lang') for lng in link.findall('language')]
+    for link in tree.findall(".//external/link", namespaces=None):
+        langs = [lng.attrib.get("lang") for lng in link.findall("language")]
         duplicates = [item for item, count in Counter(langs).items() if count > 1]
 
         if duplicates:
-            docsetid = link.xpath('ancestor::docset/@setid')[0]
+            docsetid = link.xpath("ancestor::docset/@setid")[0]
             message = (
-                'Some language elements within a link have non-unique lang attributes. '
-                f'In docset={docsetid}, check for duplicate external/link/language. '
-                f'Found duplicates: {", ".join(duplicates)}'
+                "Some language elements within a link have non-unique lang attributes. "
+                f"In docset={docsetid}, check for duplicate external/link/language. "
+                f"Found duplicates: {', '.join(duplicates)}"
             )
             messages.append(message)
 
@@ -468,16 +468,16 @@ def check_lang_code_in_overridedesc(
     :return: True if all lang attributes in overridedesc are valid, False otherwise.
     """
     messages = []
-    for node in tree.findall('.//docset/overridedesc', namespaces=None):
+    for node in tree.findall(".//docset/overridedesc", namespaces=None):
         langs = [
-            lng.attrib.get('lang') for lng in node.findall('./desc', namespaces=None)
+            lng.attrib.get("lang") for lng in node.findall("./desc", namespaces=None)
         ]
         duplicates = [item for item, count in Counter(langs).items() if count > 1]
 
         if duplicates:
             message = (
-                'Some language elements within overridedesc have non-unique '
-                f'lang attributes. Found duplicates: {", ".join(duplicates)}'
+                "Some language elements within overridedesc have non-unique "
+                f"lang attributes. Found duplicates: {', '.join(duplicates)}"
             )
             messages.append(message)
 
@@ -503,21 +503,21 @@ def check_subdeliverable_in_deliverable(
     :return: True if site/section is present, False otherwise.
     """
     messages = []
-    for deliverables in tree.iter('deliverable'):
+    for deliverables in tree.iter("deliverable"):
         subdelis = [
             node.text
-            for node in deliverables.findall('subdeliverable', namespaces=None)
+            for node in deliverables.findall("subdeliverable", namespaces=None)
         ]
         duplicates = [item for item, count in Counter(subdelis).items() if count > 1]
 
         if duplicates:
-            setid = deliverables.xpath('ancestor::docset/@setid')[0]
-            language = deliverables.xpath('ancestor::language/@lang')[0]
+            setid = deliverables.xpath("ancestor::docset/@setid")[0]
+            language = deliverables.xpath("ancestor::language/@lang")[0]
             message = (
-                'Some subdeliverable elements within a deliverable have non-unique '
-                'values. '
-                f'In docset={setid}/language={language}, '
-                f'found duplicates: {", ".join(duplicates)}'
+                "Some subdeliverable elements within a deliverable have non-unique "
+                "values. "
+                f"In docset={setid}/language={language}, "
+                f"found duplicates: {', '.join(duplicates)}"
             )
             messages.append(message)
 
@@ -558,31 +558,31 @@ def check_translation_deliverables(
     """
     messages = []
     for deliverable in tree.xpath(
-        './docset/builddocs/language['
+        "./docset/builddocs/language["
         "  not(@default) or not(@default='true' or @default='1')"
-        ']/deliverable',
+        "]/deliverable",
         namespaces=None,
     ):
-        current_dc = deliverable.findtext('dc')
-        for subdeli in deliverable.iterchildren('subdeliverable'):
+        current_dc = deliverable.findtext("dc")
+        for subdeli in deliverable.iterchildren("subdeliverable"):
             current_subdeli = subdeli.text
             xpath = (
                 "ancestor::builddocs/language[@default='1' or @default='true']/"
-                f'descendant::deliverable[dc={current_dc!r}]/'
-                f'subdeliverable[. = {subdeli.text!r}]'
+                f"descendant::deliverable[dc={current_dc!r}]/"
+                f"subdeliverable[. = {subdeli.text!r}]"
             )
 
             # We expect that a subdeliverable in translation contains the same
             # subdeliverable in the default language deliverable.
             if not deliverable.xpath(xpath, namespaces=None):
-                setid = deliverable.xpath('ancestor::docset/@setid')[0]
-                lang = deliverable.xpath('ancestor::language/@lang')[0]
+                setid = deliverable.xpath("ancestor::docset/@setid")[0]
+                lang = deliverable.xpath("ancestor::language/@lang")[0]
                 message = (
-                    f'The subdeliverable {current_subdeli!r} is configured for '
-                    f'docset={setid}/language={lang}/deliverable={current_dc} '
-                    'but not for same deliverable of the default language. '
-                    'Documents configured for translation languages must be a '
-                    'subset of the documents configured for the default language.'
+                    f"The subdeliverable {current_subdeli!r} is configured for "
+                    f"docset={setid}/language={lang}/deliverable={current_dc} "
+                    "but not for same deliverable of the default language. "
+                    "Documents configured for translation languages must be a "
+                    "subset of the documents configured for the default language."
                 )
                 messages.append(message)
 
@@ -606,17 +606,17 @@ def check_valid_languages(
 
     def iter_lang_attrib() -> Generator[tuple[etree._Element, str], None, None]:
         for node in tree.iter(tag=None):  # "desc", "language"
-            lang = node.attrib.get('lang')
+            lang = node.attrib.get("lang")
             if lang:
                 yield node, lang
 
     messages = []
     for node, lang in iter_lang_attrib():
         if lang not in ALLOWED_LANGUAGES:
-            setid = node.xpath('ancestor-or-self::docset/@setid')[0]
+            setid = node.xpath("ancestor-or-self::docset/@setid")[0]
             message = (
-                f'In docset={setid}, invalid language code found: {lang}. '
-                f'Valid codes are: {", ".join(ALLOWED_LANGUAGES)}'
+                f"In docset={setid}, invalid language code found: {lang}. "
+                f"Valid codes are: {', '.join(ALLOWED_LANGUAGES)}"
             )
             messages.append(message)
 

--- a/src/docbuild/config/xml/list.py
+++ b/src/docbuild/config/xml/list.py
@@ -24,38 +24,38 @@ def list_all_deliverables(
     """
     # Select the product node regardless if its a child of "/" or under a
     # different root element.
-    productnode = tree.xpath('(/product | /*/product)[1]')[0]
+    productnode = tree.xpath("(/product | /*/product)[1]")[0]
     # TODO: error handling if no product node is found?
 
     if doctypes is not None:
-        log.debug('Filtering for docset %r', doctypes)
+        log.debug("Filtering for docset %r", doctypes)
         for dt in doctypes:
             # Gradually build the XPath expression
-            xpath = 'self::product'
-            if '*' not in dt.product:
-                xpath += f'[@productid={dt.product.value!r}]'
+            xpath = "self::product"
+            if "*" not in dt.product:
+                xpath += f"[@productid={dt.product.value!r}]"
 
-            xpath += '/docset'
-            if '*' not in dt.docset:
-                xpath += '[' + ' or '.join([f'@setid={d!r}' for d in dt.docset]) + ']'
+            xpath += "/docset"
+            if "*" not in dt.docset:
+                xpath += "[" + " or ".join([f"@setid={d!r}" for d in dt.docset]) + "]"
 
             if LifecycleFlag.unknown != dt.lifecycle:  # type: ignore
                 xpath += (
-                    '['
-                    + ' or '.join([f'@lifecycle={lc.name!r}' for lc in dt.lifecycle])
-                    + ']'
+                    "["
+                    + " or ".join([f"@lifecycle={lc.name!r}" for lc in dt.lifecycle])
+                    + "]"
                 )
 
-            xpath += '/builddocs/language'
+            xpath += "/builddocs/language"
 
-            if '*' not in dt.langs:
+            if "*" not in dt.langs:
                 xpath += (
-                    '['
-                    + ' or '.join([f'@lang={lng.language!r}' for lng in dt.langs])
-                    + ']'
+                    "["
+                    + " or ".join([f"@lang={lng.language!r}" for lng in dt.langs])
+                    + "]"
                 )
 
-            xpath += '/deliverable'
+            xpath += "/deliverable"
             # -----------------
             # xpath = (
             #     f"/*/product[@productid={p!r}]"
@@ -69,16 +69,16 @@ def list_all_deliverables(
             #     xpath += f"[@lang={lang!r}]"
             # xpath += "/deliverable"
             # xpathlog.debug("XPath: %r", xpath)
-            print('XPath:', xpath)
+            print("XPath:", xpath)
             nodes = productnode.xpath(xpath)
             if nodes:
                 yield from nodes
             else:
-                log.warning('No deliverables found for %r', dt)
+                log.warning("No deliverables found for %r", dt)
 
     else:
         # TODO: do we need all languages? How to handle non-en-us languages?
         xpath = "self::product/docset/builddocs/language[@lang='en-us']/deliverable"
-        xpathlog.debug('XPath: %r', xpath)
-        print('XPath:', xpath)
+        xpathlog.debug("XPath: %r", xpath)
+        print("XPath:", xpath)
         yield from productnode.xpath(xpath)

--- a/src/docbuild/config/xml/references.py
+++ b/src/docbuild/config/xml/references.py
@@ -8,13 +8,13 @@ def check_ref_to_subdeliverable(
     attrs: dict[str, str],
 ) -> str | None:
     """Check reference to a subdeliverable."""
-    product = attrs.get('product')
-    docset = attrs.get('docset')
-    dc = attrs.get('dc')
-    subdeliverable = attrs.get('subdeliverable')
+    product = attrs.get("product")
+    docset = attrs.get("docset")
+    dc = attrs.get("dc")
+    subdeliverable = attrs.get("subdeliverable")
     # Build the XPath
     xpath = (  # Use // to be more robust against nesting
-        f'//product[@productid = {product!r}]/docset[@setid = {docset!r}]'
+        f"//product[@productid = {product!r}]/docset[@setid = {docset!r}]"
         f"/builddocs/language[@default = 'true' or @default = 1]"
         f"/deliverable[dc = '{dc}'][subdeliverable = '{subdeliverable}']"
     )
@@ -24,26 +24,26 @@ def check_ref_to_subdeliverable(
             'concat(ancestor::product/@productid, "/",  ancestor::docset/@setid)'
         )
         return (
-            f'Failed reference from {origin!r} to '
-            f'{product}/{docset}:{dc}#{subdeliverable}: '
-            'Referenced subdeliverable does not exist.'
+            f"Failed reference from {origin!r} to "
+            f"{product}/{docset}:{dc}#{subdeliverable}: "
+            "Referenced subdeliverable does not exist."
         )
 
 
 def check_ref_to_deliverable(ref: etree._Element, attrs: dict[str, str]) -> str | None:
     """Check reference to a deliverable."""
-    product = attrs.get('product')
-    docset = attrs.get('docset')
-    dc = attrs.get('dc')
+    product = attrs.get("product")
+    docset = attrs.get("docset")
+    dc = attrs.get("dc")
 
     # Build the XPath
     base_xpath = (  # Use // to be more robust against nesting
-        f'//product[@productid = {product!r}]/docset[@setid = {docset!r}]'
+        f"//product[@productid = {product!r}]/docset[@setid = {docset!r}]"
         f"/builddocs/language[@default = 'true' or @default = 1]"
         f"/deliverable[dc = '{dc}']"
     )
-    xpath_has_sub = f'{base_xpath}[subdeliverable]'
-    xpath_hasnot_sub = f'{base_xpath}[not(subdeliverable)]'
+    xpath_has_sub = f"{base_xpath}[subdeliverable]"
+    xpath_hasnot_sub = f"{base_xpath}[not(subdeliverable)]"
     tree = ref.getroottree()
 
     origin = ref.xpath(
@@ -57,25 +57,25 @@ def check_ref_to_deliverable(ref: etree._Element, attrs: dict[str, str]) -> str 
     # If we are here, it's an invalid reference. We need to find out why.
     if tree.xpath(xpath_has_sub):
         return (
-            f'Failed reference from {origin!r} to {product}/{docset}:{dc}: '
-            'Referenced deliverable has subdeliverables, '
-            'you must choose a subdeliverable in your reference.'
+            f"Failed reference from {origin!r} to {product}/{docset}:{dc}: "
+            "Referenced deliverable has subdeliverables, "
+            "you must choose a subdeliverable in your reference."
         )
     else:
         return (
-            f'Failed reference from {origin!r} to {product}/{docset}:{dc}: '
-            'Referenced deliverable does not exist.'
+            f"Failed reference from {origin!r} to {product}/{docset}:{dc}: "
+            "Referenced deliverable does not exist."
         )
 
 
 def check_ref_to_link(ref: etree._Element, attrs: dict[str, str]) -> str | None:
     """Check ref to an external link."""
-    product = attrs.get('product')
-    docset = attrs.get('docset')
-    link = attrs.get('link')
+    product = attrs.get("product")
+    docset = attrs.get("docset")
+    link = attrs.get("link")
 
     xpath = (  # Use // to be more robust against nesting
-        f'//product[@productid = {product!r}]/docset[@setid = {docset!r}]'
+        f"//product[@productid = {product!r}]/docset[@setid = {docset!r}]"
         f"/builddocs/language[@default = 'true' or @default = 1]"
         f"/external/link[@linkid = '{link}']"
     )
@@ -86,17 +86,17 @@ def check_ref_to_link(ref: etree._Element, attrs: dict[str, str]) -> str | None:
             'concat(ancestor::product/@productid, "/",  ancestor::docset/@setid)'
         )
         return (
-            f'Failed reference from {origin!r} to {product}/{docset}@{link}: '
-            'Referenced external link does not exist.'
+            f"Failed reference from {origin!r} to {product}/{docset}@{link}: "
+            "Referenced external link does not exist."
         )
 
 
 def check_ref_to_docset(ref: etree._Element, attrs: dict[str, str]) -> str | None:
     """Check reference to a docset."""
-    product = attrs.get('product')
-    docset = attrs.get('docset')
+    product = attrs.get("product")
+    docset = attrs.get("docset")
     xpath = (  # Use // to be more robust against nesting
-        f'//product[@productid = {product!r}]/docset[@setid = {docset!r}]'
+        f"//product[@productid = {product!r}]/docset[@setid = {docset!r}]"
     )
 
     tree = ref.getroottree()
@@ -105,24 +105,24 @@ def check_ref_to_docset(ref: etree._Element, attrs: dict[str, str]) -> str | Non
             'concat(ancestor::product/@productid, "/",  ancestor::docset/@setid)'
         )
         return (
-            f'Failed reference from {origin!r} to {product}/{docset}: '
-            'Referenced docset does not exist.'
+            f"Failed reference from {origin!r} to {product}/{docset}: "
+            "Referenced docset does not exist."
         )
 
 
 def check_ref_to_product(ref: etree._Element, attrs: dict[str, str]) -> str | None:
     """Check reference to a product."""
-    product = attrs.get('product')
+    product = attrs.get("product")
 
-    xpath = f'//product[@productid = {product!r}]'  # Use // to be more robust
+    xpath = f"//product[@productid = {product!r}]"  # Use // to be more robust
     tree = ref.getroottree()
     if not tree.xpath(xpath):
         origin = ref.xpath(
             'concat(ancestor::product/@productid, "/",  ancestor::docset/@setid)'
         )
         return (
-            f'Failed reference from {origin!r} to {product}: '
-            'Referenced product does not exist.'
+            f"Failed reference from {origin!r} to {product}: "
+            "Referenced product does not exist."
         )
 
 
@@ -142,13 +142,13 @@ def check_stitched_references(tree: etree._ElementTree) -> list[str]:
     #       the processing of <ref> elements. Ensure thread safety when appending
     #       to the `errors` list, and handle exceptions raised during concurrent
     #       execution to avoid losing error messages.
-    for ref in tree.iter('ref'):
+    for ref in tree.iter("ref"):
         attrs = ref.attrib
-        product = attrs.get('product')
-        docset = attrs.get('docset')
-        dc = attrs.get('dc')
-        subdeliverable = attrs.get('subdeliverable')
-        link = attrs.get('link')
+        product = attrs.get("product")
+        docset = attrs.get("docset")
+        dc = attrs.get("dc")
+        subdeliverable = attrs.get("subdeliverable")
+        link = attrs.get("link")
 
         result = None
         # Case 1: Reference to a subdeliverable
@@ -177,9 +177,9 @@ def check_stitched_references(tree: etree._ElementTree) -> list[str]:
                 'concat(ancestor::product/@productid, "/",  ancestor::docset/@setid)'
             )
             result = (
-                f'Reference failed in {origin!r}. '
-                'This issue should have been caught by the RNC validation: '
-                'This is a docserv-stitch bug.'
+                f"Reference failed in {origin!r}. "
+                "This issue should have been caught by the RNC validation: "
+                "This is a docserv-stitch bug."
             )
 
         if result:

--- a/src/docbuild/config/xml/stitch.py
+++ b/src/docbuild/config/xml/stitch.py
@@ -13,7 +13,6 @@ import sys
 
 from lxml import etree
 
-from ...constants import XMLDATADIR
 from .references import check_stitched_references
 
 log = logging.getLogger(__name__)
@@ -21,12 +20,12 @@ log = logging.getLogger(__name__)
 
 def load_check_functions() -> list[Callable]:
     """Load all check functions from :mod:`docbuild.config.xml.checks`."""
-    xmlchecks = importlib.import_module('docbuild.config.xml.checks')
+    xmlchecks = importlib.import_module("docbuild.config.xml.checks")
 
     return [
         func
         for name, func in inspect.getmembers(xmlchecks, inspect.isfunction)
-        if name.startswith('check_')
+        if name.startswith("check_")
     ]
 
 
@@ -42,7 +41,7 @@ def log_memory_usage() -> int:
     memory_in_kb = usage.ru_maxrss
 
     # Adjustment for macOS to keep units consistent (convert to KB)
-    if sys.platform == 'darwin':
+    if sys.platform == "darwin":
         # Use integer division to match the function's return type hint
         memory_in_kb //= 1024
 
@@ -89,7 +88,7 @@ async def create_stitchfile(
         return tree
 
     # Step 1: Concurrently parse all XML files
-    docservconfig = etree.Element('docservconfig', attrib=None, nsmap=None)
+    docservconfig = etree.Element("docservconfig", attrib=None, nsmap=None)
     tasks = [parse_and_xinclude(Path(xmlfile)) for xmlfile in xmlfiles]
     parsed_trees = await asyncio.gather(*tasks)
 
@@ -100,20 +99,20 @@ async def create_stitchfile(
         del tree  # Explicitly delete the tree to free memory
 
     # Step 2: Check for unique IDs
-    product_ids = docservconfig.xpath('//@productid')
+    product_ids = docservconfig.xpath("//@productid")
     if len(product_ids) > len(set(product_ids)):
         duplicates = [item for item, count in Counter(product_ids).items() if count > 1]
-        raise ValueError(f'Duplicate product IDs found: {", ".join(duplicates)}')
+        raise ValueError(f"Duplicate product IDs found: {', '.join(duplicates)}")
 
     # Step 3: Check references
     if with_ref_check:
         result = check_stitchfile(docservconfig)
         if not result:
             raise ValueError(
-                'Unresolved references found in stitch file. '
-                'Run the validate subcommand'
+                "Unresolved references found in stitch file. "
+                "Run the validate subcommand"
             )
 
-    log.debug('Memory usage: %.1f MB', log_memory_usage() / 1024)
+    log.debug("Memory usage: %.1f MB", log_memory_usage() / 1024)
 
     return etree.ElementTree(docservconfig)

--- a/src/docbuild/constants.py
+++ b/src/docbuild/constants.py
@@ -6,18 +6,18 @@ import re
 from .models.lifecycle import LifecycleFlag
 from .models.serverroles import ServerRole
 
-APP_NAME = 'docbuild'
+APP_NAME = "docbuild"
 """The name of the application, used in paths and config files."""
 
-DEFAULT_LANGS = ('en-us',)
+DEFAULT_LANGS = ("en-us",)
 """The default languages used by the application."""
 
 ALLOWED_LANGUAGES = frozenset(
-    'de-de en-us es-es fr-fr ja-jp ko-kr pt-br zh-cn'.split(' '),
+    "de-de en-us es-es fr-fr ja-jp ko-kr pt-br zh-cn".split(" "),
 )
 """The languages supported by the documentation portal."""
 
-DEFAULT_DELIVERABLES = '*/@supported/en-us'
+DEFAULT_DELIVERABLES = "*/@supported/en-us"
 """The default deliverables when no specific doctype is provided."""
 
 # SERVER_ROLES = (
@@ -30,13 +30,10 @@ SERVER_ROLES = tuple(
 )
 """The different server roles, including long and short spelling."""
 
-DEFAULT_LIFECYCLE = 'supported'
+DEFAULT_LIFECYCLE = "supported"
 """The default lifecycle state for a docset."""
 
-ALLOWED_LIFECYCLES: tuple[str] = tuple(
-    lc.name
-    for lc in LifecycleFlag
-)
+ALLOWED_LIFECYCLES: tuple[str] = tuple(lc.name for lc in LifecycleFlag)
 # ('supported', 'beta', 'hidden', 'unsupported')
 """The available lifecycle states for a docset (without 'unknown')."""
 
@@ -51,7 +48,7 @@ ALLOWED_LIFECYCLES: tuple[str] = tuple(
 VALID_PRODUCTS: dict[str, str] = {
     key.strip(): value.strip()
     for key, value in (
-        line.split(' ', 1)
+        line.split(" ", 1)
         # Syntax: acronym <SPACE> full name:
         for line in """appliance Appliance building
 cloudnative Cloud Native
@@ -89,16 +86,16 @@ trd Technical Reference Documentation""".strip().splitlines()
 ALLOWED_PRODUCTS = tuple([item for item in VALID_PRODUCTS])
 """A tuple of valid product acronyms."""
 
-SINGLE_LANG_REGEX = re.compile(r'[a-z]{2}-[a-z]{2}')
+SINGLE_LANG_REGEX = re.compile(r"[a-z]{2}-[a-z]{2}")
 """Regex for a single language code in the format 'xx-XX' (e.g., 'en-us')."""
 
 MULTIPLE_LANG_REGEX = re.compile(
-    rf'^({SINGLE_LANG_REGEX.pattern},)*'
-    rf'{SINGLE_LANG_REGEX.pattern}',
+    rf"^({SINGLE_LANG_REGEX.pattern},)*"
+    rf"{SINGLE_LANG_REGEX.pattern}",
 )
 """Regex for multiple languages, separated by commas."""
 
-LIFECYCLES_STR = '|'.join(ALLOWED_LIFECYCLES)
+LIFECYCLES_STR = "|".join(ALLOWED_LIFECYCLES)
 """Regex for lifecycle states, separated by pipe (|)."""
 
 
@@ -106,11 +103,11 @@ LIFECYCLES_STR = '|'.join(ALLOWED_LIFECYCLES)
 PROJECT_DIR = Path.cwd()
 """The current working directory, used as the project directory."""
 
-USER_CONFIG_DIR = Path.home() / '.config' / APP_NAME
+USER_CONFIG_DIR = Path.home() / ".config" / APP_NAME
 """The user-specific configuration directory, typically located
 at ~/.config/docbuild."""
 
-SYSTEM_CONFIG_DIR = Path('/etc') / APP_NAME
+SYSTEM_CONFIG_DIR = Path("/etc") / APP_NAME
 """The system-wide configuration directory, typically located
 at /etc/docbuild."""
 
@@ -124,45 +121,45 @@ CONFIG_PATHS = (
 )
 """The paths where the application will look for configuration files."""
 
-APP_CONFIG_BASENAMES = ('.config.toml', 'config.toml')
+APP_CONFIG_BASENAMES = (".config.toml", "config.toml")
 """The base filenames for the application configuration files, in
 order of priority."""
 
 PROJECT_LEVEL_APP_CONFIG_FILENAMES = (
-    f'.{APP_NAME}.config.toml',
-    f'{APP_NAME}.config.toml',
+    f".{APP_NAME}.config.toml",
+    f"{APP_NAME}.config.toml",
     # 'app.config.toml',
 )
 """Additional configuration filenames at the project level."""
 
-APP_CONFIG_FILENAME = 'config.toml'
+APP_CONFIG_FILENAME = "config.toml"
 """The filename of the application's config file without any paths."""
 
-ENV_CONFIG_FILENAME = 'env.{role}.toml'
+ENV_CONFIG_FILENAME = "env.{role}.toml"
 """The filename of the environment's config file without any paths."""
 
-DEFAULT_ENV_CONFIG_FILENAME = ENV_CONFIG_FILENAME.format(role='production')
+DEFAULT_ENV_CONFIG_FILENAME = ENV_CONFIG_FILENAME.format(role="production")
 """The default filename for the environment's config file, typically
 used in production."""
 
-GIT_CONFIG_FILENAME = Path(__file__).parent / 'etc/git/gitconfig'
+GIT_CONFIG_FILENAME = Path(__file__).parent / "etc/git/gitconfig"
 """The project-specific Git configuration file (relative to this project)"""
 
 # --- State and Logging Constants (Refactored) ---
 
-BASE_STATE_DIR = Path.home() / '.local' / 'state' / APP_NAME
+BASE_STATE_DIR = Path.home() / ".local" / "state" / APP_NAME
 """The directory where application state, logs, and locks are stored,
 per XDG Base Directory Specification."""
 
 GITLOGGER_NAME = "docbuild.git"
 """The standardized name for the Git-related logger."""
 
-BASE_LOG_DIR = BASE_STATE_DIR / 'logs'
+BASE_LOG_DIR = BASE_STATE_DIR / "logs"
 """The directory where log files will be stored."""
 
 # --- Locking constants ---
-BASE_LOCK_DIR = BASE_STATE_DIR / 'locks'
+BASE_LOCK_DIR = BASE_STATE_DIR / "locks"
 """The directory where PID lock files will be stored."""
 
-XMLDATADIR = Path(__file__).parent / 'config' / 'xml' / 'data'
+XMLDATADIR = Path(__file__).parent / "config" / "xml" / "data"
 """Directory where additional files (RNC, XSLT) for XML processing are stored."""

--- a/src/docbuild/logging.py
+++ b/src/docbuild/logging.py
@@ -21,7 +21,7 @@ logging.raiseExceptions = False  # Suppress internal logging exception traceback
 _original_emit = logging.StreamHandler.emit
 
 
-def _safe_emit(self: Self, record: logging.LogRecord) -> None: # pyright: ignore[reportGeneralTypeIssues]
+def _safe_emit(self: Self, record: logging.LogRecord) -> None:  # pyright: ignore[reportGeneralTypeIssues]
     # Happens if a background thread logs after sys.stdout/stderr closed.
     with suppress(ValueError):
         _original_emit(self, record)
@@ -90,7 +90,9 @@ def _shutdown_logging() -> None:
     """Ensure all logging threads and handlers shut down cleanly."""
     listener = _LOGGING_STATE["listener"].get()
     handlers: list[logging.Handler] = _LOGGING_STATE["handlers"].get()
-    bg_threads: list[threading.Thread] | None = _LOGGING_STATE["background_threads"].get()
+    bg_threads: list[threading.Thread] | None = _LOGGING_STATE[
+        "background_threads"
+    ].get()
 
     # Defensive: some tests or earlier code may have mutated the stored
     # value accidentally (e.g. to the `list` type). Coerce to an iterable
@@ -171,8 +173,7 @@ def build_handlers_from_config(config: dict[str, Any]) -> list[logging.Handler]:
             formatter_kwargs["datefmt"] = fmt_conf.get("datefmt")
             formatter_kwargs["style"] = fmt_conf.get("style")
             formatter_kwargs = {
-                k: v for k, v in formatter_kwargs.items()
-                if v is not None
+                k: v for k, v in formatter_kwargs.items() if v is not None
             }
             fmt_cls = _resolve_class(fmt_conf.get("class", "logging.Formatter"))
             handler.setFormatter(fmt_cls(**formatter_kwargs))
@@ -187,6 +188,7 @@ def setup_logging(cliverbosity: int, user_config: dict[str, Any] | None = None) 
     config = copy.deepcopy(DEFAULT_LOGGING_CONFIG)
 
     if user_config and "logging" in user_config:
+
         def deep_merge(target: dict, source: dict) -> None:
             for k, v in source.items():
                 if k in target and isinstance(target[k], dict) and isinstance(v, dict):

--- a/src/docbuild/models/config/__init__.py
+++ b/src/docbuild/models/config/__init__.py
@@ -1,5 +1,6 @@
 """Config model package for the docbuild application."""
 
-
-from .env import EnvConfig 
 from .app import AppConfig
+from .env import EnvConfig
+
+__all__ = ["AppConfig", "EnvConfig"]

--- a/src/docbuild/models/config/app.py
+++ b/src/docbuild/models/config/app.py
@@ -1,62 +1,83 @@
 """Pydantic model for application configuration."""
 
+from collections.abc import Sequence  # Added Sequence for internal use
 from copy import deepcopy
-from typing import Any, Self, Literal, Sequence # Added Sequence for internal use
-import logging 
+from typing import Any, Literal, Self
 
-from pydantic import BaseModel, Field, model_validator, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from docbuild.config.app import replace_placeholders
-from docbuild.config.app import CircularReferenceError, PlaceholderResolutionError
-from docbuild.logging import DEFAULT_LOGGING_CONFIG 
-
+from docbuild.config.app import (
+    CircularReferenceError,
+    PlaceholderResolutionError,
+    replace_placeholders,
+)
+from docbuild.logging import DEFAULT_LOGGING_CONFIG
 
 # --- 1. Logging Sub-Models (Schema for logging.config.dictConfig) ---
 
+
 class FormatterConfig(BaseModel):
-    # ... (FormatterConfig remains unchanged) ...
-    model_config = ConfigDict(extra='allow', populate_by_name=True)
+    """A Pydantic model for logging formatter configuration."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
 
     format: str | None = None
     datefmt: str | None = None
-    style: Literal['%', '{', '$'] | None = None
-    class_name: str | None = Field(None, alias='class',
-                                   description='The fully qualified name of the handler class',
-                                   ) 
+    style: Literal["%", "{", "$"] | None = None
+    class_name: str | None = Field(
+        None,
+        alias="class",
+        description="The fully qualified name of the handler class",
+    )
     # Renamed to avoid shadowing the BaseModel.validate() method.
     validation: bool | None = Field(
-        None, 
-        alias='validate', # IMPORTANT: Keep the original key name for external config files
-        description='If specified, controls whether configuration is validated.'
+        None,
+        alias="validate",
+        description="If specified, controls whether configuration is validated.",
     )
 
 
 class HandlerConfig(BaseModel):
-    model_config = ConfigDict(extra='allow', populate_by_name=True)
+    """A Pydantic model for logging handler configuration."""
 
-    class_name: str | None = Field(None, alias='class',
-                                   description='The fully qualified name of the handler class',
-                                   )
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    class_name: str | None = Field(
+        None,
+        alias="class",
+        description="The fully qualified name of the handler class",
+    )
     level: str | int | None = None
     formatter: str | None = Field(None, description="Must match a key in 'formatters'.")
     filters: list[str] | None = None
 
 
 class LoggerConfig(BaseModel):
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    """A Pydantic model for logging logger configuration."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     level: str | int | None = None
-    handlers: list[str] | None = Field(None, description="Must match keys in 'handlers'.")
+    handlers: list[str] | None = Field(
+        None, description="Must match keys in 'handlers'."
+    )
     propagate: bool | None = True
     filters: list[str] | None = None
 
 
 class RootLoggerConfig(BaseModel):
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    
-    level: str | int | None = Field('WARNING', description="The minimum severity level to log.")
-    handlers: list[str] | None = Field(default_factory=list, description="Must match keys in 'handlers'.")
+    """A Pydantic model for the root logger configuration."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    level: str | int | None = Field(
+        "WARNING", description="The minimum severity level to log."
+    )
+    handlers: list[str] | None = Field(
+        default_factory=list, description="Must match keys in 'handlers'."
+    )
     filters: list[str] | None = None
+
 
 # --- 2. Type Aliases for Dictionaries ---
 
@@ -65,37 +86,55 @@ type HandlersDict = dict[str, HandlerConfig]
 type LoggersDict = dict[str, LoggerConfig]
 type FiltersDict = dict[str, Any]
 
-# --- 3. The Top-Level Logging Configuration Model (App_LoggingConfig) ---
 
-class App_LoggingConfig(BaseModel):
+# --- 3. The Top-Level Logging Configuration Model (AppLoggingConfig) ---
+class AppLoggingConfig(BaseModel):
+    """Pydantic model for the logging configuration.
+
+    Used by :func:`logging.config.dictConfig`
     """
-    The complete Pydantic model for Python's logging.dictConfig.
-    """
+
     version: Literal[1] = Field(description="The schema version. Must be 1.")
     disable_existing_loggers: bool = False
 
-    formatters: FormattersDict = Field(default_factory=dict, description="All configured formatters.")
-    filters: FiltersDict = Field(default_factory=dict, description="All configured filters.")
-    handlers: HandlersDict = Field(default_factory=dict, description="All configured handlers.")
-    loggers: LoggersDict = Field(default_factory=dict, description="All specific loggers (e.g., 'my_app').")
+    formatters: FormattersDict = Field(
+        default_factory=dict, description="All configured formatters."
+    )
+    filters: FiltersDict = Field(
+        default_factory=dict, description="All configured filters."
+    )
+    handlers: HandlersDict = Field(
+        default_factory=dict, description="All configured handlers."
+    )
+    loggers: LoggersDict = Field(
+        default_factory=dict, description="All specific loggers (e.g., 'my_app')."
+    )
     # Use an instance as we have only one root logger
-    root: RootLoggerConfig = Field(default_factory=RootLoggerConfig, description="The root logger configuration.")
-    
-    incremental: bool = Field(False, description="Allows incremental configuration updates.")
-    
+    root: RootLoggerConfig = Field(
+        default_factory=RootLoggerConfig, description="The root logger configuration."
+    )
+
+    incremental: bool = Field(
+        False, description="Allows incremental configuration updates."
+    )
+
     # --- CROSS-REFERENCE VALIDATION ---
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def _validate_cross_references(self) -> Self:
-        """
-        Validates that all loggers and handlers refer to defined components.
+        """Validate that all loggers and handlers refer to defined components.
+
         This prevents runtime errors when logging.config.dictConfig is called.
         """
         defined_formatters = set(self.formatters.keys())
         defined_handlers = set(self.handlers.keys())
-        defined_loggers = set(self.loggers.keys()) # Not strictly needed but good practice
-        
+
         # Helper function to check if a list of names exists in a defined set
-        def check_names(names: Sequence[str], defined_set: set[str], item_type: str, source_name: str):
+        def check_names(
+            names: Sequence[str],
+            defined_set: set[str],
+            item_type: str,
+            source_name: str,
+        ) -> None:
             if not names:
                 return
             missing = [name for name in names if name not in defined_set]
@@ -110,40 +149,50 @@ class App_LoggingConfig(BaseModel):
             formatter_name = handler_config.formatter
             if formatter_name and formatter_name not in defined_formatters:
                 raise ValueError(
-                    f"Configuration error in handler '{h_name}': Formatter '{formatter_name}' "
+                    f"Configuration error in handler '{h_name}': Formatter '"
+                    f"{formatter_name}' "
                     "is referenced but not defined in the 'formatters' section."
                 )
-            
+
             # We skip checking filters here as they can be external/dynamic
 
         # 2. Check Loggers and Root Logger for valid Handlers
-        
+
         # Check specific loggers
         for l_name, logger_config in self.loggers.items():
-            check_names(logger_config.handlers or [], defined_handlers, 'handler', f"logger '{l_name}'")
-        
+            check_names(
+                logger_config.handlers or [],
+                defined_handlers,
+                "handler",
+                f"logger '{l_name}'",
+            )
+
         # Check root logger
-        check_names(self.root.handlers or [], defined_handlers, 'handler', 'root logger')
+        check_names(
+            self.root.handlers or [], defined_handlers, "handler", "root logger"
+        )
 
         return self
 
+
 # --- 4. Root Application Model ---
+
 
 class AppConfig(BaseModel):
     """Root model for application configuration (config.toml)."""
-    
-    logging: App_LoggingConfig = Field(
-        default_factory=lambda: App_LoggingConfig.model_validate(
+
+    logging: AppLoggingConfig = Field(
+        default_factory=lambda: AppLoggingConfig.model_validate(
             DEFAULT_LOGGING_CONFIG
         ),
-        description="Configuration for the application's logging system."
+        description="Configuration for the application's logging system.",
     )
-    
-    model_config = ConfigDict(extra='allow') 
 
-    @model_validator(mode='before')
+    model_config = ConfigDict(extra="allow")
+
+    @model_validator(mode="before")
     @classmethod
-    def _resolve_placeholders(cls, data: Any) -> Any:
+    def _resolve_placeholders(cls, data: dict[str, Any]) -> dict[str, Any] | None:
         if isinstance(data, dict):
             try:
                 return replace_placeholders(deepcopy(data))
@@ -153,5 +202,5 @@ class AppConfig(BaseModel):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Self:
-        """Convenience method to validate and return an instance."""
+        """Create an AppConfig instance from a dictionary."""
         return cls.model_validate(data)

--- a/src/docbuild/models/config/env.py
+++ b/src/docbuild/models/config/env.py
@@ -1,17 +1,27 @@
 """Pydantic models for application and environment configuration."""
 
 from copy import deepcopy
-from typing import Any, Self, Annotated, Literal 
 from pathlib import Path
+from typing import Annotated, Any, Self
 
-from pydantic import BaseModel, Field, HttpUrl, IPvAnyAddress, model_validator, ConfigDict, field_serializer 
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    HttpUrl,
+    IPvAnyAddress,
+    field_serializer,
+    model_validator,
+)
 
-from ...config.app import replace_placeholders
-from ...config.app import CircularReferenceError, PlaceholderResolutionError
-from ..language import LanguageCode 
-from ..serverroles import ServerRole 
+from ...config.app import (
+    CircularReferenceError,
+    PlaceholderResolutionError,
+    replace_placeholders,
+)
+from ..language import LanguageCode
 from ..path import EnsureWritableDirectory
-
+from ..serverroles import ServerRole
 
 # --- Custom Types and Utilities ---
 
@@ -29,39 +39,41 @@ DomainName = Annotated[
 
 # --- Build Sub-Models (To allow extra sections in env.toml) ---
 
-class Env_BuildDaps(BaseModel):
+
+class EnvBuildDaps(BaseModel):
     """Configuration for daps command execution."""
 
     # Allows extra keys from the TOML file that aren't yet defined in the model schema.
-    model_config = ConfigDict(extra='allow') 
-    
+    model_config = ConfigDict(extra="allow")
+
     command: str = Field(..., description="The base daps command.")
     meta: str = Field(..., description="The daps metadata command.")
 
 
-class Env_BuildContainer(BaseModel):
+class EnvBuildContainer(BaseModel):
     """Configuration for container usage."""
 
-    model_config = ConfigDict(extra='allow')
-    
+    model_config = ConfigDict(extra="allow")
+
     container: str = Field(..., description="The container registry path/name.")
 
 
-class Env_Build(BaseModel):
+class EnvBuild(BaseModel):
     """General build configuration."""
 
-    model_config = ConfigDict(extra='forbid') 
-    
-    daps: Env_BuildDaps
-    container: Env_BuildContainer
+    model_config = ConfigDict(extra="forbid")
+
+    daps: EnvBuildDaps
+    container: EnvBuildContainer
 
 
 # --- Configuration Models ---
 
-class Env_Server(BaseModel):
+
+class EnvServer(BaseModel):
     """Defines server settings."""
 
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")
 
     name: str = Field(
         title="Server Name",
@@ -70,7 +82,7 @@ class Env_Server(BaseModel):
     )
     "The descriptive name of the server."
 
-    role: ServerRole = Field( 
+    role: ServerRole = Field(
         title="Server Role",
         description="The operational role of the environment.",
         examples=["production"],
@@ -86,55 +98,63 @@ class Env_Server(BaseModel):
 
     enable_mail: bool = Field(
         title="Enable Email",
-        description="Flag to enable email sending features (e.g., build notifications).",
+        description=(
+            "Flag to enable email sending features (e.g., build notifications)."
+        ),
         examples=[True],
     )
     "Whether email functionality should be active."
 
 
-class Env_GeneralConfig(BaseModel):
+class EnvGeneralConfig(BaseModel):
     """Defines general configuration."""
 
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")
 
-    default_lang: LanguageCode = Field( 
+    default_lang: LanguageCode = Field(
         title="Default Language",
-        description="The primary language code (e.g., 'en') used for non-localized content.",
+        description=(
+            "The primary language code (e.g., 'en') used for non-localized content."
+        ),
         examples=["en-us", "de-de", "ja-jp"],
     )
     "The default language code."
 
-    languages: list[LanguageCode] = Field( 
+    languages: list[LanguageCode] = Field(
         title="Supported Languages",
-        description="A list of all language codes supported by this documentation instance.",
+        description=(
+            "A list of all language codes supported by this documentation instance."
+        ),
         examples=[["en-us", "de-de", "fr-fr"]],
     )
     "A list of supported language codes."
 
     canonical_url_domain: HttpUrl = Field(
         title="Canonical URL Domain",
-        description="The base domain used to construct canonical URLs for SEO purposes.",
+        description=(
+            "The base domain used to construct canonical URLs for SEO purposes."
+        ),
         examples=["https://docs.example.com"],
     )
     "The canonical domain for URLs."
 
     # --- NEW: Custom Serialization for LanguageCode Models ---
-    @field_serializer('default_lang')
+    @field_serializer("default_lang")
     def serialize_default_lang(self, lang_obj: LanguageCode) -> str:
-        """Serializes the LanguageCode model back to a simple string (e.g., 'en-us')."""
+        """Serialize the LanguageCode model back to a simple string (e.g., 'en-us')."""
         # Assumes LanguageCode has a 'language' attribute containing the full code.
         return lang_obj.language
 
-    @field_serializer('languages')
+    @field_serializer("languages")
     def serialize_languages(self, lang_list: list[LanguageCode]) -> list[str]:
-        """Serializes the list of LanguageCode models back to a list of strings."""
+        """Serialize the list of LanguageCode models back to a list of strings."""
         return [lang_obj.language for lang_obj in lang_list]
 
 
-class Env_TmpPaths(BaseModel):
+class EnvTmpPaths(BaseModel):
     """Defines temporary paths."""
 
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")
 
     tmp_base_dir: EnsureWritableDirectory = Field(
         title="Temporary Base Directory",
@@ -145,20 +165,25 @@ class Env_TmpPaths(BaseModel):
 
     tmp_path: EnsureWritableDirectory = Field(
         title="General Temporary Path for specific server",
-        description="A general-purpose subdirectory within the base temporary path to distinguish between different servers.",
+        description=(
+            "A general-purpose subdirectory within the base temporary path to "
+            "distinguish between different servers."
+        ),
         examples=["/var/tmp/docbuild/doc-example-com"],
-        alias='tmp_dir', 
+        alias="tmp_dir",
     )
     "General temporary path."
-    
+
     tmp_deliverable_path: EnsureWritableDirectory = Field(
         title="Temporary Deliverable Path",
-        description="The directory where deliverable repositories are cloned and processed.",
+        description=(
+            "The directory where deliverable repositories are cloned and processed."
+        ),
         examples=["/var/tmp/docbuild/doc-example-com/deliverable/"],
-        alias='tmp_deliverable_dir', 
+        alias="tmp_deliverable_dir",
     )
     "Path for temporary deliverable clones."
-    
+
     tmp_metadata_dir: EnsureWritableDirectory = Field(
         title="Temporary Metadata Directory",
         description="Temporary directory for metadata files.",
@@ -166,19 +191,25 @@ class Env_TmpPaths(BaseModel):
     )
     "Temporary metadata directory."
 
-
     tmp_build_dir: str = Field(
         title="Temporary Build Directory",
-        description="Temporary directory for intermediate files (contains placeholders).",
-        examples=["/var/tmp/docbuild/doc-example-com/build/{{product}}-{{docset}}-{{lang}}"],
+        description=(
+            "Temporary directory for intermediate files (contains placeholders)."
+        ),
+        examples=[
+            "/var/tmp/docbuild/doc-example-com/build/{{product}}-{{docset}}-{{lang}}"
+        ],
     )
     "Temporary build output directory."
 
     tmp_out_path: EnsureWritableDirectory = Field(
         title="Temporary Output Path",
-        description="The final temporary directory where built artifacts land before deployment.",
+        description=(
+            "The final temporary directory where built artifacts land before "
+            "deployment."
+        ),
         examples=["/var/tmp/docbuild/doc-example-com/out/"],
-        alias='tmp_out_dir', 
+        alias="tmp_out_dir",
     )
     "Temporary final output path."
 
@@ -186,54 +217,65 @@ class Env_TmpPaths(BaseModel):
         title="Log Path",
         description="The directory where build logs and application logs are stored.",
         examples=["/var/tmp/docbuild/doc-example-com/log"],
-        alias='log_dir', 
+        alias="log_dir",
     )
     "Path for log files."
 
     tmp_deliverable_name: str = Field(
         title="Temporary Deliverable Name",
-        description="The name used for the current deliverable being built (e.g., branch name or version).",
+        description=(
+            "The name used for the current deliverable being built "
+            "(e.g., branch name or version)."
+        ),
         examples=["{{product}}_{{docset}}_{{lang}}_XXXXXX"],
     )
     "Temporary deliverable name."
 
 
-class Env_TargetPaths(BaseModel):
+class EnvTargetPaths(BaseModel):
     """Defines target paths."""
 
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")
 
     target_path: str = Field(
         title="Target Server Deployment Path",
         description="The final remote destination for the built documentation",
         examples=["doc@10.100.100.100:/srv/docs"],
-        alias='target_dir', 
+        alias="target_dir",
     )
     "The destination path for final built documentation."
 
     backup_path: Path = Field(
         title="Build Server Path",
-        description="The location on the build server before it is synced to the target path.",
-        alias='backup_dir', 
+        description=(
+            "The location on the build server before it is synced to the target path."
+        ),
+        alias="backup_dir",
     )
     "Path for backups."
 
 
-class Env_PathsConfig(BaseModel):
+class EnvPathsConfig(BaseModel):
     """Defines various application paths, including permanent storage and cache."""
 
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")
 
     config_dir: Path = Field(
         title="Configuration Directory",
-        description="The configuration directory containing application and environment files (e.g. app.toml)",
+        description=(
+            "The configuration directory containing application and environment "
+            "files (e.g. app.toml)"
+        ),
         examples=["/etc/docbuild"],
     )
     "Path to configuration files."
 
     root_config_dir: Path = Field(
         title="Root Configuration Directory",
-        description="The highest-level configuration directory containing common configuration files.",
+        description=(
+            "The highest-level configuration directory containing common "
+            "configuration files."
+        ),
         examples=["/etc/docbuild"],
     )
     "Path to the root configuration files."
@@ -247,11 +289,14 @@ class Env_PathsConfig(BaseModel):
 
     server_rootfiles_dir: Path = Field(
         title="Server Root Files Directory",
-        description="Directory for files that should be placed in the root of the server deployment.",
+        description=(
+            "Directory for files that should be placed in the root of the "
+            "server deployment."
+        ),
         examples=["/etc/docbuild/server-root-files-doc-suse-com"],
     )
     "Path for server root files."
-    
+
     repo_dir: Path = Field(
         title="Permanent Repository Directory",
         description="The directory where permanent bare Git repositories are stored.",
@@ -261,7 +306,10 @@ class Env_PathsConfig(BaseModel):
 
     temp_repo_dir: Path = Field(
         title="Temporary Repository Directory",
-        description="The directory used for temporary working copies cloned from the permanent bare repositories.",
+        description=(
+            "The directory used for temporary working copies cloned from "
+            "the permanent bare repositories."
+        ),
         examples=["/var/cache/docbuild/repos/temporary-branches/"],
     )
     "Path for temporary working copies."
@@ -282,67 +330,72 @@ class Env_PathsConfig(BaseModel):
 
     meta_cache_dir: Path = Field(
         title="Metadata Cache Directory",
-        description="Cache directory specifically for repository and deliverable metadata.",
+        description=(
+            "Cache directory specifically for repository and deliverable metadata."
+        ),
         examples=["/var/cache/docbuild/doc-example-com/meta"],
     )
     "Metadata cache path."
 
     base_tmp_dir: EnsureWritableDirectory = Field(
         title="Base Temporary Directory (System Wide)",
-        description="The root directory for all temporary artifacts (used for placeholder resolution).",
+        description=(
+            "The root directory for all temporary artifacts (used for "
+            "placeholder resolution)."
+        ),
         examples=["/var/tmp/docbuild"],
     )
     "Base system temporary path."
 
-    tmp: Env_TmpPaths
+    tmp: EnvTmpPaths
     "Temporary build paths."
 
-    target: Env_TargetPaths
+    target: EnvTargetPaths
     "Target deployment and backup paths."
 
 
 class EnvConfig(BaseModel):
     """Root model for the environment configuration (env.toml)."""
-    
-    model_config = ConfigDict(extra='forbid')
 
-    server: Env_Server = Field(
+    model_config = ConfigDict(extra="forbid")
+
+    server: EnvServer = Field(
         title="Server Configuration",
         description="Configuration related to the server/deployment environment.",
     )
     "Server-related settings."
 
-    config: Env_GeneralConfig = Field(
+    config: EnvGeneralConfig = Field(
         title="General Configuration",
         description="General settings like default language and canonical domain.",
     )
     "General application settings."
 
-    paths: Env_PathsConfig = Field(
+    paths: EnvPathsConfig = Field(
         title="Path Configuration",
         description="All file system path definitions.",
     )
     "File system paths."
-    
+
     # Build section integration
-    build: Env_Build = Field(
+    build: EnvBuild = Field(
         title="Build Configuration",
         description="Settings for DAPS command execution and containerization.",
     )
     "Build process settings."
 
-    xslt_params: dict[str, Any] = Field( 
+    xslt_params: dict[str, Any] = Field(
         default_factory=dict,
-        alias='xslt-params',
+        alias="xslt-params",
         title="XSLT Parameters",
         description="Custom XSLT parameters passed directly to DAPS.",
     )
     "XSLT processing parameters."
 
     # --- Placeholder Resolution ---
-    @model_validator(mode='before')
+    @model_validator(mode="before")
     @classmethod
-    def _resolve_placeholders(cls, data: Any) -> Any:
+    def _resolve_placeholders(cls, data: dict[str, Any]) -> dict[str, Any] | None:
         """Resolve placeholders before any other validation."""
         if isinstance(data, dict):
             try:
@@ -353,5 +406,5 @@ class EnvConfig(BaseModel):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Self:
-        """Convenience method to validate and return an instance."""
+        """Create an EnvConfig instance from a dictionary."""
         return cls.model_validate(data)

--- a/src/docbuild/models/deliverable.py
+++ b/src/docbuild/models/deliverable.py
@@ -29,54 +29,54 @@ class Deliverable:
     _meta: Metadata | None = None
 
     @cached_property
-    def productid(self) -> str|None:
+    def productid(self) -> str | None:
         """Return the product ID."""
         # ancestor::product/@productid
-        return self.product_node.attrib.get('productid', None)
+        return self.product_node.attrib.get("productid", None)
 
     @cached_property
-    def productname(self) -> str|None:
+    def productname(self) -> str | None:
         """Return the product name."""
         # ancestor::product/name
-        return self.product_node.findtext('name', default=None, namespaces=None)
+        return self.product_node.findtext("name", default=None, namespaces=None)
 
     @cached_property
     def docsetid(self) -> str:
         """Return the docset ID."""
         # ancestor::docset/@setid
-        return next(self._node.iterancestors('docset')).attrib.get('setid')
+        return next(self._node.iterancestors("docset")).attrib.get("setid")
 
     @cached_property
     def lang(self) -> str:
         """Returns the language and country code (e.g., 'en-us')."""
         # ../../builddocs/language/@lang
-        return self._node.getparent().attrib.get('lang').strip()
+        return self._node.getparent().attrib.get("lang").strip()
 
     @cached_property
     def language(self) -> str:
         """Returns only the language (e.g., 'en')."""
-        return re.split(r'[_-]', self.lang)[0]
+        return re.split(r"[_-]", self.lang)[0]
 
     @cached_property
     def product_docset(self) -> str:
         """Returns product and docset."""
-        return f'{self.productid}/{self.docsetid}'
+        return f"{self.productid}/{self.docsetid}"
 
     @cached_property
     def pdlang(self) -> str:
         """Return product, docset, and language."""
-        return f'{self.product_docset}/{self.lang}'
+        return f"{self.product_docset}/{self.lang}"
 
     @cached_property
     def pdlangdc(self) -> str:
         """Return product, docset, language and DC filename."""
-        return f'{self.pdlang}:{self.dcfile}'
+        return f"{self.pdlang}:{self.dcfile}"
 
     @cached_property
     def full_id(self) -> str:
         """Return the full ID of the deliverable."""
         branch = self.make_safe_name(self.branch)
-        return f'{self.product_docset}/{branch}/{self.lang}:{self.dcfile}'
+        return f"{self.product_docset}/{branch}/{self.lang}:{self.dcfile}"
 
     @cached_property
     def lang_is_default(self) -> bool:
@@ -84,22 +84,22 @@ class Deliverable:
         # ../language/@default
         # If the attribute default does not exist we get None.
         # As a fall back we return "0" => False
-        content: str = self._node.getparent().attrib.get('default', '0')
+        content: str = self._node.getparent().attrib.get("default", "0")
 
         mapping = {
-            '1': True,
-            '0': False,
-            'on': True,
-            'off': False,
-            'true': True,
-            'false': False,
+            "1": True,
+            "0": False,
+            "on": True,
+            "off": False,
+            "true": True,
+            "false": False,
         }
         return mapping.get(content.strip(), False)
 
     @cached_property
     def docsuite(self) -> str:
         """Return the product, docset, language and the DC filename."""
-        return f'{self.pdlang}:{self.dcfile}'
+        return f"{self.pdlang}:{self.dcfile}"
 
     @cached_property
     def branch(self) -> str:
@@ -111,29 +111,29 @@ class Deliverable:
         :return: The branch name as a string.
         :raises ValueError: If no branch is found
         """
-        node = self._node.getparent().findtext('branch', default=None)
+        node = self._node.getparent().findtext("branch", default=None)
         if node is not None:
             return node.strip()
 
         # If we cannot find the branch in the current language node,
         # we look in the English language and use this branch
         node = self._node.getparent().xpath(
-            'ancestor::builddocs/language'
+            "ancestor::builddocs/language"
             "[@lang!='en-us' or @default!='1' or @default!='true']/branch",
         )
         if node:
             return node[0].text.strip()
 
-        raise ValueError(f'No branch found for this deliverable {self.pdlangdc}')
+        raise ValueError(f"No branch found for this deliverable {self.pdlangdc}")
 
     @cached_property
     def subdir(self) -> str:
         """Return subdirectory or an empty string if not found."""
-        node = self._node.getparent().findtext('subdir', default=None)
+        node = self._node.getparent().findtext("subdir", default=None)
         if node is not None:
             return node.strip()
         else:
-            return ''
+            return ""
 
     @cached_property
     def git(self) -> Repo:
@@ -143,27 +143,27 @@ class Deliverable:
         :raises ValueError: If no git remote is found for the deliverable.
         """
         # ../preceding-sibling::git/@remote
-        node = self._node.getparent().getparent().find('git')
+        node = self._node.getparent().getparent().find("git")
         if node is not None:
-            return Repo(node.attrib.get('remote'))
+            return Repo(node.attrib.get("remote"))
         raise ValueError(
-            'No git remote found for '
-            f'{self.productid}/{self.docsetid}/{self.lang}/{self.dcfile}'
+            "No git remote found for "
+            f"{self.productid}/{self.docsetid}/{self.lang}/{self.dcfile}"
         )
 
     @cached_property
     def dcfile(self) -> str:
         """Return the DC filename or None if not found."""
         # ./dc
-        return self._node.findtext('dc', default=None, namespaces=None)
+        return self._node.findtext("dc", default=None, namespaces=None)
 
     @cached_property
     def basefile(self) -> str:
         """Return the DC filename without the DC prefix."""
-        return self.dcfile.lstrip('DC-')
+        return self.dcfile.lstrip("DC-")
 
     @cached_property
-    def format(self) -> dict[Literal['html', 'single-html', 'pdf', 'epub'], bool]:
+    def format(self) -> dict[Literal["html", "single-html", "pdf", "epub"], bool]:
         """Return the formats of the deliverable.
 
         Normalize the format attributes to boolean values.
@@ -176,12 +176,12 @@ class Deliverable:
         # We need to look inside English deliverables for formats
         node = self._node.xpath(
             f"(format|../../language[@lang='en-us']/"
-            f'deliverable[dc[{dc!r} = .]]/format)[last()]'
+            f"deliverable[dc[{dc!r} = .]]/format)[last()]"
         )
         if not node:
             raise ValueError(
-                'No format found for '
-                f'{self.productid}/{self.docsetid}/{self.lang}/{self.dcfile}'
+                "No format found for "
+                f"{self.productid}/{self.docsetid}/{self.lang}/{self.dcfile}"
             )
 
         return {key: convert2bool(value) for key, value in node[0].attrib.items()}
@@ -195,29 +195,29 @@ class Deliverable:
     def acronym(self) -> str:
         """Return the product acronym or None if not found."""
         # ancestor::product/acronym
-        node = self.product_node.findtext('acronym', default=None, namespaces=None)
+        node = self.product_node.findtext("acronym", default=None, namespaces=None)
         if node is not None:
             return node.strip()
-        return ''
+        return ""
 
     @cached_property
     def version(self) -> str:
         """Return the version of the docset or None if not found."""
         # ancestor::docset/version
-        return self.docset_node.findtext('version', default=None, namespaces=None)
+        return self.docset_node.findtext("version", default=None, namespaces=None)
 
     @cached_property
     def lifecycle(self) -> str:
         # TODO: Return Lifecycle object?
         """Return the lifecycle of the docset."""
         # ancestor::docset/@lifecycle
-        return self.docset_node.attrib.get('lifecycle')
+        return self.docset_node.attrib.get("lifecycle")
 
     # --- Path properties
     @cached_property
     def relpath(self) -> str:
         """Return the relative path of the deliverable."""
-        return f'{self.lang}/{self.product_docset}'
+        return f"{self.lang}/{self.product_docset}"
 
     @cached_property
     def repo_path(self) -> Path:
@@ -228,14 +228,14 @@ class Deliverable:
     def zip_path(self) -> str:
         """Return the path to the ZIP file."""
         return (
-            f'{self.lang}/{self.productid}/{self.docsetid}/'
-            f'{self.productid}-{self.docsetid}-{self.lang}.zip'
+            f"{self.lang}/{self.productid}/{self.docsetid}/"
+            f"{self.productid}-{self.docsetid}-{self.lang}.zip"
         )
 
     def _base_format_path(self, fmt: str) -> str:
         """Return the base path for a given format."""
-        path = '/'
-        fallback_rootid = self.dcfile.lstrip('DC-')
+        path = "/"
+        fallback_rootid = self.dcfile.lstrip("DC-")
         if self.meta is not None:
             rootid = self.meta.rootid
             if rootid is None:
@@ -245,32 +245,32 @@ class Deliverable:
             rootid = fallback_rootid
 
         # Suppress English
-        if self.lang != 'en-us':
-            path += f'{self.lang}/'
+        if self.lang != "en-us":
+            path += f"{self.lang}/"
 
-        path += f'{self.productid}/{self.docsetid}/{fmt}/{rootid}/'
+        path += f"{self.productid}/{self.docsetid}/{fmt}/{rootid}/"
         return path
 
     @cached_property
     def html_path(self) -> str:
         """Return the path to the HTML directory."""
-        return self._base_format_path('html')
+        return self._base_format_path("html")
 
     @cached_property
     def singlehtml_path(self) -> str:
         """Return the path to the single HTML directory."""
-        return self._base_format_path('single-html')
+        return self._base_format_path("single-html")
 
     @cached_property
     def pdf_path(self) -> str:
         """Return the path to the PDF file."""
-        path = '/'
-        draft = ''  # TODO
-        name = self.dcfile.lstrip('DC-')
-        if self.lang != 'en-us':
-            path += f'{self.lang}/'
+        path = "/"
+        draft = ""  # TODO
+        name = self.dcfile.lstrip("DC-")
+        if self.lang != "en-us":
+            path += f"{self.lang}/"
 
-        path += f'{self.product_docset}/pdf/{name}{draft}_{self.language}.pdf'
+        path += f"{self.product_docset}/pdf/{name}{draft}_{self.language}.pdf"
         return path
 
     # --- Node handling
@@ -305,7 +305,7 @@ class Deliverable:
     def meta(self, value: Metadata) -> None:
         """Set the metadata content of the deliverable."""
         if not isinstance(value, Metadata):
-            raise TypeError(f'Expected type Metadata, but got {type(value)}')
+            raise TypeError(f"Expected type Metadata, but got {type(value)}")
         self._meta = value
 
     def __hash__(self) -> int:
@@ -315,29 +315,29 @@ class Deliverable:
     def __repr__(self) -> str:
         """Implement repr(self)."""
         return (
-            f'{self.__class__.__name__}(productid={self.productid!r}, '
-            f'docsetid={self.docsetid!r}, '
-            f'lang={self.lang!r}, '
-            f'branch={self.branch!r}, '
-            f'dcfile={self.dcfile!r})'
+            f"{self.__class__.__name__}(productid={self.productid!r}, "
+            f"docsetid={self.docsetid!r}, "
+            f"lang={self.lang!r}, "
+            f"branch={self.branch!r}, "
+            f"dcfile={self.dcfile!r})"
         )
 
     def to_dict(self) -> dict:
         """Return the deliverable as a JSON object."""
-        raise NotImplementedError('Not yet implemented')
+        raise NotImplementedError("Not yet implemented")
 
     @staticmethod
     def make_safe_name(name: str) -> str:
         """Make a name safe for use in a filename or directory."""
         table = str.maketrans(
             {
-                '/': '_',
-                ':': '-',
-                '*': '_',
-                '?': '_',
-                '<': '',
-                '>': '',
-                '\\': '',
+                "/": "_",
+                ":": "-",
+                "*": "_",
+                "?": "_",
+                "<": "",
+                ">": "",
+                "\\": "",
             }
         )
         return name.translate(table)

--- a/src/docbuild/models/doctype.py
+++ b/src/docbuild/models/doctype.py
@@ -50,41 +50,41 @@ class Doctype(BaseModel):
     # """   # type: ignore
 
     product: Product = Field(
-        title='A SUSE product',
-        description='A SUSE product is a lowercase acronym.',
-        examples=['sles', 'smart'],
+        title="A SUSE product",
+        description="A SUSE product is a lowercase acronym.",
+        examples=["sles", "smart"],
     )
     """A SUSE product is a lowercase acronym"""
 
     docset: list[str] = Field(
         title="A specific 'docset' of a product",
         description=(
-            'A specific release or version of a product. '
-            'Values can be combined using commas. '
-            'After validation, docsets are sorted.'
+            "A specific release or version of a product. "
+            "Values can be combined using commas. "
+            "After validation, docsets are sorted."
         ),
-        examples=['15-SP6', 'systems-management'],
+        examples=["15-SP6", "systems-management"],
     )
     """A specific 'docset' of a product (usually a release or version)"""
 
     lifecycle: LifecycleFlag = Field(
-        title='The state of the Doctype',
+        title="The state of the Doctype",
         description=(
-            'One or more lifecycle states that indicate the '
-            'support or development. '
-            'Values can be combined using commas or pipes.'
+            "One or more lifecycle states that indicate the "
+            "support or development. "
+            "Values can be combined using commas or pipes."
         ),
-        examples=['supported', 'beta', 'unsupported'],
+        examples=["supported", "beta", "unsupported"],
     )
     """The state  (supported, beta, etc.) of the Doctype"""
 
     langs: list[LanguageCode] = Field(
-        title='A natural language',
+        title="A natural language",
         description=(
-            'The natural language containing language and country. '
-            'After validation, langs are sorted'
+            "The natural language containing language and country. "
+            "After validation, langs are sorted"
         ),
-        examples=['en-us', 'de-de'],
+        examples=["en-us", "de-de"],
     )
     """A natural language containing language and country"""
 
@@ -92,11 +92,11 @@ class Doctype(BaseModel):
     # The regex contains non-capturing groups on purpose
     # This leads to None in the result if that group isn't matched
     _DOCTYPE_REGEX: ClassVar[Pattern] = re.compile(
-        r'^'  # start
-        r'(?:/?([^/@]+|\*))?'  # optional product (group 1)
-        r'/(?:([^/@]+|\*))?'  # optional docset (group 2)
-        r'(?:@([a-z]+(?:[,|][a-z]+)*))?'  # optional lifecycle (group 3)
-        r'/(\*|[\w-]+(?:,[\w-]+)*)$',  # required langs (group 4)
+        r"^"  # start
+        r"(?:/?([^/@]+|\*))?"  # optional product (group 1)
+        r"/(?:([^/@]+|\*))?"  # optional docset (group 2)
+        r"(?:@([a-z]+(?:[,|][a-z]+)*))?"  # optional lifecycle (group 3)
+        r"/(\*|[\w-]+(?:,[\w-]+)*)$",  # required langs (group 4)
     )
 
     # dunder methods
@@ -127,23 +127,23 @@ class Doctype(BaseModel):
 
     def __str__(self) -> str:
         """Implement str(self)."""
-        langs_str = ','.join(lang.language for lang in self.langs)
-        docset_str = ','.join(self.docset)
-        return f'{self.product.value}/{docset_str}@{self.lifecycle.name}/{langs_str}'
+        langs_str = ",".join(lang.language for lang in self.langs)
+        docset_str = ",".join(self.docset)
+        return f"{self.product.value}/{docset_str}@{self.lifecycle.name}/{langs_str}"
 
     def __repr__(self) -> str:
         """Implement repr(self)."""
-        langs_str = ','.join(lang.language for lang in self.langs)
-        docset_str = ','.join(self.docset)
+        langs_str = ",".join(lang.language for lang in self.langs)
+        docset_str = ",".join(self.docset)
         return (
-            f'{self.__class__.__name__}(product={self.product.value!r}, '
-            f'docset=[{docset_str}], '
-            f'lifecycle={self.lifecycle.name!r}, '
-            f'langs=[{langs_str}]'
-            f')'
+            f"{self.__class__.__name__}(product={self.product.value!r}, "
+            f"docset=[{docset_str}], "
+            f"lifecycle={self.lifecycle.name!r}, "
+            f"langs=[{langs_str}]"
+            f")"
         )
 
-    def __contains__(self, other: 'Doctype') -> bool:
+    def __contains__(self, other: "Doctype") -> bool:
         """Return if bool(other in self).
 
         Every part of a Doctype is compared element-wise.
@@ -154,9 +154,9 @@ class Doctype(BaseModel):
         return all(
             [
                 self.product == other.product or self.product == Product.ALL,
-                set(other.docset).issubset(self.docset) or '*' in self.docset,
+                set(other.docset).issubset(self.docset) or "*" in self.docset,
                 other.lifecycle in self.lifecycle,
-                set(other.langs).issubset(self.langs) or '*' in self.langs,
+                set(other.langs).issubset(self.langs) or "*" in self.langs,
             ],
         )
 
@@ -171,19 +171,19 @@ class Doctype(BaseModel):
         )
 
     # Validators
-    @field_validator('product', mode='before')
+    @field_validator("product", mode="before")
     @classmethod
     def coerce_product(cls, value: str | Product) -> Product:
         """Convert a string into a valid Product."""
         return value if isinstance(value, Product) else Product(value)
 
-    @field_validator('docset', mode='before')
+    @field_validator("docset", mode="before")
     @classmethod
     def coerce_docset(cls, value: str | list[str]) -> list[str]:
         """Convert a string into a list."""
-        return sorted(value.split(',')) if isinstance(value, str) else sorted(value)
+        return sorted(value.split(",")) if isinstance(value, str) else sorted(value)
 
-    @field_validator('lifecycle', mode='before')
+    @field_validator("lifecycle", mode="before")
     @classmethod
     def coerce_lifecycle(cls, value: str | LifecycleFlag) -> LifecycleFlag:
         """Convert a string into a LifecycleFlag."""
@@ -195,13 +195,13 @@ class Doctype(BaseModel):
             return lifecycles
         return LifecycleFlag(value)
 
-    @field_validator('langs', mode='before')
+    @field_validator("langs", mode="before")
     @classmethod
     def coerce_langs(cls, value: str | list[str | LanguageCode]) -> list[LanguageCode]:
         """Convert a comma-separated string or a list of strings into LanguageCode."""
         # Allow list of strings or Language enums
         if isinstance(value, str):
-            value = sorted(value.split(','))
+            value = sorted(value.split(","))
         return sorted(
             [
                 lang if isinstance(lang, LanguageCode) else LanguageCode(language=lang)
@@ -215,13 +215,13 @@ class Doctype(BaseModel):
         match = cls._DOCTYPE_REGEX.match(doctype_str)
 
         if not match:
-            raise ValueError(f'Invalid doctype string format: {doctype_str!r}')
+            raise ValueError(f"Invalid doctype string format: {doctype_str!r}")
 
         product, docset, lifecycle, langs = match.groups()
-        product = '*' if not product else product
-        docset = '*' if not docset else docset
-        lifecycle = 'unknown' if lifecycle is None else lifecycle
-        langs = 'en-us' if langs is None else langs
+        product = "*" if not product else product
+        docset = "*" if not docset else docset
+        lifecycle = "unknown" if lifecycle is None else lifecycle
+        langs = "en-us" if langs is None else langs
         return cls(
             product=product,
             docset=docset,
@@ -245,32 +245,32 @@ class Doctype(BaseModel):
             deliverables that match this Doctype.
         """
         # Example: /sles/15-SP6@supported/en-us,de-de
-        product = 'product'
+        product = "product"
         if self.product != Product.ALL:
-            product += f'[@productid={self.product.value!r}]'
+            product += f"[@productid={self.product.value!r}]"
 
-        setids = [f'@setid={d!r}' for d in self.docset if d != '*']
+        setids = [f"@setid={d!r}" for d in self.docset if d != "*"]
 
-        setids_str = ' or '.join(setids)
+        setids_str = " or ".join(setids)
         if setids_str:
-            docset = f'docset[{setids_str}]'
+            docset = f"docset[{setids_str}]"
         else:
-            docset = 'docset'
+            docset = "docset"
 
-        lifecycle = ' or '.join(
+        lifecycle = " or ".join(
             [
-                f'@lifecycle={lc.name!r}'
+                f"@lifecycle={lc.name!r}"
                 for lc in self.lifecycle
                 if lc != LifecycleFlag.unknown
             ]
         )
         if lifecycle:
-            docset += f'[{lifecycle}]'
+            docset += f"[{lifecycle}]"
 
-        if '*' in self.langs:
-            language = 'language'
+        if "*" in self.langs:
+            language = "language"
         else:
-            language = ' or '.join([f'@lang={lang.language!r}' for lang in self.langs])
-            language = f'language[{language}]'
+            language = " or ".join([f"@lang={lang.language!r}" for lang in self.langs])
+            language = f"language[{language}]"
 
-        return f'{product}/{docset}/builddocs/{language}'
+        return f"{product}/{docset}/builddocs/{language}"

--- a/src/docbuild/models/language.py
+++ b/src/docbuild/models/language.py
@@ -18,14 +18,14 @@ class LanguageCode(BaseModel):
     """
 
     language: str = Field(
-        title='The natural language',
+        title="The natural language",
         description=(
-            'A natural language in the format ll-cc, '
+            "A natural language in the format ll-cc, "
             "whereas 'll' is the language and 'cc' the country "
-            'both in lowercase letters. '
+            "both in lowercase letters. "
             "The special syntax '*' denotes every language."
         ),
-        examples=['en-us', 'de-de'],
+        examples=["en-us", "de-de"],
         frozen=True,
     )
     """The natural language in the format ll-cc, where 'll' is the
@@ -36,27 +36,27 @@ class LanguageCode(BaseModel):
     conforming to Pydantic's :class:`~pydantic.config.ConfigDict`."""
 
     ALLOWED_LANGS: ClassVar[frozenset] = frozenset(
-        {'*'} | ALLOWED_LANGUAGES,
+        {"*"} | ALLOWED_LANGUAGES,
     )
     """Class variable containing all allowed languages."""
 
-    @model_validator(mode='before')
+    @model_validator(mode="before")
     @classmethod
-    def _convert_str_to_dict(cls, data: Any) -> Any:
+    def _convert_str_to_dict(cls, data: str | dict[str, Any]) -> dict[str, Any]:
         """Allow initializing LanguageCode from a plain string."""
         if isinstance(data, str):
-            return {'language': data}
+            return {"language": data}
         return data
 
     def __str__(self) -> str:
         """Implement str(self)."""
-        return f'{self.language}'
+        return f"{self.language}"
 
     def __repr__(self) -> str:
         """Implement repr(self)."""
-        return f'{self.__class__.__name__}(language={str(self)!r})'
+        return f"{self.__class__.__name__}(language={str(self)!r})"
 
-    def __eq__(self, other: 'object|str|LanguageCode') -> bool:
+    def __eq__(self, other: "object|str|LanguageCode") -> bool:
         """Implement self == other.
 
         The comparison does NOT break the principle of equality:
@@ -72,7 +72,7 @@ class LanguageCode(BaseModel):
             return self.language == other
         return NotImplemented
 
-    def __lt__(self, other: 'object|str|LanguageCode') -> bool:
+    def __lt__(self, other: "object|str|LanguageCode") -> bool:
         """Implement self < other.
 
         Special properties:
@@ -88,9 +88,9 @@ class LanguageCode(BaseModel):
             return NotImplemented
 
         # "*" is always smallest
-        if self.language == '*':
-            return other_value != '*'
-        if other_value == '*':
+        if self.language == "*":
+            return other_value != "*"
+        if other_value == "*":
             return False
 
         # Perform string comparison after handling the wildcard case
@@ -103,7 +103,7 @@ class LanguageCode(BaseModel):
         """
         return hash(self.language)
 
-    def matches(self, other: 'LanguageCode | str') -> bool:
+    def matches(self, other: "LanguageCode | str") -> bool:
         """Return True if this LanguageCode matches the other, considering wildcards.
 
         The string '*' matches any language:
@@ -115,18 +115,18 @@ class LanguageCode(BaseModel):
         """
         other_value = str(other)
         return (
-            self.language == '*' or other_value == '*' or self.language == other_value
+            self.language == "*" or other_value == "*" or self.language == other_value
         )
 
-    @field_validator('language', mode='before')
+    @field_validator("language", mode="before")
     @classmethod
     def _normalize_language_separator(cls, value: str) -> str:
         """Normalize separator from _ to -."""
         if isinstance(value, str):
-            return value.replace('_', '-')
+            return value.replace("_", "-")
         return value
 
-    @field_validator('language')
+    @field_validator("language")
     @classmethod
     def validate_language(cls, value: str) -> str:
         """Check if the passed language adheres to the allowed language."""
@@ -134,7 +134,7 @@ class LanguageCode(BaseModel):
             raise ValueError(
                 (
                     f"Invalid language code '{value}'. "
-                    f'Expected one of {", ".join(sorted(cls.ALLOWED_LANGS))}'
+                    f"Expected one of {', '.join(sorted(cls.ALLOWED_LANGS))}"
                 ),
             )
         return value
@@ -150,17 +150,17 @@ class LanguageCode(BaseModel):
           - ``(language, country)`` if both parts are present.
           - ``('*',)`` if the language code is ``"*"``
         """
-        if self.language == '*':
-            return ('*',)
+        if self.language == "*":
+            return ("*",)
 
         # Use split('-') as the separator is already normalized
-        parts = self.language.split('-')
+        parts = self.language.split("-")
         return (parts[0], parts[1]) if len(parts) > 1 else (parts[0],)
 
     @computed_field(
         repr=False,
-        title='The language part of the language code',
-        examples=['en', 'de', 'ja'],
+        title="The language part of the language code",
+        examples=["en", "de", "ja"],
     )
     def lang(self) -> str:
         """Extract the language part of the language code (property)."""
@@ -168,9 +168,9 @@ class LanguageCode(BaseModel):
 
     @computed_field(
         repr=False,
-        title='The country part of the language code',
-        examples=['us', 'de', 'jp'],
+        title="The country part of the language code",
+        examples=["us", "de", "jp"],
     )
     def country(self) -> str:
         """Extract the country part of the language code (property)."""
-        return self._parts[1] if len(self._parts) > 1 else '*'
+        return self._parts[1] if len(self._parts) > 1 else "*"

--- a/src/docbuild/models/lifecycle.py
+++ b/src/docbuild/models/lifecycle.py
@@ -34,7 +34,7 @@ class LifecycleFlag(Flag):
     # _SEPARATOR = re.compile(r'[|,]')  # Static class variable
 
     @classmethod
-    def from_str(cls: 'LifecycleFlag', value: str) -> 'LifecycleFlag':
+    def from_str(cls: "LifecycleFlag", value: str) -> "LifecycleFlag":
         """Convert a string to a LifecycleFlag object.
 
         The string accepts the values 'supported', 'beta', 'hidden',
@@ -66,9 +66,9 @@ class LifecycleFlag(Flag):
             return flag
 
         except KeyError as err:
-            allowed = ', '.join(cls.__members__.keys())
+            allowed = ", ".join(cls.__members__.keys())
             raise ValueError(
-                f'Invalid lifecycle name: {err.args[0]!r}. Allowed values: {allowed}',
+                f"Invalid lifecycle name: {err.args[0]!r}. Allowed values: {allowed}",
             ) from err
 
     def __contains__(self: Self, other: str | Flag) -> bool:
@@ -92,4 +92,4 @@ class LifecycleFlag(Flag):
 
 
 # attach after class creation so EnumMeta doesn't touch it
-LifecycleFlag._SEPARATOR: ClassVar[re.Pattern] = re.compile(r'[|,]')
+LifecycleFlag._SEPARATOR: ClassVar[re.Pattern] = re.compile(r"[|,]")

--- a/src/docbuild/models/metadata.py
+++ b/src/docbuild/models/metadata.py
@@ -13,18 +13,18 @@ class Metadata:
     title: str | None = field(default=None)
     """The title of the deliverable."""
 
-    subtitle: str = field(default='')
+    subtitle: str = field(default="")
     """The subtitle of the deliverable."""
 
     # SEO metadata
     seo_title: str | None = field(default=None)
     """The SEO title of the deliverable."""
-    seo_description: str = field(default='')
+    seo_description: str = field(default="")
     """The SEO description of the deliverable."""
-    seo_social_descr: str = field(default='')
+    seo_social_descr: str = field(default="")
     """The SEO social description of the deliverable."""
     #
-    dateModified: str = field(default='')  # noqa: N815
+    dateModified: str = field(default="")  # noqa: N815
     """The date when the deliverable was last modified."""
     tasks: list[str] = field(default_factory=list)
     """A list of tasks related to the deliverable."""
@@ -41,7 +41,7 @@ class Metadata:
     # archives: list[str] | None = field(default=None)
     # category: str | None = field(default=None)
     #
-    _match: ClassVar[re.Pattern] = re.compile(r'\[(.*?)\](.*)')
+    _match: ClassVar[re.Pattern] = re.compile(r"\[(.*?)\](.*)")
 
     def read(self, metafile: Path | str) -> Self:  # noqa: C901
         """Read the metadata from a file.
@@ -51,57 +51,57 @@ class Metadata:
         """
         lines = Path(metafile).open().readlines()
         for line in lines:
-            if line.lstrip().startswith('#'):
+            if line.lstrip().startswith("#"):
                 continue
-            key, value = map(str.strip, line.split('=', 1))
+            key, value = map(str.strip, line.split("=", 1))
 
             match key:
                 # case "category":
                 #     if value:
                 #         self.category = value
-                case 'title':
+                case "title":
                     self.title = value
 
-                case 'subtitle':
+                case "subtitle":
                     if value:
                         self.subtitle = value
 
-                case 'seo-title':
+                case "seo-title":
                     if value:
                         self.seo_title = value
 
-                case 'seo-social-descr':
+                case "seo-social-descr":
                     if value:
                         self.seo_social_descr = value
 
-                case 'seo-description':
+                case "seo-description":
                     if value:
                         self.seo_description = value
 
-                case 'date':
+                case "date":
                     if value:
                         self.dateModified = value
 
-                case 'rootid':
+                case "rootid":
                     if value:
                         self.rootid = value
 
-                case 'task':
-                    self.tasks = [task.strip() for task in value.split(';')]
+                case "task":
+                    self.tasks = [task.strip() for task in value.split(";")]
 
-                case 'productname':
+                case "productname":
                     # productlist = [entry["name"] for entry in self.products]
                     if mtch := self._match.match(value):
-                        versions = mtch.group(1).strip().split(';')
+                        versions = mtch.group(1).strip().split(";")
                         product = mtch.group(2).strip()
 
                         dct = {
-                            'name': product,
-                            'versions': versions,
+                            "name": product,
+                            "versions": versions,
                         }
                         self.products.append(dct)
 
-                case 'series':
+                case "series":
                     if value:
                         self.series = value
 

--- a/src/docbuild/models/path.py
+++ b/src/docbuild/models/path.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from typing import Any, Self
+from typing import Self
 
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
@@ -31,7 +31,7 @@ class EnsureWritableDirectory:
 
     @classmethod
     def __get_pydantic_core_schema__(
-        cls, source_type: Any, handler: GetCoreSchemaHandler
+        cls, source_type: type[Path], handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
         """Define Validation AND Serialization logic."""
         # 1. Validation Logic (The Chain)
@@ -45,7 +45,7 @@ class EnsureWritableDirectory:
         # This tells Pydantic: "When dumping to JSON or Python, use str(instance)"
         serialization_schema = core_schema.plain_serializer_function_ser_schema(
             lambda instance: str(instance),
-            when_used='always',  # Apply to both JSON and Python (dict) dumps
+            when_used="always",  # Apply to both JSON and Python (dict) dumps
         )
         # 3. Combine Validation and Serialization
         return core_schema.json_or_python_schema(
@@ -80,9 +80,12 @@ class EnsureWritableDirectory:
 
         # 3. Permission Checks (R/W/X)
         missing_perms = []
-        if not os.access(path, os.R_OK): missing_perms.append("READ")
-        if not os.access(path, os.W_OK): missing_perms.append("WRITE")
-        if not os.access(path, os.X_OK): missing_perms.append("EXECUTE")
+        if not os.access(path, os.R_OK):
+            missing_perms.append("READ")
+        if not os.access(path, os.W_OK):
+            missing_perms.append("WRITE")
+        if not os.access(path, os.X_OK):
+            missing_perms.append("EXECUTE")
 
         if missing_perms:
             raise ValueError(
@@ -108,7 +111,7 @@ class EnsureWritableDirectory:
 
     # Allows access to methods/attributes of the underlying Path object
     # (e.g., .joinpath)
-    def __getattr__(self, name: str) -> Any:
+    def __getattr__(self, name: str) -> object:
         """Delegate attribute access to the underlying Path object."""
         return getattr(self._path, name)
 

--- a/src/docbuild/models/product.py
+++ b/src/docbuild/models/product.py
@@ -10,16 +10,16 @@ from ..constants import ALLOWED_PRODUCTS
 class StrEnumMeta(EnumMeta):
     """Custom metaclass for StrEnum to allow attribute-style access."""
 
-    def __getitem__(cls, key: str) -> 'StrEnumMeta':
+    def __getitem__(cls, key: str) -> "StrEnumMeta":
         """Access enum members using attribute-style names with underscores."""
-        candidate = key.replace('-', '_')
+        candidate = key.replace("-", "_")
         try:
             return super().__getitem__(candidate)
         except KeyError:
-            allowed = ', '.join(repr(member.value) for member in cls)
+            allowed = ", ".join(repr(member.value) for member in cls)
             raise KeyError(
-                f'{key!r} is not a valid member name or value for {cls.__name__}. '
-                f'Allowed (values): {allowed}',
+                f"{key!r} is not a valid member name or value for {cls.__name__}. "
+                f"Allowed (values): {allowed}",
             ) from None
 
 
@@ -29,9 +29,9 @@ class BaseProductEnum(StrEnum, metaclass=StrEnumMeta):
     @classmethod
     def _missing_(cls, value: object) -> Never:
         """Raise custom error for unknown values."""
-        allowed = ', '.join(repr(v.value) for v in cls)
+        allowed = ", ".join(repr(v.value) for v in cls)
         raise ValueError(
-            f'{value!r} is not a valid {cls.__name__}. Allowed values are: {allowed}',
+            f"{value!r} is not a valid {cls.__name__}. Allowed values are: {allowed}",
         )
 
 
@@ -40,7 +40,7 @@ class BaseProductEnum(StrEnum, metaclass=StrEnumMeta):
 # Product name with dashes are replace with underscores.
 # You can access "Product.sle_ha", but not "Product.sle-ha"
 Product = BaseProductEnum(
-    'Product',
-    {'ALL': '*'} | {item.replace('-', '_'): item for item in ALLOWED_PRODUCTS},
+    "Product",
+    {"ALL": "*"} | {item.replace("-", "_"): item for item in ALLOWED_PRODUCTS},
 )
 """A :py:class:`~enum.StrEnum` for the products of the docbuild application."""

--- a/src/docbuild/models/repo.py
+++ b/src/docbuild/models/repo.py
@@ -17,31 +17,31 @@ class Repo:
     regardless of the original URL (HTTPS vs. SSH).
     """
 
-    DEFAULT_HOST: ClassVar[str] = 'https://github.com'
+    DEFAULT_HOST: ClassVar[str] = "https://github.com"
     """The default host to use when constructing a URL from a short name."""
 
     _MAP_SERVICE2URL: ClassVar[dict[str, str]] = {
-        'gl': 'https://gitlab.com',
-        'gls': 'https://gitlab.suse.de',
-        'gh': 'https://github.com',
-        'bb': 'https://bitbucket.org',
-        'gt': 'https://gitea.com',
-        'cb': 'https://codeberg.org',
-        'ghe': 'https://github.enterprise.com',
+        "gl": "https://gitlab.com",
+        "gls": "https://gitlab.suse.de",
+        "gh": "https://github.com",
+        "bb": "https://bitbucket.org",
+        "gt": "https://gitea.com",
+        "cb": "https://codeberg.org",
+        "ghe": "https://github.enterprise.com",
     }
     _MAP_URL2SERVICE: ClassVar[dict[str, str]] = {
         v: k for k, v in _MAP_SERVICE2URL.items()
     }
 
     _SSH_PATTERN: ClassVar[re.Pattern] = re.compile(
-        r'^(?P<user>[^@]+)@(?P<host>[^:]+):(?P<repo>.+?)(?:\.git)?$'
+        r"^(?P<user>[^@]+)@(?P<host>[^:]+):(?P<repo>.+?)(?:\.git)?$"
     )
 
     _SERVICE_PATTERN: ClassVar[re.Pattern] = re.compile(
-        r'^(?P<abbr>[a-z]{2,4}):/{1,2}(?P<repo>.+?)(?:\.git)?$', re.IGNORECASE
+        r"^(?P<abbr>[a-z]{2,4}):/{1,2}(?P<repo>.+?)(?:\.git)?$", re.IGNORECASE
     )
 
-    _SCHEMA_PATTERN: ClassVar[re.Pattern] = re.compile(r'(?P<schema>https?)://')
+    _SCHEMA_PATTERN: ClassVar[re.Pattern] = re.compile(r"(?P<schema>https?)://")
 
     url: str = field(repr=False)
     """The full URL of the repository."""
@@ -70,9 +70,8 @@ class Repo:
           - ``ghe`` for GitHub Enterprise
         * An abbreviated name like ``org/repo`` which defaults to GitHub.
         """
-        cls = type(self)
         if not value:
-            raise ValueError('Repository value cannot be empty.')
+            raise ValueError("Repository value cannot be empty.")
 
         url: str
         name: str
@@ -80,46 +79,46 @@ class Repo:
         service_match = self._SERVICE_PATTERN.match(value)
         ssh_match = self._SSH_PATTERN.match(value)
 
-        if 'https://' in value or 'http://' in value:
+        if "https://" in value or "http://" in value:
             parsed_original = urlparse(value.lower())
-            name = parsed_original.path.strip('/').rsplit('.git', 1)[0]
-            url = f'{parsed_original.scheme}://{parsed_original.netloc}/{name}.git'
-            host = f'{parsed_original.scheme}://{parsed_original.netloc}'
-            surl = f'{self._MAP_URL2SERVICE.get(host, "gh")}://{name}'
+            name = parsed_original.path.strip("/").rsplit(".git", 1)[0]
+            url = f"{parsed_original.scheme}://{parsed_original.netloc}/{name}.git"
+            host = f"{parsed_original.scheme}://{parsed_original.netloc}"
+            surl = f"{self._MAP_URL2SERVICE.get(host, 'gh')}://{name}"
 
         elif service_match:
-            service = service_match.group('abbr').lower()
-            name = service_match.group('repo').lower().rstrip('/')
+            service = service_match.group("abbr").lower()
+            name = service_match.group("repo").lower().rstrip("/")
             host = self._MAP_SERVICE2URL.get(service)
             if not host:
                 raise ValueError(f"Unknown repo abbreviation: '{service}'")
-            url = f'{host}/{name}.git'
-            surl = f'{service}://{name}'
+            url = f"{host}/{name}.git"
+            surl = f"{service}://{name}"
 
         elif ssh_match:
-            host = ssh_match['host'].lower()
-            name = ssh_match['repo'].lower()
-            name = name.rstrip('/')
-            url = f'https://{host}/{name}.git'
-            surl = f'{self._MAP_URL2SERVICE.get(host, "gh")}://{name}'
+            host = ssh_match["host"].lower()
+            name = ssh_match["repo"].lower()
+            name = name.rstrip("/")
+            url = f"https://{host}/{name}.git"
+            surl = f"{self._MAP_URL2SERVICE.get(host, 'gh')}://{name}"
 
-        elif '/' in value:
+        elif "/" in value:
             value = value.lower()
-            name = value.rsplit('.git', 1)[0].rstrip('/')
-            url = f'{self.DEFAULT_HOST}/{name}.git'
-            surl = f'gh://{name}'
+            name = value.rsplit(".git", 1)[0].rstrip("/")
+            url = f"{self.DEFAULT_HOST}/{name}.git"
+            surl = f"gh://{name}"
 
         else:
             raise ValueError(
                 f"Invalid repository value: '{value}'. "
-                'Expected a full HTTPS URL, SSH URL, abbr notation, '
-                'or an abbreviated name.'
+                "Expected a full HTTPS URL, SSH URL, abbr notation, "
+                "or an abbreviated name."
             )
 
         # Use object.__setattr__ because the dataclass is frozen
-        object.__setattr__(self, 'url', url)
-        object.__setattr__(self, 'name', name)
-        object.__setattr__(self, 'surl', surl)
+        object.__setattr__(self, "url", url)
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "surl", surl)
 
     def __eq__(self, other: object) -> bool:
         """Compare Repo with another Repo (by name) or a string (by name)."""
@@ -147,5 +146,5 @@ class Repo:
     def slug(self) -> str:
         """Return the slug name of the repository."""
         return self.url.translate(
-            str.maketrans({':': '_', '/': '_', '-': '_', '.': '_'}),
+            str.maketrans({":": "_", "/": "_", "-": "_", ".": "_"}),
         )

--- a/src/docbuild/models/serverroles.py
+++ b/src/docbuild/models/serverroles.py
@@ -18,7 +18,7 @@ class ServerRole(StrEnum):
     """The server role."""
 
     # production
-    PRODUCTION = 'production'
+    PRODUCTION = "production"
     """Server is in production mode, serving live traffic."""
     PROD = PRODUCTION
     P = PRODUCTION
@@ -26,7 +26,7 @@ class ServerRole(StrEnum):
     prod = PRODUCTION
     p = PRODUCTION
     # staging
-    STAGING = 'staging'
+    STAGING = "staging"
     """Server is in staging mode, used for testing before production."""
     STAGE = STAGING
     S = STAGING
@@ -34,7 +34,7 @@ class ServerRole(StrEnum):
     stage = STAGING
     s = STAGING
     # testing
-    TESTING = 'testing'
+    TESTING = "testing"
     """Server is in testing mode, used for development and QA."""
     TEST = TESTING
     T = TESTING

--- a/src/docbuild/utils/contextmgr.py
+++ b/src/docbuild/utils/contextmgr.py
@@ -13,7 +13,6 @@ import tempfile
 import time
 from types import TracebackType
 from typing import Any
-import weakref as _weakref
 
 # Type aliases for exception handling
 type ExcType = type[BaseException] | None
@@ -23,14 +22,15 @@ type ExcTback = TracebackType | None
 # Logging
 log = logging.getLogger(__name__)
 
+
 @dataclass
 class TimerData:
     """Data structure to hold timer information."""
 
     name: str
-    start: float = float('nan')
-    end: float = float('nan')
-    elapsed: float = float('nan')
+    start: float = float("nan")
+    end: float = float("nan")
+    elapsed: float = float("nan")
 
 
 def make_timer(
@@ -149,12 +149,10 @@ class PersistentOnErrorTemporaryDirectory(tempfile.TemporaryDirectory):
             except OSError as e:
                 # Your custom logging is more informative than the parent's
                 # `ignore_errors=True`, so we replicate it here.
-                log.exception('Failed to delete temp dir %s: %s', self.name, e)
+                log.exception("Failed to delete temp dir %s: %s", self.name, e)
 
-    async def __aexit__(self,
-        exc_type: ExcType,
-        exc_val: ExcVal,
-        exc_tb: ExcTback
+    async def __aexit__(
+        self, exc_type: ExcType, exc_val: ExcVal, exc_tb: ExcTback
     ) -> None:
         """Asynchronously clean up the directory on successful exit.
 
@@ -202,22 +200,22 @@ def edit_json(path: Path | str) -> Iterator[dict[str, Any]]:
             config["docs"][0]["format"]["html"] = "..."
             # more modifications...
     """
-    encoding = 'utf-8'
+    encoding = "utf-8"
     path = Path(path)
     parent = path.parent
 
     # Guard: ensure file exists
     if not path.exists():
-        raise FileNotFoundError(f'JSON file not found: {path}')
+        raise FileNotFoundError(f"JSON file not found: {path}")
 
     # Load JSON with better error context
-    with path.open('r', encoding=encoding) as f:
+    with path.open("r", encoding=encoding) as f:
         try:
             data = json.load(f)
         except json.JSONDecodeError as e:
             # Re-raise with file path context while preserving original info
             raise json.JSONDecodeError(
-                f'Invalid JSON in {path}: {e.msg}', e.doc, e.pos
+                f"Invalid JSON in {path}: {e.msg}", e.doc, e.pos
             ) from e
 
     # Hand control to the user
@@ -232,12 +230,12 @@ def edit_json(path: Path | str) -> Iterator[dict[str, Any]]:
     tmp_path = None
     try:
         with tempfile.NamedTemporaryFile(
-            'w',
+            "w",
             encoding=encoding,
             dir=str(parent),
             delete=False,  # We manage deletion manually
-            prefix=f'.{path.stem}.',
-            suffix='.tmp',
+            prefix=f".{path.stem}.",
+            suffix=".tmp",
         ) as tmp_file:
             tmp_path = Path(tmp_file.name)
 

--- a/src/docbuild/utils/convert.py
+++ b/src/docbuild/utils/convert.py
@@ -12,17 +12,17 @@ def convert2bool(value: str | bool) -> bool:
     :raises ValueError: If the value cannot be converted to a valid boolean
     """
     mapping = {
-        'yes': True,
-        'true': True,
-        '1': True,
-        'on': True,
-        'no': False,
-        'false': False,
-        '0': False,
-        'off': False,
+        "yes": True,
+        "true": True,
+        "1": True,
+        "on": True,
+        "no": False,
+        "false": False,
+        "0": False,
+        "off": False,
     }
     value = str(value).lower()
     if value in mapping:
         return mapping[value]
 
-    raise ValueError(f'Invalid boolean value: {value}')
+    raise ValueError(f"Invalid boolean value: {value}")

--- a/src/docbuild/utils/decorators.py
+++ b/src/docbuild/utils/decorators.py
@@ -9,8 +9,8 @@ from lxml import etree
 if TYPE_CHECKING:
     from ..config.xml.checks import CheckResult
 
-F = TypeVar('F', bound=Callable[[etree._Element | etree._ElementTree], 'CheckResult'])
-"""Type variable for functions that take an XML element or tree and return CheckResult."""
+F = TypeVar("F", bound=Callable[[etree._Element | etree._ElementTree], "CheckResult"])
+"""A type variable representing a callable that takes an XML element or tree"""
 
 
 class RegistryDecorator:
@@ -30,11 +30,11 @@ class RegistryDecorator:
         :return: The wrapped function.
         """
         if not callable(func):
-            raise TypeError('Only callable objects can be registered as checks.')
+            raise TypeError("Only callable objects can be registered as checks.")
         self.registry.append(func)
 
         @wraps(func)
-        def wrapper(*args: object, **kwargs: object) -> 'CheckResult':
+        def wrapper(*args: object, **kwargs: object) -> "CheckResult":
             return func(*args, **kwargs)
 
         return cast(F, wrapper)

--- a/src/docbuild/utils/doc.py
+++ b/src/docbuild/utils/doc.py
@@ -1,12 +1,12 @@
-""" """
+"""Utility decorators for docbuild."""
 
 from collections.abc import Callable
 import functools
 from typing import Any, ParamSpec, TypeVar
 
-T = TypeVar('T', bound=Callable[..., object])
-P = ParamSpec('P')
-R = TypeVar('R')
+T = TypeVar("T", bound=Callable[..., object])
+P = ParamSpec("P")
+R = TypeVar("R")
 FormatValue = str | int | bool
 
 
@@ -15,7 +15,7 @@ class SafeDict(dict):
 
     def __missing__(self, key: str) -> str:
         """Let missing keys stay as keys."""
-        return '{' + key + '}'
+        return "{" + key + "}"
 
 
 def docstring(
@@ -53,7 +53,7 @@ def docstring(
     """
 
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
-        base_template = template if template is not None else func.__doc__ or ''
+        base_template = template if template is not None else func.__doc__ or ""
         formatted_doc = base_template.format_map(SafeDict(kwargs))
 
         @functools.wraps(func)

--- a/src/docbuild/utils/git.py
+++ b/src/docbuild/utils/git.py
@@ -31,10 +31,9 @@ class ManagedGitRepo:
         cls._locks.clear()
         cls._is_updated.clear()
 
-    def __init__(self: Self,
-                 remote_url: str,
-                 rootdir: Path,
-                 gitconfig: Path | None = None) -> None:
+    def __init__(
+        self: Self, remote_url: str, rootdir: Path, gitconfig: Path | None = None
+    ) -> None:
         """Initialize the managed repository.
 
         :param remote_url: The remote URL of the repository.
@@ -55,7 +54,7 @@ class ManagedGitRepo:
     def __repr__(self: Self) -> str:
         """Return a string representation of the ManagedGitRepo."""
         return (
-            f'{self.__class__.__name__}(remote_url={self.remote_url!r}, '
+            f"{self.__class__.__name__}(remote_url={self.remote_url!r}, "
             f"bare_repo_path='{self.bare_repo_path!s}')"
         )
 
@@ -85,9 +84,9 @@ class ManagedGitRepo:
         url = self._repo_model.url
         try:
             self.result = await execute_git_command(
-                'clone',
-                '--bare',
-                '--progress',
+                "clone",
+                "--bare",
+                "--progress",
                 str(url),
                 str(self.bare_repo_path),
                 cwd=self._permanent_root,
@@ -122,14 +121,14 @@ class ManagedGitRepo:
         async with self._locks[repo_model]:
             # Re-check the update status after acquiring the lock
             if self._is_updated.get(repo_model, False):
-                log.info('Repository %r already processed this run.', repo_model.name)
+                log.info("Repository %r already processed this run.", repo_model.name)
                 return True
 
             result = False
             if self.bare_repo_path.exists():
                 log.info(
-                    'Repository already exists, fetching updates for %r',
-                    repo_model.name
+                    "Repository already exists, fetching updates for %r",
+                    repo_model.name,
                 )
                 result = await self.fetch_updates()
             else:
@@ -152,20 +151,21 @@ class ManagedGitRepo:
         """Create a temporary worktree from the bare repository."""
         if not self.bare_repo_path.exists():
             raise FileNotFoundError(
-                'Cannot create worktree. Bare repository does not exist at: '
-                f'{self.bare_repo_path}'
+                "Cannot create worktree. Bare repository does not exist at: "
+                f"{self.bare_repo_path}"
             )
 
-        clone_args = ['clone']
+        clone_args = ["clone"]
         if is_local:
-            clone_args.append('--local')
-        clone_args.extend(['--branch', branch])
+            clone_args.append("--local")
+        clone_args.extend(["--branch", branch])
         if options:
             clone_args.extend(options)
         clone_args.extend([str(self.bare_repo_path), str(target_dir)])
 
         self.result = await execute_git_command(
-            *clone_args, cwd=target_dir.parent,
+            *clone_args,
+            cwd=target_dir.parent,
             gitconfig=self._gitconfig,
         )
 
@@ -176,7 +176,7 @@ class ManagedGitRepo:
         """
         if not self.bare_repo_path.exists():
             log.warning(
-                'Cannot fetch updates: Bare repository does not exist at %s',
+                "Cannot fetch updates: Bare repository does not exist at %s",
                 self.bare_repo_path,
             )
             return False
@@ -186,8 +186,12 @@ class ManagedGitRepo:
             # To update *every* branch in the bare Git repo, we need to use
             # this weird 'git fetch' command:
             self.result = await execute_git_command(
-                'fetch', 'origin', '+refs/heads/*:refs/heads/*', '-v', '--prune',
-                cwd=self.bare_repo_path
+                "fetch",
+                "origin",
+                "+refs/heads/*:refs/heads/*",
+                "-v",
+                "--prune",
+                cwd=self.bare_repo_path,
             )
             log.info("Successfully fetched updates for '%s'", self.slug)
             return True

--- a/src/docbuild/utils/merge.py
+++ b/src/docbuild/utils/merge.py
@@ -29,8 +29,8 @@ def _merge_langs(
     :param langs2: Second list of LanguageCode objects.
     :return: Merged sorted list of LanguageCode objects.
     """
-    if '*' in langs1 or '*' in langs2:
-        return [LanguageCode(language='*')]
+    if "*" in langs1 or "*" in langs2:
+        return [LanguageCode(language="*")]
     return sorted(set(chain(langs1, langs2)))  # sorted(set(langs1 + langs2))
 
 
@@ -59,10 +59,10 @@ def _split_wildcard_docset(dt1: Doctype, dt2: Doctype) -> list[Doctype] | None:
     :param dt2: Second Doctype instance.
     :return: List of merged Doctypes or None if no merging is possible.
     """
-    if ('*' in dt1.docset and '*' not in dt2.docset) or (
-        '*' in dt2.docset and '*' not in dt1.docset
+    if ("*" in dt1.docset and "*" not in dt2.docset) or (
+        "*" in dt2.docset and "*" not in dt1.docset
     ):
-        wildcard, specific = (dt1, dt2) if '*' in dt1.docset else (dt2, dt1)
+        wildcard, specific = (dt1, dt2) if "*" in dt1.docset else (dt2, dt1)
         wildcard_langs = set(wildcard.langs)
         specific_langs = set(specific.langs)
         common_langs = wildcard_langs & specific_langs
@@ -71,7 +71,7 @@ def _split_wildcard_docset(dt1: Doctype, dt2: Doctype) -> list[Doctype] | None:
             merged = [
                 Doctype(
                     product=wildcard.product,
-                    docset=['*'],
+                    docset=["*"],
                     lifecycle=wildcard.lifecycle,
                     langs=sorted(common_langs),
                 ),
@@ -80,7 +80,7 @@ def _split_wildcard_docset(dt1: Doctype, dt2: Doctype) -> list[Doctype] | None:
                 merged.append(
                     Doctype(
                         product=specific.product,
-                        docset=[d for d in specific.docset if d != '*'],
+                        docset=[d for d in specific.docset if d != "*"],
                         lifecycle=specific.lifecycle,
                         langs=sorted(extra_langs),
                     ),

--- a/src/docbuild/utils/paths.py
+++ b/src/docbuild/utils/paths.py
@@ -27,7 +27,7 @@ def calc_max_len(files: tuple[Path | str, ...], last_parts: int = -2) -> int:
         path = Path(filepath)
         # Shorten the filename
         if len(path.parts) >= abs(last_parts):
-            shortname = '/'.join(path.parts[last_parts:])
+            shortname = "/".join(path.parts[last_parts:])
         else:
             shortname = str(filepath)
         lengths.append(len(shortname))

--- a/src/docbuild/utils/shell.py
+++ b/src/docbuild/utils/shell.py
@@ -28,7 +28,8 @@ async def run_command(
     # 1. Start the subprocess and connect the pipes
     # We always pipe because we must return the output strings.
     process = await asyncio.create_subprocess_exec(
-        args[0], *args[1:],
+        args[0],
+        *args[1:],
         cwd=cwd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
@@ -41,8 +42,8 @@ async def run_command(
     return CompletedProcess(
         args=args,
         returncode=process.returncode or 0,
-        stdout=bstdout.decode('utf-8').strip(),
-        stderr=bstderr.decode('utf-8').strip(),
+        stdout=bstdout.decode("utf-8").strip(),
+        stderr=bstderr.decode("utf-8").strip(),
     )
 
 
@@ -65,25 +66,25 @@ async def execute_git_command(
     :raises FileNotFoundError: If `cwd` is specified but does not exist.
     """
     if cwd and not cwd.is_dir():
-        raise FileNotFoundError(f'Git working directory not found: {cwd}')
+        raise FileNotFoundError(f"Git working directory not found: {cwd}")
 
     # Determine which config file to use
     gconfig = gitconfig if gitconfig else GIT_CONFIG_FILENAME
 
     # Default Git arguments for consistent behavior
-    git_config_args = ('-c', 'color.ui=never')
-    command = ('git', *git_config_args, *args)
-    log.debug('Executing Git command: %s in %s', ' '.join(command), cwd)
+    git_config_args = ("-c", "color.ui=never")
+    command = ("git", *git_config_args, *args)
+    log.debug("Executing Git command: %s in %s", " ".join(command), cwd)
 
     # Default environment for secure and non-interactive execution
     default_env = {
-        'LANG': 'C',
-        'LC_ALL': 'C',
-        'GIT_TERMINAL_PROMPT': '0',
-        'GIT_PROGRESS_FORCE': '1',
-        'GIT_CONFIG_SYSTEM': '/dev/null',
+        "LANG": "C",
+        "LC_ALL": "C",
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_PROGRESS_FORCE": "1",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
         # 'GIT_CONFIG_NOSYSTEM': '1',  # For older Git versions
-        'GIT_CONFIG_GLOBAL': str(gconfig),
+        "GIT_CONFIG_GLOBAL": str(gconfig),
     }
 
     # Merge environments, allowing kwargs to override defaults
@@ -98,8 +99,8 @@ async def execute_git_command(
 
     if process.returncode != 0:
         raise RuntimeError(
-            f'Git command failed with exit code {process.returncode}: '
-            f'{" ".join(command)}\nStderr: {process.stderr}'
+            f"Git command failed with exit code {process.returncode}: "
+            f"{' '.join(command)}\nStderr: {process.stderr}"
         )
 
     return process

--- a/tests/cli/cmd_build/test_cmd_build.py
+++ b/tests/cli/cmd_build/test_cmd_build.py
@@ -7,11 +7,10 @@ import pytest
 
 from docbuild.cli import callback as callback_module
 from docbuild.cli.callback import validate_doctypes
-from docbuild.cli.cmd_cli import cli
 
 
 def test_validate_doctypes_with_empty_doctypes():
-    cmd = Command('dummy_build')
+    cmd = Command("dummy_build")
     ctx = Context(cmd)
     ctx.obj = SimpleNamespace()
 
@@ -21,28 +20,28 @@ def test_validate_doctypes_with_empty_doctypes():
 
 
 def test_validate_doctypes_abort(monkeypatch):
-    ctx = Context(Command('dummy_build'))
+    ctx = Context(Command("dummy_build"))
     ctx.obj = SimpleNamespace()
 
     def raise_for_invalid(s: str) -> DummyDoctype:
-        if s.startswith('wrong'):
-            raise Abort('is not a valid Product')
+        if s.startswith("wrong"):
+            raise Abort("is not a valid Product")
         return DummyDoctype(s)
 
     monkeypatch.setattr(
         callback_module.Doctype,
-        'from_str',
+        "from_str",
         staticmethod(raise_for_invalid),
     )
 
-    with pytest.raises(Abort, match='is not a valid Product'):
-        validate_doctypes(ctx, None, ('wrong/1/en-us',))
+    with pytest.raises(Abort, match="is not a valid Product"):
+        validate_doctypes(ctx, None, ("wrong/1/en-us",))
 
 
 class DummyDoctype:
     def __init__(self, value):
         self.value = value
-        parts = value.split('/')
+        parts = value.split("/")
         self.product = parts[0]
         self.version = parts[1]
 
@@ -58,38 +57,38 @@ def patch_doctype(monkeypatch):
     # Patch Doctype.from_str to return a DummyDoctype for testing
     monkeypatch.setattr(
         callback_module,
-        'Doctype',
+        "Doctype",
         type(
-            'Doctype',
+            "Doctype",
             (),
             {
-                'from_str': staticmethod(lambda s: DummyDoctype(s)),
-                'model_fields': {
-                    'field': type(
-                        'Field',
+                "from_str": staticmethod(lambda s: DummyDoctype(s)),
+                "model_fields": {
+                    "field": type(
+                        "Field",
                         (),
-                        {'description': 'desc', 'examples': ['ex']},
+                        {"description": "desc", "examples": ["ex"]},
                     )(),
                 },
             },
         ),
     )
     # Patch merge_doctypes to just return the list for simplicity
-    monkeypatch.setattr(callback_module, 'merge_doctypes', lambda *args: list(args))
+    monkeypatch.setattr(callback_module, "merge_doctypes", lambda *args: list(args))
 
 
 def test_validate_doctypes_empty(ctx):
     context = ctx(SimpleNamespace())
     result = validate_doctypes(context, None, ())
     assert result == []
-    assert not hasattr(context.obj, 'doctypes') or context.obj.doctypes == []
+    assert not hasattr(context.obj, "doctypes") or context.obj.doctypes == []
 
 
 def test_validate_doctypes_valid(ctx):
     context = ctx(SimpleNamespace())
-    doctypes = ('foo/1/en-us', 'bar/2/de-de')
+    doctypes = ("foo/1/en-us", "bar/2/de-de")
     result = validate_doctypes(context, None, doctypes)
-    assert result == [DummyDoctype('foo/1/en-us'), DummyDoctype('bar/2/de-de')]
+    assert result == [DummyDoctype("foo/1/en-us"), DummyDoctype("bar/2/de-de")]
     assert context.obj.doctypes == result
 
 
@@ -99,40 +98,40 @@ def test_validate_doctypes_invalid(monkeypatch, ctx):
     # Patch Doctype.from_str to raise ValidationError
     class DummyValidationError(Exception):
         def errors(self):
-            return [{'loc': ['field'], 'msg': 'bad', 'type': 'value_error'}]
+            return [{"loc": ["field"], "msg": "bad", "type": "value_error"}]
 
     monkeypatch.setattr(
         callback_module,
-        'Doctype',
+        "Doctype",
         type(
-            'Doctype',
+            "Doctype",
             (),
             {
-                'from_str': staticmethod(
+                "from_str": staticmethod(
                     lambda s: (_ for _ in ()).throw(Abort()),
                 ),
-                'model_fields': {
-                    'field': type(
-                        'Field',
+                "model_fields": {
+                    "field": type(
+                        "Field",
                         (),
-                        {'description': 'desc', 'examples': ['ex']},
+                        {"description": "desc", "examples": ["ex"]},
                     )(),
                 },
             },
         ),
     )
     with pytest.raises(click.Abort):
-        validate_doctypes(context, None, ('bad/doctype',))
+        validate_doctypes(context, None, ("bad/doctype",))
 
 
 @pytest.mark.parametrize(
-    'doctypes,expected',
+    "doctypes,expected",
     [
         (tuple(), []),
-        (('sles/15-SP6/en-us',), [DummyDoctype('sles/15-SP6/en-us')]),
+        (("sles/15-SP6/en-us",), [DummyDoctype("sles/15-SP6/en-us")]),
         (
-            ('sles/15-SP6/en-us', 'suma/4.3/de-de'),
-            [DummyDoctype('sles/15-SP6/en-us'), DummyDoctype('suma/4.3/de-de')],
+            ("sles/15-SP6/en-us", "suma/4.3/de-de"),
+            [DummyDoctype("sles/15-SP6/en-us"), DummyDoctype("suma/4.3/de-de")],
         ),
     ],
 )
@@ -154,32 +153,32 @@ def test_validate_doctypes_validation_error(monkeypatch, ctx, capsys):
         def errors(self):
             return [
                 {
-                    'loc': ['product'],
-                    'msg': 'Invalid product name',
-                    'type': 'value_error',
+                    "loc": ["product"],
+                    "msg": "Invalid product name",
+                    "type": "value_error",
                 },
             ]
 
     def mock_from_str(s: str):
-        if s.startswith('invalid'):
+        if s.startswith("invalid"):
             raise MockValidationError()
         return DummyDoctype(s)
 
     # Patch necessary methods
-    monkeypatch.setattr(callback_module, 'ValidationError', MockValidationError)
+    monkeypatch.setattr(callback_module, "ValidationError", MockValidationError)
     monkeypatch.setattr(
-        callback_module.Doctype, 'from_str', staticmethod(mock_from_str)
+        callback_module.Doctype, "from_str", staticmethod(mock_from_str)
     )
     monkeypatch.setattr(
         callback_module.Doctype,
-        'model_fields',
+        "model_fields",
         {
-            'product': type(
-                'Field',
+            "product": type(
+                "Field",
                 (),
                 {
-                    'description': 'Product name must be alphanumeric',
-                    'examples': ['sles', 'suma'],
+                    "description": "Product name must be alphanumeric",
+                    "examples": ["sles", "suma"],
                 },
             )(),
         },
@@ -187,18 +186,18 @@ def test_validate_doctypes_validation_error(monkeypatch, ctx, capsys):
 
     # Test that the function properly aborts and formats error messages
     with pytest.raises(click.Abort):
-        validate_doctypes(context, None, ('invalid/product/en-us',))
+        validate_doctypes(context, None, ("invalid/product/en-us",))
 
     captured = capsys.readouterr()
     assert "ERROR in 'product': Invalid product name" in captured.err
-    assert 'Hint: Product name must be alphanumeric' in captured.out
-    assert 'Examples: sles, suma' in captured.out
+    assert "Hint: Product name must be alphanumeric" in captured.out
+    assert "Examples: sles, suma" in captured.out
 
 
 def test_validate_doctypes_merge_called(monkeypatch, ctx):
     """Test that merge_doctypes is called with the correct arguments."""
     context = ctx(SimpleNamespace())
-    doctypes = ('sles/15/en-us', 'suma/4.3/de-de')
+    doctypes = ("sles/15/en-us", "suma/4.3/de-de")
 
     # Track merge_doctypes calls
     mock_merge_called_with = []
@@ -208,7 +207,7 @@ def test_validate_doctypes_merge_called(monkeypatch, ctx):
         mock_merge_called_with = args
         return list(args)
 
-    monkeypatch.setattr(callback_module, 'merge_doctypes', mock_merge)
+    monkeypatch.setattr(callback_module, "merge_doctypes", mock_merge)
 
     validate_doctypes(context, None, doctypes)
 
@@ -216,51 +215,51 @@ def test_validate_doctypes_merge_called(monkeypatch, ctx):
     assert len(mock_merge_called_with) == 2
     assert all(isinstance(dt, DummyDoctype) for dt in mock_merge_called_with)
     assert [dt.value for dt in mock_merge_called_with] == [
-        'sles/15/en-us',
-        'suma/4.3/de-de',
+        "sles/15/en-us",
+        "suma/4.3/de-de",
     ]
 
 
 def test_validate_doctypes_echo_outputs(ctx):
     """Test the echo statements in validate_doctypes."""
     context = ctx(SimpleNamespace(verbose=1))
-    result = validate_doctypes(context, None, ('sles/15/en-us',))
+    result = validate_doctypes(context, None, ("sles/15/en-us",))
 
-    assert result[0].value == 'sles/15/en-us'
+    assert result[0].value == "sles/15/en-us"
 
 
 def test_validate_doctypes_full_error_message(monkeypatch, capsys):
     def mock_validation_error(*args, **kwargs):
         raise ValidationError.from_exception_data(
-            'Mock validation error',
+            "Mock validation error",
             [
                 {
-                    'type': 'string_type',
-                    'loc': ('product', 'foo'),
-                    'input': 4,
-                    'ctx': {'gt': 5},
+                    "type": "string_type",
+                    "loc": ("product", "foo"),
+                    "input": 4,
+                    "ctx": {"gt": 5},
                 },
             ],
         )
 
     monkeypatch.setattr(
         callback_module.Doctype,
-        'model_fields',
+        "model_fields",
         {
-            'product': Field(
-                title='Product',
-                description='A product name is a lowercase acronym.',
-                examples=['alpha', 'beta'],
+            "product": Field(
+                title="Product",
+                description="A product name is a lowercase acronym.",
+                examples=["alpha", "beta"],
             ),
         },
     )
-    monkeypatch.setattr(callback_module.Doctype, 'from_str', mock_validation_error)
+    monkeypatch.setattr(callback_module.Doctype, "from_str", mock_validation_error)
 
-    with pytest.raises(click.Abort, match=r'Mock validation error'):
+    with pytest.raises(click.Abort, match=r"Mock validation error"):
         validate_doctypes(
-            click.Context(click.Command('dummy')),
+            click.Context(click.Command("dummy")),
             None,
-            ('foo/bar',),
+            ("foo/bar",),
         )
 
     # Capture output after the function call
@@ -274,38 +273,38 @@ def test_validate_doctypes_full_error_message(monkeypatch, capsys):
 def test_validate_doctypes_only_hint_error_message(monkeypatch, capsys):
     def mock_validation_error(*args, **kwargs):
         raise ValidationError.from_exception_data(
-            'Mock validation error',
+            "Mock validation error",
             [
                 {
-                    'type': 'string_type',
-                    'loc': ('product', 'foo'),
-                    'input': 4,
-                    'ctx': {'gt': 5},
+                    "type": "string_type",
+                    "loc": ("product", "foo"),
+                    "input": 4,
+                    "ctx": {"gt": 5},
                 },
             ],
         )
 
     monkeypatch.setattr(
         callback_module.Doctype,
-        'model_fields',
+        "model_fields",
         {
-            'product': type(
-                'Field',
+            "product": type(
+                "Field",
                 (),
                 {
-                    'description': 'A product name is a lowercase acronym.',
+                    "description": "A product name is a lowercase acronym.",
                     # no examples provided
                 },
             )(),
         },
     )
-    monkeypatch.setattr(callback_module.Doctype, 'from_str', mock_validation_error)
+    monkeypatch.setattr(callback_module.Doctype, "from_str", mock_validation_error)
 
-    with pytest.raises(click.Abort, match=r'Mock validation error'):
+    with pytest.raises(click.Abort, match=r"Mock validation error"):
         validate_doctypes(
-            click.Context(click.Command('dummy')),
+            click.Context(click.Command("dummy")),
             None,
-            ('foo/bar',),
+            ("foo/bar",),
         )
 
     # Capture output after the function call
@@ -318,38 +317,38 @@ def test_validate_doctypes_only_hint_error_message(monkeypatch, capsys):
 def test_validate_doctypes_only_description_error_message(monkeypatch, capsys):
     def mock_validation_error(*args, **kwargs):
         raise ValidationError.from_exception_data(
-            'Mock validation error',
+            "Mock validation error",
             [
                 {
-                    'type': 'string_type',
-                    'loc': ('product', 'foo'),
-                    'input': 4,
-                    'ctx': {'gt': 5},
+                    "type": "string_type",
+                    "loc": ("product", "foo"),
+                    "input": 4,
+                    "ctx": {"gt": 5},
                 },
             ],
         )
 
     monkeypatch.setattr(
         callback_module.Doctype,
-        'model_fields',
+        "model_fields",
         {
-            'product': type(
-                'Field',
+            "product": type(
+                "Field",
                 (),
                 {
                     # no description provided
-                    'examples': ['alpha', 'beta'],
+                    "examples": ["alpha", "beta"],
                 },
             )(),
         },
     )
-    monkeypatch.setattr(callback_module.Doctype, 'from_str', mock_validation_error)
+    monkeypatch.setattr(callback_module.Doctype, "from_str", mock_validation_error)
 
-    with pytest.raises(click.Abort, match=r'Mock validation error'):
+    with pytest.raises(click.Abort, match=r"Mock validation error"):
         validate_doctypes(
-            click.Context(click.Command('dummy')),
+            click.Context(click.Command("dummy")),
             None,
-            ('foo/bar',),
+            ("foo/bar",),
         )
 
     # Capture output after the function call

--- a/tests/cli/cmd_config/test_application.py
+++ b/tests/cli/cmd_config/test_application.py
@@ -4,8 +4,8 @@ from docbuild.cli.cmd_config.application import app
 
 
 def test_config_app(context, runner):
-    context.appconfigfiles = ['/tmp/app1.toml', '/tmp/app2.toml']
-    context.appconfig = {'foo': 'bar', 'baz': [1, 2, 3]}
+    context.appconfigfiles = ["/tmp/app1.toml", "/tmp/app2.toml"]
+    context.appconfig = {"foo": "bar", "baz": [1, 2, 3]}
 
     # Run the command with the fake context
     result = runner.invoke(app, obj=context)
@@ -16,43 +16,43 @@ def test_config_app(context, runner):
     )
 
     lines = result.output.splitlines()
-    pretty_dict_str = '\n'.join(lines[1:]).strip()
+    pretty_dict_str = "\n".join(lines[1:]).strip()
     # Convert to dict
     output_dict = ast.literal_eval(pretty_dict_str)
-    assert output_dict == {'foo': 'bar', 'baz': [1, 2, 3]}
+    assert output_dict == {"foo": "bar", "baz": [1, 2, 3]}
 
 
 def test_config_app_no_config_files(context, runner):
     """Test the app command when no config files are provided."""
     context.appconfigfiles = []  # Empty list
-    context.appconfig = {'default': 'config'}
+    context.appconfig = {"default": "config"}
 
     # Run the command with the fake context
     result = runner.invoke(app, obj=context)
 
     assert result.exit_code == 0
-    assert '# No application config files provided' in result.output
+    assert "# No application config files provided" in result.output
 
     lines = result.output.splitlines()
-    pretty_dict_str = '\n'.join(lines[1:]).strip()
+    pretty_dict_str = "\n".join(lines[1:]).strip()
     # Convert to dict
     output_dict = ast.literal_eval(pretty_dict_str)
-    assert output_dict == {'default': 'config'}
+    assert output_dict == {"default": "config"}
 
 
 def test_config_app_none_config_files(context, runner):
     """Test the app command when appconfigfiles is None."""
     context.appconfigfiles = None  # None value
-    context.appconfig = {'empty': 'state'}
+    context.appconfig = {"empty": "state"}
 
     # Run the command with the fake context
     result = runner.invoke(app, obj=context)
 
     assert result.exit_code == 0
-    assert '# No application config files provided' in result.output
+    assert "# No application config files provided" in result.output
 
     lines = result.output.splitlines()
-    pretty_dict_str = '\n'.join(lines[1:]).strip()
+    pretty_dict_str = "\n".join(lines[1:]).strip()
     # Convert to dict
     output_dict = ast.literal_eval(pretty_dict_str)
-    assert output_dict == {'empty': 'state'}
+    assert output_dict == {"empty": "state"}

--- a/tests/cli/cmd_config/test_config.py
+++ b/tests/cli/cmd_config/test_config.py
@@ -1,10 +1,6 @@
 
-from unittest.mock import Mock
-
 import pytest
-import click
 
-from docbuild.cli.cmd_cli import cli
 
 @pytest.mark.skip(reason="CLI help test is unstable due to initialization context.")
 def test_placeholder_for_config_help():

--- a/tests/cli/cmd_metadata/test_cmd_metadata.py
+++ b/tests/cli/cmd_metadata/test_cmd_metadata.py
@@ -32,13 +32,13 @@ def mock_envconfig(tmp_path: Path) -> Mock:
     nested configurations like `env.paths.repo_dir` and `env.build.daps.meta`.
     """
     mock_paths = Mock()
-    mock_paths.repo_dir = tmp_path / 'repos'
-    mock_paths.base_cache_dir = tmp_path / 'cache'
-    mock_paths.meta_cache_dir = tmp_path / 'cache' / 'metadata'
-    mock_paths.temp_repo_dir = tmp_path / 'temp_repos'
+    mock_paths.repo_dir = tmp_path / "repos"
+    mock_paths.base_cache_dir = tmp_path / "cache"
+    mock_paths.meta_cache_dir = tmp_path / "cache" / "metadata"
+    mock_paths.temp_repo_dir = tmp_path / "temp_repos"
 
     mock_build = Mock()
-    mock_build.daps.meta = 'daps-command-template'
+    mock_build.daps.meta = "daps-command-template"
 
     mock_envconfig = Mock()
     mock_envconfig.paths = mock_paths
@@ -55,11 +55,11 @@ def xmlconfig(request) -> etree.ElementTree:
     If used without, it provides a default empty <config/> tree.
     """
     xml_string = None
-    if hasattr(request, 'param'):
+    if hasattr(request, "param"):
         xml_string = request.param
 
     if not xml_string:
-        xml_string = '<docservconfig/>'
+        xml_string = "<docservconfig/>"
     root = etree.fromstring(xml_string)
     return etree.ElementTree(root)
 
@@ -74,13 +74,13 @@ def mock_context_with_config_dir(
     for scenarios requiring a `config_dir` and `tmp.tmp_metadata_dir`.
     """
     context = Mock(spec=DocBuildContext)
-    config_dir = tmp_path / 'config'
-    tmp_metadata_dir = tmp_path / 'tmp' / 'metadata'
+    config_dir = tmp_path / "config"
+    tmp_metadata_dir = tmp_path / "tmp" / "metadata"
 
     config_dir.mkdir()
     tmp_metadata_dir.mkdir(parents=True)
 
-    (config_dir / 'dummy.xml').write_text('<docservconfig/>')
+    (config_dir / "dummy.xml").write_text("<docservconfig/>")
 
     # Customize the mock_envconfig for this fixture's needs
     mock_envconfig.paths.config_dir = config_dir
@@ -101,48 +101,105 @@ def mock_context_with_config_dir(
         (
             """
             <docservconfig>
-              <product productid="sles"><docset setid="15-sp6"><builddocs><language lang="en-us">
-                <deliverable><dc>DC-SLE-Micro-5.5-admin</dc><format html="1"/></deliverable>
-              </language></builddocs></docset></product>
-              <product productid="other"><docset setid="1.0"><builddocs><language lang="en-us">
-                <deliverable><dc>DC-Micro-5.4-cockpit</dc><format html="1"/></deliverable>
-                <deliverable><dc>DC-Micro-5.5-cockpit</dc><format html="1"/></deliverable>
-              </language></builddocs></docset></product>
+              <product productid="sles">
+                <docset setid="15-sp6">
+                  <builddocs>
+                    <language lang="en-us">
+                        <deliverable>
+                            <dc>DC-SLE-Micro-5.5-admin</dc>
+                            <format html="1"/>
+                        </deliverable>
+                    </language>
+                  </builddocs>
+                </docset>
+              </product>
+              <product productid="other">
+                <docset setid="1.0">
+                   <builddocs>
+                     <language lang="en-us">
+                        <deliverable>
+                            <dc>DC-Micro-5.4-cockpit</dc>
+                            <format html="1"/>
+                        </deliverable>
+                        <deliverable>
+                            <dc>DC-Micro-5.5-cockpit</dc>
+                            <format html="1"/>
+                        </deliverable>
+                    </language>
+                   </builddocs>
+                </docset>
+              </product>
             </docservconfig>
             """,
-            "sles/15-sp6/en-us", 1, {'sles/15-sp6/en-us:DC-SLE-Micro-5.5-admin'}
+            "sles/15-sp6/en-us",
+            1,
+            {"sles/15-sp6/en-us:DC-SLE-Micro-5.5-admin"},
         ),
         (
             """
             <docservconfig>
-              <product productid="sles"><docset setid="15-sp6"><builddocs><language lang="en-us">
-                <deliverable><dc>DC-SLE-Micro-5.5-admin</dc><format html="1"/></deliverable>
-              </language></builddocs></docset></product>
-              <product productid="other"><docset setid="1.0"><builddocs><language lang="en-us">
-                <deliverable><dc>DC-Micro-5.4-cockpit</dc><format html="1"/></deliverable>
-              </language></builddocs></docset></product>
+              <product productid="sles">
+                <docset setid="15-sp6">
+                    <builddocs>
+                        <language lang="en-us">
+                            <deliverable>
+                                <dc>DC-SLE-Micro-5.5-admin</dc>
+                                <format html="1"/>
+                            </deliverable>
+                        </language>
+                    </builddocs>
+                </docset>
+              </product>
+              <product productid="other">
+              <docset setid="1.0">
+                  <builddocs>
+                    <language lang="en-us">
+                      <deliverable>
+                        <dc>DC-Micro-5.4-cockpit</dc>
+                        <format html="1"/>
+                      </deliverable>
+                    </language>
+                  </builddocs>
+                </docset>
+              </product>
             </docservconfig>
             """,
-            "//en-us", 2, {'other/1.0/en-us:DC-Micro-5.4-cockpit', 'sles/15-sp6/en-us:DC-SLE-Micro-5.5-admin'}
+            "//en-us",
+            2,
+            {
+                "other/1.0/en-us:DC-Micro-5.4-cockpit",
+                "sles/15-sp6/en-us:DC-SLE-Micro-5.5-admin",
+            },
         ),
+        ("<docservconfig/>", "nonexistent/1.0/en-us", 0, set()),
         (
-            "<docservconfig/>", "nonexistent/1.0/en-us", 0, set()
-        ),
-        (
-            "<docservconfig><product productid='sles'><docset setid='15-sp6'/></product></docservconfig>",
-            "sles/15-sp6/de-de", 0, set()
+            """<docservconfig>
+                 <product productid='sles'>
+                    <docset setid='15-sp6'/>
+                 </product>
+               </docservconfig>""",
+            "sles/15-sp6/de-de",
+            0,
+            set(),
         ),
     ],
     indirect=["xmlconfig"],
-    ids=["specific_doctype", "wildcard_doctype", "nonexistent_product", "nonexistent_lang"]
+    ids=[
+        "specific_doctype",
+        "wildcard_doctype",
+        "nonexistent_product",
+        "nonexistent_lang",
+    ],
 )
-def test_get_deliverable_from_doctype(xmlconfig, doctype_str, expected_count, expected_ids):
+def test_get_deliverable_from_doctype(
+    xmlconfig, doctype_str, expected_count, expected_ids
+):
     """Verify deliverables are correctly extracted for various doctypes."""
     # Arrange & Act
     if "nonexistent" in doctype_str:
         with pytest.raises(ValueError):
             Doctype.from_str(doctype_str)
-        return # Test passes if validation error is raised
+        return  # Test passes if validation error is raised
     else:
         doctype = Doctype.from_str(doctype_str)
 
@@ -178,7 +235,7 @@ def deliverable() -> Deliverable:
     </docservconfig>
     """
     root = etree.fromstring(xml_string)
-    deliverable_node = root.find('.//deliverable')
+    deliverable_node = root.find(".//deliverable")
     return Deliverable(deliverable_node)
 
 
@@ -188,12 +245,12 @@ def stitchnode(deliverable: Deliverable) -> etree._ElementTree:
 
     Provides the common product/docset/name/acronym structure used by tests.
     """
-    prod_node = etree.Element('product', productid=deliverable.productid)
-    name_el = etree.SubElement(prod_node, 'name')
-    name_el.text = 'SUSE Linux Enterprise Server'
-    etree.SubElement(prod_node, 'acronym').text = 'SLES'
-    etree.SubElement(prod_node, 'docset', setid=deliverable.docsetid)
-    root = etree.Element('docservconfig')
+    prod_node = etree.Element("product", productid=deliverable.productid)
+    name_el = etree.SubElement(prod_node, "name")
+    name_el.text = "SUSE Linux Enterprise Server"
+    etree.SubElement(prod_node, "acronym").text = "SLES"
+    etree.SubElement(prod_node, "docset", setid=deliverable.docsetid)
+    root = etree.Element("docservconfig")
     root.append(prod_node)
     return etree.ElementTree(root)
 
@@ -206,7 +263,9 @@ class TestProcessDeliverable:
     def mock_subprocess(self) -> Iterator[AsyncMock]:
         """Fixture to mock asyncio.create_subprocess_exec."""
         # 'docbuild.cli.cmd_metadata.asyncio.create_subprocess_exec',
-        with patch.object(metaprocess_pkg.asyncio, 'create_subprocess_exec',
+        with patch.object(
+            metaprocess_pkg.asyncio,
+            "create_subprocess_exec",
             new_callable=AsyncMock,
         ) as mock:
             yield mock
@@ -215,10 +274,10 @@ class TestProcessDeliverable:
     def setup_paths(self, tmp_path: Path, deliverable: Deliverable) -> dict:
         """Set up common paths and directories for tests."""
         paths = {
-            'repo_dir': tmp_path / 'repos',
-            'temp_repo_dir': tmp_path / 'temp_repos',
-            'base_cache_dir': tmp_path / 'cache',
-            'meta_cache_dir': tmp_path / 'cache' / 'metadata',
+            "repo_dir": tmp_path / "repos",
+            "temp_repo_dir": tmp_path / "temp_repos",
+            "base_cache_dir": tmp_path / "cache",
+            "meta_cache_dir": tmp_path / "cache" / "metadata",
         }
         for path in paths.values():
             path.mkdir(parents=True, exist_ok=True)
@@ -238,30 +297,35 @@ class TestProcessDeliverable:
             ),
             (
                 "bare_repo_not_found",
-                lambda mocks: mocks['managed_git_repo'].side_effect,
+                lambda mocks: mocks["managed_git_repo"].side_effect,
                 False,
                 "Bare repository not found",
             ),
             (
                 "clone_fails",
-                lambda mocks: setattr(mocks['repo_instance'], 'clone_bare', AsyncMock(return_value=False)),
+                lambda mocks: setattr(
+                    mocks["repo_instance"], "clone_bare", AsyncMock(return_value=False)
+                ),
                 False,
                 "Failed to ensure bare repository",
             ),
             (
                 "daps_fails",
-                lambda mocks: mocks['subprocess'].__setattr__(
-                    'return_value',
-                    AsyncMock(returncode=1, communicate=AsyncMock(return_value=(b'', b'DAPS Error'))),
+                lambda mocks: mocks["subprocess"].__setattr__(
+                    "return_value",
+                    AsyncMock(
+                        returncode=1,
+                        communicate=AsyncMock(return_value=(b"", b"DAPS Error")),
+                    ),
                 ),
                 False,
                 "Error processing",
             ),
         ],
-        ids=["success", "bare_repo_not_found", "clone_fails", "daps_fails"]
+        ids=["success", "bare_repo_not_found", "clone_fails", "daps_fails"],
     )
-    @patch.object(metaprocess_pkg, 'edit_json')
-    @patch.object(metaprocess_pkg, 'ManagedGitRepo')
+    @patch.object(metaprocess_pkg, "edit_json")
+    @patch.object(metaprocess_pkg, "ManagedGitRepo")
     async def test_process_deliverable_scenarios(
         self,
         mock_managed_git_repo: Mock,
@@ -283,22 +347,26 @@ class TestProcessDeliverable:
         mock_repo_instance.create_worktree.return_value = None
 
         mock_daps_proc = AsyncMock()
-        mock_daps_proc.communicate.return_value = (b'', b'')
+        mock_daps_proc.communicate.return_value = (b"", b"")
         mock_daps_proc.returncode = 0
         mock_subprocess.return_value = mock_daps_proc
 
-        mock_json_data = {'docs': [{'format': {}, 'lang': ''}]}
+        mock_json_data = {"docs": [{"format": {}, "lang": ""}]}
         mock_edit_json.return_value.__aenter__.return_value = mock_json_data
         mock_edit_json.return_value.__enter__.return_value = mock_json_data
 
         # Dynamically set up mocks for the specific scenario
-        mocks = {'managed_git_repo': mock_managed_git_repo, 'repo_instance': mock_repo_instance, 'subprocess': mock_subprocess}
+        mocks = {
+            "managed_git_repo": mock_managed_git_repo,
+            "repo_instance": mock_repo_instance,
+            "subprocess": mock_subprocess,
+        }
         setup_mocks(mocks)
 
         if scenario != "bare_repo_not_found":
-            (setup_paths['repo_dir'] / deliverable.git.slug).mkdir()
+            (setup_paths["repo_dir"] / deliverable.git.slug).mkdir()
 
-        dapstmpl = 'daps --dc-file={dcfile} --output={output}'
+        dapstmpl = "daps --dc-file={dcfile} --output={output}"
 
         # Act
         result = await process_deliverable(
@@ -326,10 +394,10 @@ class TestProcessDoctype:
     @pytest.fixture
     def mock_root(self) -> etree._ElementTree:
         """Provide a mock XML root element for testing."""
-        return etree.ElementTree(etree.fromstring('<docservconfig/>'))
+        return etree.ElementTree(etree.fromstring("<docservconfig/>"))
 
-    @patch.object(metaprocess_pkg, 'process_deliverable', new_callable=AsyncMock)
-    @patch.object(metaprocess_pkg, 'get_deliverable_from_doctype')
+    @patch.object(metaprocess_pkg, "process_deliverable", new_callable=AsyncMock)
+    @patch.object(metaprocess_pkg, "get_deliverable_from_doctype")
     async def test_success_with_deliverables(
         self,
         mock_get_deliverables: Mock,
@@ -338,12 +406,12 @@ class TestProcessDoctype:
         mock_context: DocBuildContext,
     ):
         """Test successful processing when deliverables are found."""
-        doctype = Doctype.from_str('sles/15/en-us')
+        doctype = Doctype.from_str("sles/15/en-us")
         # Correctly mock the nested git.url attribute
-        mock_deliverable = Mock(spec=Deliverable, git=Mock(spec=Repo, url='gh://SUSE/doc-test'))
-        mock_deliverables = [
-            mock_deliverable, mock_deliverable
-        ]
+        mock_deliverable = Mock(
+            spec=Deliverable, git=Mock(spec=Repo, url="gh://SUSE/doc-test")
+        )
+        mock_deliverables = [mock_deliverable, mock_deliverable]
         mock_get_deliverables.return_value = mock_deliverables
         # Ensure the mock returns an awaitable result
         mock_process_deliverable.return_value = True
@@ -356,8 +424,8 @@ class TestProcessDoctype:
         mock_get_deliverables.assert_called_once_with(mock_root, doctype)
         assert mock_process_deliverable.call_count == 2
 
-    @patch.object(metaprocess_pkg, 'process_deliverable', new_callable=AsyncMock)
-    @patch.object(metaprocess_pkg, 'get_deliverable_from_doctype')
+    @patch.object(metaprocess_pkg, "process_deliverable", new_callable=AsyncMock)
+    @patch.object(metaprocess_pkg, "get_deliverable_from_doctype")
     async def test_no_deliverables_found(
         self,
         mock_get_deliverables: Mock,
@@ -366,7 +434,7 @@ class TestProcessDoctype:
         mock_context: DocBuildContext,
     ):
         """Test behavior when no deliverables are found for the doctype."""
-        doctype = Doctype.from_str('sles/15/en-us')
+        doctype = Doctype.from_str("sles/15/en-us")
         mock_get_deliverables.return_value = []
 
         result = await process_doctype(mock_root, mock_context, doctype)
@@ -375,29 +443,32 @@ class TestProcessDoctype:
         mock_get_deliverables.assert_called_once_with(mock_root, doctype)
         mock_process_deliverable.assert_not_called()
 
-    @patch.object(metaprocess_pkg, 'get_deliverable_from_doctype')
+    @patch.object(metaprocess_pkg, "get_deliverable_from_doctype")
     async def test_missing_paths_in_config_raises_error(
-        self, mock_get_deliverables: Mock, mock_root: etree._ElementTree
-        , mock_envconfig: Mock):
+        self,
+        mock_get_deliverables: Mock,
+        mock_root: etree._ElementTree,
+        mock_envconfig: Mock,
+    ):
         """Test that an AttributeError is raised if required paths are missing."""
-        doctype = Doctype.from_str('sles/15/en-us')
+        doctype = Doctype.from_str("sles/15/en-us")
         mock_get_deliverables.return_value = [Mock(spec=Deliverable)]
         context_missing_path = Mock(spec=DocBuildContext)
 
         # Use the mock_envconfig and then delete the attribute to simulate missing
         del mock_envconfig.paths.repo_dir
         # Ensure other paths are set, even if repo_dir is missing
-        mock_envconfig.paths.base_cache_dir = Path('/fake/cache')
-        mock_envconfig.paths.meta_cache_dir = Path('/fake/cache/meta')
-        mock_envconfig.paths.temp_repo_dir = Path('/fake/temp')
+        mock_envconfig.paths.base_cache_dir = Path("/fake/cache")
+        mock_envconfig.paths.meta_cache_dir = Path("/fake/cache/meta")
+        mock_envconfig.paths.temp_repo_dir = Path("/fake/temp")
         context_missing_path.envconfig = mock_envconfig
 
         with pytest.raises(AttributeError):
             await process_doctype(mock_root, context_missing_path, doctype)
 
-    @patch.object(metaprocess_pkg, 'process_deliverable', new_callable=AsyncMock)
-    @patch.object(metaprocess_pkg, 'get_deliverable_from_doctype')
-    @patch.object(metaprocess_pkg, 'update_repositories', new_callable=AsyncMock)
+    @patch.object(metaprocess_pkg, "process_deliverable", new_callable=AsyncMock)
+    @patch.object(metaprocess_pkg, "get_deliverable_from_doctype")
+    @patch.object(metaprocess_pkg, "update_repositories", new_callable=AsyncMock)
     async def test_exitfirst_fails_fast(
         self,
         mock_update_repositories: AsyncMock,
@@ -407,18 +478,18 @@ class TestProcessDoctype:
         mock_context: DocBuildContext,
     ):
         """When `exitfirst=True`, process_doctype should stop on first failure."""
-        doctype = Doctype.from_str('sles/15/en-us')
+        doctype = Doctype.from_str("sles/15/en-us")
 
         # Create two mock deliverables
         d1 = Mock(spec=Deliverable)
-        d1.full_id = 'sles/15/en-us:DC-ONE'
+        d1.full_id = "sles/15/en-us:DC-ONE"
         d2 = Mock(spec=Deliverable)
-        d2.full_id = 'sles/15-en-us:DC-TWO'
+        d2.full_id = "sles/15-en-us:DC-TWO"
 
         mock_get_deliverables.return_value = [d1, d2]
 
         # First call returns a failing tuple, second would be successful
-        mock_process_deliverable.side_effect = [ (False, d1), (True, d2) ]
+        mock_process_deliverable.side_effect = [(False, d1), (True, d2)]
 
         # Prevent update_repositories from attempting real repo work
         mock_update_repositories.return_value = None
@@ -433,10 +504,10 @@ class TestProcessDoctype:
 class TestProcessEmptyDoctypes:
     """Tests for the case when no doctypes are passed to process."""
 
-    @patch.object(metaprocess_pkg, 'store_productdocset_json', new_callable=Mock)
-    @patch.object(metaprocess_pkg, 'collect_files_flat', new_callable=Mock)
-    @patch.object(metaprocess_pkg, 'create_stitchfile', new_callable=AsyncMock)
-    @patch.object(metaprocess_pkg, 'process_doctype', new_callable=AsyncMock)
+    @patch.object(metaprocess_pkg, "store_productdocset_json", new_callable=Mock)
+    @patch.object(metaprocess_pkg, "collect_files_flat", new_callable=Mock)
+    @patch.object(metaprocess_pkg, "create_stitchfile", new_callable=AsyncMock)
+    @patch.object(metaprocess_pkg, "process_doctype", new_callable=AsyncMock)
     async def test_process_empty_doctypes(
         self,
         mock_process_doctype: AsyncMock,
@@ -467,7 +538,7 @@ class TestProcessEmptyDoctypes:
         mock_create_stitchfile.return_value = mock_stitch_node
 
         mock_collect_files_flat.return_value = [
-            (Doctype.from_str(DEFAULT_DELIVERABLES), '*', [Path('dummy.xml')])
+            (Doctype.from_str(DEFAULT_DELIVERABLES), "*", [Path("dummy.xml")])
         ]
 
         await process(mock_context_with_config_dir, doctypes=())
@@ -479,10 +550,10 @@ class TestProcessEmptyDoctypes:
         # Assert that store_productdocset_json was called
         mock_store_json.assert_called()
 
-    @patch.object(metaprocess_pkg, 'store_productdocset_json', new_callable=Mock)
-    @patch.object(metaprocess_pkg, 'collect_files_flat', new_callable=Mock)
-    @patch.object(metaprocess_pkg, 'create_stitchfile', new_callable=AsyncMock)
-    @patch.object(metaprocess_pkg, 'process_doctype', new_callable=AsyncMock)
+    @patch.object(metaprocess_pkg, "store_productdocset_json", new_callable=Mock)
+    @patch.object(metaprocess_pkg, "collect_files_flat", new_callable=Mock)
+    @patch.object(metaprocess_pkg, "create_stitchfile", new_callable=AsyncMock)
+    @patch.object(metaprocess_pkg, "process_doctype", new_callable=AsyncMock)
     async def test_no_doctypes_uses_default(
         self,
         mock_process_doctype: AsyncMock,
@@ -511,11 +582,11 @@ class TestProcessEmptyDoctypes:
         mock_create_stitchfile.return_value = mock_stitch_node
         mock_process_doctype.return_value = []
         mock_collect_files_flat.return_value = [
-            (Doctype.from_str(DEFAULT_DELIVERABLES), '*', [Path('dummy.xml')])
+            (Doctype.from_str(DEFAULT_DELIVERABLES), "*", [Path("dummy.xml")])
         ]
 
         # Act and suppress console output during the test
-        with patch.object(metaprocess_pkg, 'stdout'):
+        with patch.object(metaprocess_pkg, "stdout"):
             result = await process(mock_context_with_config_dir, doctypes=tuple())
 
         # Assert
@@ -524,13 +595,17 @@ class TestProcessEmptyDoctypes:
         mock_store_json.assert_called()
         default_doctype = Doctype.from_str(DEFAULT_DELIVERABLES)
         mock_process_doctype.assert_awaited_once_with(
-            mock_stitch_node, mock_context_with_config_dir, default_doctype, exitfirst=False, skip_repo_update=False
+            mock_stitch_node,
+            mock_context_with_config_dir,
+            default_doctype,
+            exitfirst=False,
+            skip_repo_update=False,
         )
 
-    @patch.object(metaprocess_pkg, 'store_productdocset_json', new_callable=Mock)
-    @patch.object(metaprocess_pkg, 'collect_files_flat', new_callable=Mock)
-    @patch.object(metaprocess_pkg, 'create_stitchfile', new_callable=AsyncMock)
-    @patch.object(metaprocess_pkg, 'process_doctype', new_callable=AsyncMock)
+    @patch.object(metaprocess_pkg, "store_productdocset_json", new_callable=Mock)
+    @patch.object(metaprocess_pkg, "collect_files_flat", new_callable=Mock)
+    @patch.object(metaprocess_pkg, "create_stitchfile", new_callable=AsyncMock)
+    @patch.object(metaprocess_pkg, "process_doctype", new_callable=AsyncMock)
     async def test_process_reports_failed_deliverables_and_returns_one(
         self,
         mock_process_doctype: AsyncMock,
@@ -551,14 +626,17 @@ class TestProcessEmptyDoctypes:
 
         # Simulate a failing deliverable returned by process_doctype
         mock_deliverable = Mock(spec=Deliverable)
-        mock_deliverable.full_id = f"{deliverable.productid}/{deliverable.docsetid}/{deliverable.lang}:DC-FAIL"
+        mock_deliverable.full_id = (
+            f"{deliverable.productid}/{deliverable.docsetid}/{deliverable.lang}:DC-FAIL"
+        )
         mock_process_doctype.return_value = [mock_deliverable]
 
-        # collect_files_flat won't be reached when failures exist, but provide an empty list
+        # collect_files_flat won't be reached when failures exist, but
+        # provide an empty list
         mock_collect_files_flat.return_value = []
 
         # Act: call process and capture console_err output
-        with patch.object(metaprocess_pkg, 'console_err') as mock_console_err:
+        with patch.object(metaprocess_pkg, "console_err") as mock_console_err:
             result = await process(mock_context_with_config_dir, doctypes=tuple())
 
         # Assert: process should return 1 and console_err should have been used
@@ -571,11 +649,11 @@ def test_store_productdocset_json_merges_and_writes(
     deliverable: Deliverable,
     stitchnode: etree._ElementTree,
 ):
-    """store_productdocset_json should merge docs from metadata files and write product/docset JSON."""
+    """Merge docs from metadata files and write product/docset JSON."""
     # Use the fixture's meta cache dir and create a metadata file there
     meta_cache_dir = mock_context_with_config_dir.envconfig.paths.meta_cache_dir
-    meta_file = Path(meta_cache_dir) / 'meta1.json'
-    meta_file.write_text(json.dumps({'docs': [{'title': 'Doc1'}]}), encoding='utf-8')
+    meta_file = Path(meta_cache_dir) / "meta1.json"
+    meta_file.write_text(json.dumps({"docs": [{"title": "Doc1"}]}), encoding="utf-8")
 
     doctype = Doctype.from_str(
         f"{deliverable.productid}/{deliverable.docsetid}/{deliverable.lang}"
@@ -584,19 +662,21 @@ def test_store_productdocset_json_merges_and_writes(
     # Patch collect_files_flat to return our file (relative path)
     with patch.object(
         metaprocess_pkg,
-        'collect_files_flat',
-        return_value=[(doctype, deliverable.docsetid, [Path('meta1.json')])],
+        "collect_files_flat",
+        return_value=[(doctype, deliverable.docsetid, [Path("meta1.json")])],
     ):
         metaprocess_pkg.store_productdocset_json(
             mock_context_with_config_dir, [doctype], stitchnode
         )
 
     # Assert written JSON exists and contains merged document
-    out_file = Path(meta_cache_dir) / deliverable.productid / f"{deliverable.docsetid}.json"
+    out_file = (
+        Path(meta_cache_dir) / deliverable.productid / f"{deliverable.docsetid}.json"
+    )
     assert out_file.exists()
-    merged = json.loads(out_file.read_text(encoding='utf-8'))
-    assert 'documents' in merged
-    assert merged['documents'][0]['title'] == 'Doc1'
+    merged = json.loads(out_file.read_text(encoding="utf-8"))
+    assert "documents" in merged
+    assert merged["documents"][0]["title"] == "Doc1"
 
 
 def test_store_productdocset_json_warns_on_empty_metadata(
@@ -606,19 +686,21 @@ def test_store_productdocset_json_warns_on_empty_metadata(
 ):
     """If a metadata file is empty ({}), a warning is printed to console_err."""
     meta_cache_dir = mock_context_with_config_dir.envconfig.paths.meta_cache_dir
-    meta_file = Path(meta_cache_dir) / 'empty.json'
-    meta_file.write_text('{}', encoding='utf-8')
-
+    meta_file = Path(meta_cache_dir) / "empty.json"
+    meta_file.write_text("{}", encoding="utf-8")
 
     doctype = Doctype.from_str(
         f"{deliverable.productid}/{deliverable.docsetid}/{deliverable.lang}"
     )
 
-    with patch.object(
-        metaprocess_pkg,
-        'collect_files_flat',
-        return_value=[(doctype, deliverable.docsetid, [Path('empty.json')])],
-    ), patch.object(metaprocess_pkg, 'console_err') as mock_console_err:
+    with (
+        patch.object(
+            metaprocess_pkg,
+            "collect_files_flat",
+            return_value=[(doctype, deliverable.docsetid, [Path("empty.json")])],
+        ),
+        patch.object(metaprocess_pkg, "console_err") as mock_console_err,
+    ):
         metaprocess_pkg.store_productdocset_json(
             mock_context_with_config_dir, [doctype], stitchnode
         )
@@ -634,20 +716,22 @@ def test_store_productdocset_json_handles_read_error(
 ):
     """If reading a metadata file raises, it should be caught and an error printed."""
     meta_cache_dir = mock_context_with_config_dir.envconfig.paths.meta_cache_dir
-    bad_file = Path(meta_cache_dir) / 'bad.json'
+    bad_file = Path(meta_cache_dir) / "bad.json"
     # Write invalid JSON to cause json.load to raise
-    bad_file.write_text('{ not json }', encoding='utf-8')
-
+    bad_file.write_text("{ not json }", encoding="utf-8")
 
     doctype = Doctype.from_str(
         f"{deliverable.productid}/{deliverable.docsetid}/{deliverable.lang}"
     )
 
-    with patch.object(
-        metaprocess_pkg,
-        'collect_files_flat',
-        return_value=[(doctype, deliverable.docsetid, [Path('bad.json')])],
-    ), patch.object(metaprocess_pkg, 'console_err') as mock_console_err:
+    with (
+        patch.object(
+            metaprocess_pkg,
+            "collect_files_flat",
+            return_value=[(doctype, deliverable.docsetid, [Path("bad.json")])],
+        ),
+        patch.object(metaprocess_pkg, "console_err") as mock_console_err,
+    ):
         metaprocess_pkg.store_productdocset_json(
             mock_context_with_config_dir, [doctype], stitchnode
         )
@@ -659,30 +743,32 @@ def test_store_productdocset_json_handles_read_error(
     "setup_files, doctype_str, expected_file_count",
     [
         (
-            {'en-us/sles/15-SP4': ['DC-file1', 'DC-file2', 'ignored.xml']},
-            'sles/15-SP4/en-us',
-            2
+            {"en-us/sles/15-SP4": ["DC-file1", "DC-file2", "ignored.xml"]},
+            "sles/15-SP4/en-us",
+            2,
         ),
         (
             {
-                'en-us/sles/15-SP4': ['DC-file-foo', 'DC-file-bar'],
-                'de-de/sles/15-SP4': ['DC-file-foo', 'DC-file-bar']
+                "en-us/sles/15-SP4": ["DC-file-foo", "DC-file-bar"],
+                "de-de/sles/15-SP4": ["DC-file-foo", "DC-file-bar"],
             },
-            'sles/15-SP4/en-us,de-de',
-            4
+            "sles/15-SP4/en-us,de-de",
+            4,
         ),
         (
-            {}, # No files created
-            'sles/15-SP4/en-us',
-            0
+            {},  # No files created
+            "sles/15-SP4/en-us",
+            0,
         ),
     ],
-    ids=["single_lang", "multi_lang", "no_files"]
+    ids=["single_lang", "multi_lang", "no_files"],
 )
-def test_collect_files_flat(tmp_path: Path, setup_files, doctype_str, expected_file_count):
+def test_collect_files_flat(
+    tmp_path: Path, setup_files, doctype_str, expected_file_count
+):
     """Verify that collect_files_flat finds DC-* files correctly."""
     # Arrange
-    cache_dir = tmp_path / 'cache'
+    cache_dir = tmp_path / "cache"
     for path_str, files in setup_files.items():
         dir_path = cache_dir / path_str
         dir_path.mkdir(parents=True, exist_ok=True)
@@ -705,17 +791,17 @@ def test_collect_files_flat(tmp_path: Path, setup_files, doctype_str, expected_f
 class TestUpdateRepositories:
     """Tests for the update_repositories function."""
 
-    @patch.object(metaprocess_pkg.ManagedGitRepo, 'clone_bare', new_callable=AsyncMock)
+    @patch.object(metaprocess_pkg.ManagedGitRepo, "clone_bare", new_callable=AsyncMock)
     async def test_update_repositories_success(
         self, mock_clone_bare: AsyncMock, tmp_path: Path
     ):
         """Verify that update_repositories successfully 'clones' a repo."""
         # Arrange
         mock_deliverable = Mock(spec=Deliverable)
-        mock_deliverable.git.url = 'gh://SUSE/doc-test'
-        mock_deliverable.git.slug = 'SUSE-doc-test'
+        mock_deliverable.git.url = "gh://SUSE/doc-test"
+        mock_deliverable.git.slug = "SUSE-doc-test"
         deliverables = [mock_deliverable]
-        repo_dir = tmp_path / 'repos'
+        repo_dir = tmp_path / "repos"
         mock_clone_bare.return_value = True
 
         from docbuild.cli.cmd_metadata.metaprocess import update_repositories
@@ -727,17 +813,17 @@ class TestUpdateRepositories:
         mock_clone_bare.assert_awaited_once()
         # mock_clone_bare.assert_awaited_once_with(expected_path)
 
-    @patch.object(metaprocess_pkg.ManagedGitRepo, 'clone_bare', new_callable=AsyncMock)
+    @patch.object(metaprocess_pkg.ManagedGitRepo, "clone_bare", new_callable=AsyncMock)
     async def test_update_repositories_failed(
         self, mock_clone_bare: AsyncMock, tmp_path: Path, caplog
     ):
         """Verify that update_repositories handles a git clone failure."""
         # Arrange
         mock_deliverable = Mock(spec=Deliverable)
-        mock_deliverable.git.url = 'gh://SUSE/non-existent-repo'
-        mock_deliverable.git.slug = 'SUSE-non-existent-repo'
+        mock_deliverable.git.url = "gh://SUSE/non-existent-repo"
+        mock_deliverable.git.slug = "SUSE-non-existent-repo"
         deliverables = [mock_deliverable]
-        repo_dir = tmp_path / 'repos'
+        repo_dir = tmp_path / "repos"
         mock_clone_bare.return_value = False
 
         from docbuild.cli.cmd_metadata.metaprocess import update_repositories
@@ -751,5 +837,5 @@ class TestUpdateRepositories:
 
         # Assert
         mock_clone_bare.assert_awaited_once()
-        assert 'Failed to update' in caplog.text
+        assert "Failed to update" in caplog.text
         # assert error_message in caplog.text

--- a/tests/cli/cmd_repo/test_cmd_clone.py
+++ b/tests/cli/cmd_repo/test_cmd_clone.py
@@ -1,6 +1,5 @@
 """Tests for the 'docbuild repo clone' command."""
 
-from subprocess import CompletedProcess
 import logging
 from unittest.mock import AsyncMock
 
@@ -26,11 +25,11 @@ log = logging.getLogger(__name__)
 def mock_subprocess(monkeypatch) -> AsyncMock:
     """Fixture to mock asyncio.create_subprocess_exec."""
     process_mock = AsyncMock()
-    process_mock.communicate.return_value = (b'stdout', b'stderr')
+    process_mock.communicate.return_value = (b"stdout", b"stderr")
     process_mock.returncode = 0
     mock_create_subprocess = AsyncMock(return_value=process_mock)
     monkeypatch.setattr(
-        mod_process.asyncio, 'create_subprocess_exec', mock_create_subprocess
+        mod_process.asyncio, "create_subprocess_exec", mock_create_subprocess
     )
     return mock_create_subprocess
 
@@ -38,9 +37,9 @@ def mock_subprocess(monkeypatch) -> AsyncMock:
 def test_clone_from_xml_config(runner, tmp_path, mock_subprocess, caplog):
     """Test cloning repositories defined in an XML configuration file."""
     caplog.set_level(logging.INFO, logger="docbuild.git")
-    config_dir = tmp_path / 'config'
+    config_dir = tmp_path / "config"
     config_dir.mkdir()
-    repo_dir = tmp_path / 'repos'
+    repo_dir = tmp_path / "repos"
     repo_dir.mkdir()
 
     # Create a dummy XML config
@@ -60,11 +59,11 @@ def test_clone_from_xml_config(runner, tmp_path, mock_subprocess, caplog):
   </product>
 </docservconfig>
 """
-    (config_dir / 'sles.xml').write_text(xml_content)
+    (config_dir / "sles.xml").write_text(xml_content)
 
     context = DocBuildContext(
         envconfig={
-            'paths': {'repo_dir': str(repo_dir), 'config_dir': str(config_dir)},
+            "paths": {"repo_dir": str(repo_dir), "config_dir": str(config_dir)},
         },
     )
 
@@ -74,8 +73,8 @@ def test_clone_from_xml_config(runner, tmp_path, mock_subprocess, caplog):
 
     calls = mock_subprocess.call_args_list
     cloned_repos = {call[0][6] for call in calls}  # The 7th arg is the repo URL
-    assert 'https://github.com/test/one.git' in cloned_repos
-    assert 'https://github.com/test/two.git' in cloned_repos
+    assert "https://github.com/test/one.git" in cloned_repos
+    assert "https://github.com/test/two.git" in cloned_repos
 
 
 def test_clone_invalid_envconfig(runner):
@@ -84,52 +83,52 @@ def test_clone_invalid_envconfig(runner):
 
     result = runner.invoke(
         clone,
-        ['org/repo'],
+        ["org/repo"],
         obj=context,
         # catch_exceptions=True,
     )
 
     assert result.exit_code != 0
     assert isinstance(result.exception, ValueError)
-    assert 'No envconfig found in context' in str(result.exception)
+    assert "No envconfig found in context" in str(result.exception)
 
 
 # @pytest.mark.asyncio
 async def test_process_stitchnode_none(monkeypatch, tmp_path):
     """Test that process raises ValueError if create_stitchfile returns None."""
     # Patch create_stitchfile to return None
-    monkeypatch.setattr(mod_process, 'create_stitchfile', AsyncMock(return_value=None))
+    monkeypatch.setattr(mod_process, "create_stitchfile", AsyncMock(return_value=None))
 
     context = DocBuildContext(
         envconfig={
-            'paths': {
-                'repo_dir': str(tmp_path / 'repos'),
-                'config_dir': str(tmp_path / 'config'),
+            "paths": {
+                "repo_dir": str(tmp_path / "repos"),
+                "config_dir": str(tmp_path / "config"),
             }
         }
     )
 
     # The config_dir must exist, even if empty
-    (tmp_path / 'config').mkdir()
-    (tmp_path / 'repos').mkdir()
+    (tmp_path / "config").mkdir()
+    (tmp_path / "repos").mkdir()
 
-    with pytest.raises(ValueError, match='Stitch node could not be created.'):
+    with pytest.raises(ValueError, match="Stitch node could not be created."):
         await mod_process.process(context, repos=())
 
 
 async def test_process_configdir_none():
-    context = DocBuildContext(envconfig={'paths': {}})
+    context = DocBuildContext(envconfig={"paths": {}})
     with pytest.raises(
         ValueError,
-        match='Could not get a value from envconfig.paths.config_dir',
+        match="Could not get a value from envconfig.paths.config_dir",
     ):
         await mod_process.process(context, repos=())
 
 
 async def test_process_repodir_none():
-    context = DocBuildContext(envconfig={'paths': {'config_dir': '/dummy/config'}})
+    context = DocBuildContext(envconfig={"paths": {"config_dir": "/dummy/config"}})
     with pytest.raises(
         ValueError,
-        match='Could not get a value from envconfig.paths.repo_dir',
+        match="Could not get a value from envconfig.paths.repo_dir",
     ):
         await mod_process.process(context, repos=())

--- a/tests/cli/cmd_repo/test_cmd_dir.py
+++ b/tests/cli/cmd_repo/test_cmd_dir.py
@@ -2,11 +2,11 @@ from docbuild.cli.cmd_repo.cmd_dir import cmd_dir
 
 
 def test_cmd_dir_prints_repo_dir(runner, monkeypatch):
-    dummy_repo_dir = '/tmp/myrepo'
+    dummy_repo_dir = "/tmp/myrepo"
 
     class DummyContext:
         def __init__(self, repo_dir):
-            self.envconfig = {'paths': {'repo_dir': repo_dir}}
+            self.envconfig = {"paths": {"repo_dir": repo_dir}}
 
     ctx_obj = DummyContext(dummy_repo_dir)
 
@@ -24,7 +24,7 @@ def test_cmd_dir_no_envconfig(runner, capsys):
 
     captured = capsys.readouterr()
 
-    assert captured.out == ''
+    assert captured.out == ""
     assert result.exit_code != 0
     assert isinstance(result.exception, ValueError)
-    assert 'No envconfig found in context.' in str(result.exception)
+    assert "No envconfig found in context." in str(result.exception)

--- a/tests/cli/cmd_repo/test_cmd_list.py
+++ b/tests/cli/cmd_repo/test_cmd_list.py
@@ -1,5 +1,3 @@
-
-
 from docbuild.cli.cmd_repo.cmd_list import cmd_list
 from docbuild.cli.context import DocBuildContext
 
@@ -8,36 +6,36 @@ def test_cmd_list_envconfig_none(runner):
     context = DocBuildContext(envconfig=None)
     result = runner.invoke(cmd_list, obj=context)
     assert result.exit_code != 0
-    assert 'No envconfig found in context.' in str(result.exception)
+    assert "No envconfig found in context." in str(result.exception)
 
 
 def test_cmd_list_repo_dir_none(runner):
-    context = DocBuildContext(envconfig={'paths': {}})
+    context = DocBuildContext(envconfig={"paths": {}})
     result = runner.invoke(cmd_list, obj=context)
     assert result.exit_code != 0
-    assert 'No permanent repositories defined' in str(result.exception)
+    assert "No permanent repositories defined" in str(result.exception)
 
 
 def test_cmd_list_repo_dir_not_exists(runner, tmp_path):
-    repo_dir = tmp_path / 'repos'
-    context = DocBuildContext(envconfig={'paths': {'repo_dir': str(repo_dir)}})
+    repo_dir = tmp_path / "repos"
+    context = DocBuildContext(envconfig={"paths": {"repo_dir": str(repo_dir)}})
     result = runner.invoke(cmd_list, obj=context)
     assert result.exit_code == 1
-    assert 'No permanent repositories found' in result.output
-    assert str(repo_dir) in result.output.replace('\n', '')
+    assert "No permanent repositories found" in result.output
+    assert str(repo_dir) in result.output.replace("\n", "")
 
 
 def test_cmd_list_success(runner, tmp_path):
-    repo_dir = tmp_path / 'repos'
+    repo_dir = tmp_path / "repos"
     repo_dir.mkdir()
-    (repo_dir / 'repo1').mkdir()
-    (repo_dir / 'repo2').mkdir()
-    (repo_dir / '.hidden').mkdir()
-    context = DocBuildContext(envconfig={'paths': {'repo_dir': str(repo_dir)}})
+    (repo_dir / "repo1").mkdir()
+    (repo_dir / "repo2").mkdir()
+    (repo_dir / ".hidden").mkdir()
+    context = DocBuildContext(envconfig={"paths": {"repo_dir": str(repo_dir)}})
     result = runner.invoke(cmd_list, obj=context)
     assert result.exit_code == 0
-    assert 'Available permanent repositories' in result.output
-    assert str(repo_dir) in result.output.replace('\n', '')
-    assert 'repo1' in result.output
-    assert 'repo2' in result.output
-    assert '.hidden' not in result.output
+    assert "Available permanent repositories" in result.output
+    assert str(repo_dir) in result.output.replace("\n", "")
+    assert "repo1" in result.output
+    assert "repo2" in result.output
+    assert ".hidden" not in result.output

--- a/tests/cli/cmd_repo/test_process.py
+++ b/tests/cli/cmd_repo/test_process.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, Mock, call
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -15,7 +15,7 @@ def mock_managed_git_repo(monkeypatch) -> AsyncMock:
     mock_instance = AsyncMock()
     mock_instance.clone_bare.return_value = True
     mock_class = Mock(return_value=mock_instance)
-    monkeypatch.setattr(process_module, 'ManagedGitRepo', mock_class)
+    monkeypatch.setattr(process_module, "ManagedGitRepo", mock_class)
     return mock_class
 
 
@@ -24,14 +24,14 @@ def mock_create_stitchfile(monkeypatch) -> AsyncMock:
     """Fixture to mock create_stitchfile to return a predefined set of repos."""
     stitch_mock = Mock()
     git_node1 = Mock()
-    git_node1.attrib.get.return_value = 'https://github.com/fakeorg/repo1.git'
+    git_node1.attrib.get.return_value = "https://github.com/fakeorg/repo1.git"
     git_node2 = Mock()
-    git_node2.attrib.get.return_value = 'https://github.com/fakeorg/repo2.git'
+    git_node2.attrib.get.return_value = "https://github.com/fakeorg/repo2.git"
     # Use to_thread to simulate the async call to a sync function
     stitch_mock.xpath = Mock(return_value=[git_node1, git_node2])
 
     mock = AsyncMock(return_value=stitch_mock)
-    monkeypatch.setattr(process_module, 'create_stitchfile', mock)
+    monkeypatch.setattr(process_module, "create_stitchfile", mock)
     return mock
 
 
@@ -41,24 +41,24 @@ async def test_process_with_specific_repos(
     """Test `process` when specific repos are provided, including duplicates."""
     # We don't need the stitchfile logic for this test, so we can patch it.
     monkeypatch.setattr(
-        process_module, 'create_stitchfile', AsyncMock(return_value=Mock())
+        process_module, "create_stitchfile", AsyncMock(return_value=Mock())
     )
 
-    repo_dir = tmp_path / 'repos'
+    repo_dir = tmp_path / "repos"
     context = DocBuildContext(
         envconfig={
-            'paths': {
-                'repo_dir': str(repo_dir),
-                'config_dir': str(tmp_path / 'config'),
+            "paths": {
+                "repo_dir": str(repo_dir),
+                "config_dir": str(tmp_path / "config"),
             },
         },
     )
     # The directories must exist for the function to run
-    (tmp_path / 'config').mkdir()
+    (tmp_path / "config").mkdir()
     repo_dir.mkdir()
 
     # Provide a list of repos with a duplicate
-    input_repos = ('org/repo1', 'org/repo2', 'org/repo1')
+    input_repos = ("org/repo1", "org/repo2", "org/repo1")
 
     exit_code = await process(context, repos=input_repos)
 
@@ -67,7 +67,7 @@ async def test_process_with_specific_repos(
     # Check that ManagedGitRepo was instantiated with the unique repos, preserving order
     assert mock_managed_git_repo.call_count == 2
     called_repos = [Repo(call[0][0]) for call in mock_managed_git_repo.call_args_list]
-    expected_repos = [Repo('org/repo1'), Repo('org/repo2')]
+    expected_repos = [Repo("org/repo1"), Repo("org/repo2")]
     assert called_repos == expected_repos
 
 
@@ -75,16 +75,16 @@ async def test_process_with_all_repos_from_xml(
     tmp_path, mock_managed_git_repo, mock_create_stitchfile
 ):
     """Test `process` when no specific repos are provided, using XML config."""
-    repo_dir = tmp_path / 'repos'
+    repo_dir = tmp_path / "repos"
     context = DocBuildContext(
         envconfig={
-            'paths': {
-                'repo_dir': str(repo_dir),
-                'config_dir': str(tmp_path / 'config'),
+            "paths": {
+                "repo_dir": str(repo_dir),
+                "config_dir": str(tmp_path / "config"),
             },
         },
     )
-    (tmp_path / 'config').mkdir()
+    (tmp_path / "config").mkdir()
     repo_dir.mkdir()
 
     exit_code = await process(context, repos=())
@@ -95,8 +95,8 @@ async def test_process_with_all_repos_from_xml(
     assert mock_managed_git_repo.call_count == 2
     called_repos = [Repo(call[0][0]) for call in mock_managed_git_repo.call_args_list]
     expected_repos = [
-        Repo('https://github.com/fakeorg/repo1.git'),
-        Repo('https://github.com/fakeorg/repo2.git'),
+        Repo("https://github.com/fakeorg/repo1.git"),
+        Repo("https://github.com/fakeorg/repo2.git"),
     ]
     assert called_repos == expected_repos
 
@@ -109,23 +109,23 @@ async def test_process_with_no_repos_found(
     stitch_mock = Mock()
     stitch_mock.xpath.return_value = []  # No git nodes found
     monkeypatch.setattr(
-        process_module, 'create_stitchfile', AsyncMock(return_value=stitch_mock)
+        process_module, "create_stitchfile", AsyncMock(return_value=stitch_mock)
     )
 
     # Mock the logger to check for the "No repositories" message
     mock_log_info = Mock()
-    monkeypatch.setattr(process_module.log, 'info', mock_log_info)
+    monkeypatch.setattr(process_module.log, "info", mock_log_info)
 
-    repo_dir = tmp_path / 'repos'
+    repo_dir = tmp_path / "repos"
     context = DocBuildContext(
         envconfig={
-            'paths': {
-                'repo_dir': str(repo_dir),
-                'config_dir': str(tmp_path / 'config'),
+            "paths": {
+                "repo_dir": str(repo_dir),
+                "config_dir": str(tmp_path / "config"),
             },
         },
     )
-    (tmp_path / 'config').mkdir()
+    (tmp_path / "config").mkdir()
     repo_dir.mkdir()
 
     # Call process with no specific repos, so it reads from the (empty) config
@@ -133,7 +133,7 @@ async def test_process_with_no_repos_found(
 
     assert exit_code == 0
     mock_managed_git_repo.assert_not_called()
-    mock_log_info.assert_called_once_with('No repositories found to clone.')
+    mock_log_info.assert_called_once_with("No repositories found to clone.")
 
 
 async def test_process_failure_if_one_clone_fails(
@@ -142,25 +142,25 @@ async def test_process_failure_if_one_clone_fails(
     """Test that `process` returns 1 if any clone operation fails."""
     # We don't need the stitchfile logic for this test.
     monkeypatch.setattr(
-        process_module, 'create_stitchfile', AsyncMock(return_value=Mock())
+        process_module, "create_stitchfile", AsyncMock(return_value=Mock())
     )
 
     # Configure the mock to simulate one success and one failure from clone_bare()
     mock_managed_git_repo.return_value.clone_bare.side_effect = [True, False]
 
-    repo_dir = tmp_path / 'repos'
+    repo_dir = tmp_path / "repos"
     context = DocBuildContext(
         envconfig={
-            'paths': {
-                'repo_dir': str(repo_dir),
-                'config_dir': str(tmp_path / 'config'),
+            "paths": {
+                "repo_dir": str(repo_dir),
+                "config_dir": str(tmp_path / "config"),
             },
         },
     )
-    (tmp_path / 'config').mkdir()
+    (tmp_path / "config").mkdir()
     repo_dir.mkdir()
 
-    exit_code = await process(context, repos=('org/repo1', 'org/repo2'))
+    exit_code = await process(context, repos=("org/repo1", "org/repo2"))
 
     assert exit_code == 1
     assert mock_managed_git_repo.call_count == 2

--- a/tests/cli/cmd_validate/validate/test_cmd_validate.py
+++ b/tests/cli/cmd_validate/validate/test_cmd_validate.py
@@ -3,8 +3,8 @@
 from collections.abc import Iterator
 from os import PathLike
 from pathlib import Path
-import tempfile
 from subprocess import CompletedProcess
+import tempfile
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -20,64 +20,64 @@ class TestDisplayResults:
 
     def test_display_results_verbose_0_silent_mode(self, capsys):
         """Test that verbose=0 produces no output (silent mode)."""
-        check_results = [('check1', CheckResult(success=True, messages=[]))]
+        check_results = [("check1", CheckResult(success=True, messages=[]))]
 
-        process_mod.display_results('test.xml', check_results, verbose=0, max_len=40)
+        process_mod.display_results("test.xml", check_results, verbose=0, max_len=40)
 
         captured = capsys.readouterr()
-        assert captured.out == ''
+        assert captured.out == ""
 
     def test_display_results_verbose_1_basic_output(self, capsys):
         """Test verbose=1 shows filename and overall result only."""
         check_results = [
-            ('check1', CheckResult(success=True, messages=[])),
-            ('check2', CheckResult(success=False, messages=['Error message'])),
+            ("check1", CheckResult(success=True, messages=[])),
+            ("check2", CheckResult(success=False, messages=["Error message"])),
         ]
 
-        process_mod.display_results('test.xml', check_results, verbose=1, max_len=40)
+        process_mod.display_results("test.xml", check_results, verbose=1, max_len=40)
 
         captured = capsys.readouterr()
-        assert 'test.xml' in captured.out
-        assert 'failed' in captured.out
+        assert "test.xml" in captured.out
+        assert "failed" in captured.out
 
     def test_display_results_verbose_2_with_dots(self, capsys):
         """Test verbose=2 shows dots and status."""
         check_results = [
-            ('check1', CheckResult(success=True, messages=[])),
-            ('check2', CheckResult(success=False, messages=['Error'])),
+            ("check1", CheckResult(success=True, messages=[])),
+            ("check2", CheckResult(success=False, messages=["Error"])),
         ]
 
-        process_mod.display_results('test.xml', check_results, verbose=2, max_len=40)
+        process_mod.display_results("test.xml", check_results, verbose=2, max_len=40)
 
         captured = capsys.readouterr()
-        assert 'test.xml' in captured.out
-        assert '=>' in captured.out
-        assert 'failed' in captured.out
+        assert "test.xml" in captured.out
+        assert "=>" in captured.out
+        assert "failed" in captured.out
 
     def test_display_results_verbose_3_with_detailed_errors(self, capsys):
         """Test verbose>2 shows detailed error messages."""
         check_results = [
-            ('check1', CheckResult(success=False, messages=['Detailed error message'])),
-            ('check2', CheckResult(success=True, messages=[])),
+            ("check1", CheckResult(success=False, messages=["Detailed error message"])),
+            ("check2", CheckResult(success=True, messages=[])),
         ]
 
-        process_mod.display_results('test.xml', check_results, verbose=3, max_len=40)
+        process_mod.display_results("test.xml", check_results, verbose=3, max_len=40)
 
         captured = capsys.readouterr()
-        assert '✗ check1:' in captured.err
-        assert 'Detailed error message' in captured.err
+        assert "✗ check1:" in captured.err
+        assert "Detailed error message" in captured.err
 
     def test_display_results_all_success(self, capsys):
         """Test display when all checks succeed."""
         check_results = [
-            ('check1', CheckResult(success=True, messages=[])),
-            ('check2', CheckResult(success=True, messages=[])),
+            ("check1", CheckResult(success=True, messages=[])),
+            ("check2", CheckResult(success=True, messages=[])),
         ]
 
-        process_mod.display_results('test.xml', check_results, verbose=2, max_len=40)
+        process_mod.display_results("test.xml", check_results, verbose=2, max_len=40)
 
         captured = capsys.readouterr()
-        assert 'success' in captured.out
+        assert "success" in captured.out
 
 
 class TestProcessValidation:
@@ -87,7 +87,7 @@ class TestProcessValidation:
     def mock_context(self):
         """Create a mock DocBuildContext."""
         context = Mock(spec=DocBuildContext)
-        context.envconfig = {'paths': {'config_dir': '/test/config'}}
+        context.envconfig = {"paths": {"config_dir": "/test/config"}}
         context.verbose = 1
         context.validation_method = "jing"
         return context
@@ -95,7 +95,7 @@ class TestProcessValidation:
     @pytest.fixture
     def valid_xml_file(self) -> Iterator[PathLike]:
         """Create a temporary valid XML file."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.xml', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
             f.write('<?xml version="1.0"?><root><test>content</test></root>')
             f.flush()
             yield Path(f.name)
@@ -104,7 +104,7 @@ class TestProcessValidation:
     @pytest.fixture
     def invalid_xml_file(self):
         """Create a temporary invalid XML file."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.xml', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
             f.write('<?xml version="1.0"?><root><unclosed-tag></root>')
             f.flush()
             yield Path(f.name)
@@ -115,13 +115,13 @@ class TestProcessValidation:
         context = Mock(spec=DocBuildContext)
         context.envconfig = None
 
-        with pytest.raises(ValueError, match='No envconfig found in context'):
+        with pytest.raises(ValueError, match="No envconfig found in context"):
             await process_mod.process(context, [])
 
     async def test_process_invalid_paths_config(self):
         """Test process raises ValueError when paths is not a dict."""
         context = Mock(spec=DocBuildContext)
-        context.envconfig = {'paths': 'not_a_dict'}
+        context.envconfig = {"paths": "not_a_dict"}
 
         with pytest.raises(ValueError, match="'paths.config' must be a dictionary"):
             await process_mod.process(context, [])
@@ -135,7 +135,7 @@ class TestProcessValidation:
         assert result == 0
         # assert 'No XML files found to validate.' in caplog.text
 
-    @patch.object(process_mod, 'registry')
+    @patch.object(process_mod, "registry")
     async def test_process_xml_syntax_error(
         self, mock_registry, mock_context, invalid_xml_file
     ):
@@ -146,43 +146,47 @@ class TestProcessValidation:
 
         assert result == 1  # Should return 1 for any failures
 
-    @patch.object(process_mod, 'registry')
+    @patch.object(process_mod, "registry")
     async def test_process_file_exception(self, mock_registry, mock_context):
         """Test processing non-existent file returns exit code 200."""
         mock_registry.registry = []
-        non_existent_file = Path('/non/existent/file.xml')
+        non_existent_file = Path("/non/existent/file.xml")
 
         result = await process_mod.process(mock_context, [non_existent_file])
 
         assert result == 1  # Should return 1 for any failures
 
-    @patch.object(process_mod, 'registry')
-    @patch.object(process_mod, 'validate_rng', new_callable=AsyncMock)
+    @patch.object(process_mod, "registry")
+    @patch.object(process_mod, "validate_rng", new_callable=AsyncMock)
     async def test_process_check_exception(
         self, mock_validate_rng, mock_registry, mock_context, valid_xml_file: PathLike
     ):
         """Test processing when a check raises an exception."""
-        mock_validate_rng.return_value = CompletedProcess(args=['jing'], returncode=0, stdout='', stderr='')
+        mock_validate_rng.return_value = CompletedProcess(
+            args=["jing"], returncode=0, stdout="", stderr=""
+        )
         # Create a mock check that raises an exception
         mock_check = Mock()
-        mock_check.__name__ = 'failing_check'
-        mock_check.side_effect = Exception('Check failed')
+        mock_check.__name__ = "failing_check"
+        mock_check.side_effect = Exception("Check failed")
         mock_registry.registry = [mock_check]
 
         result = await process_mod.process(mock_context, [valid_xml_file])
 
         assert result == 1  # Should return 1 for failures
 
-    @patch.object(process_mod, 'registry')
-    @patch.object(process_mod, 'validate_rng', new_callable=AsyncMock)
+    @patch.object(process_mod, "registry")
+    @patch.object(process_mod, "validate_rng", new_callable=AsyncMock)
     async def test_process_successful_checks(
         self, mock_validate_rng, mock_registry, mock_context, valid_xml_file
     ):
         """Test processing with successful checks returns 0."""
-        mock_validate_rng.return_value = CompletedProcess(args=['jing'], returncode=0, stdout='', stderr='')
+        mock_validate_rng.return_value = CompletedProcess(
+            args=["jing"], returncode=0, stdout="", stderr=""
+        )
         # Create a mock check that succeeds
         mock_check = Mock()
-        mock_check.__name__ = 'passing_check'
+        mock_check.__name__ = "passing_check"
         mock_check.return_value = CheckResult(success=True, messages=[])
         mock_registry.registry = [mock_check]
 
@@ -190,30 +194,34 @@ class TestProcessValidation:
 
         assert result == 0  # Should return 0 for success
 
-    @patch.object(process_mod, 'registry')
-    @patch.object(process_mod, 'validate_rng', new_callable=AsyncMock)
+    @patch.object(process_mod, "registry")
+    @patch.object(process_mod, "validate_rng", new_callable=AsyncMock)
     async def test_process_failed_checks(
         self, mock_validate_rng, mock_registry, mock_context, valid_xml_file
     ):
         """Test processing with failed checks returns 1."""
-        mock_validate_rng.return_value = CompletedProcess(args=['jing'], returncode=0, stdout='', stderr='')
+        mock_validate_rng.return_value = CompletedProcess(
+            args=["jing"], returncode=0, stdout="", stderr=""
+        )
         # Create a mock check that fails
         mock_check = Mock()
-        mock_check.__name__ = 'failing_check'
-        mock_check.return_value = CheckResult(success=False, messages=['Check failed'])
+        mock_check.__name__ = "failing_check"
+        mock_check.return_value = CheckResult(success=False, messages=["Check failed"])
         mock_registry.registry = [mock_check]
 
         result = await process_mod.process(mock_context, [valid_xml_file])
 
         assert result == 1  # Should return 1 for failures
 
-    @patch.object(process_mod, 'validate_rng', new_callable=AsyncMock)
+    @patch.object(process_mod, "validate_rng", new_callable=AsyncMock)
     async def test_process_shortname_generation(
         self, mock_validate_rng, mock_context, valid_xml_file
     ):
         """Test that shortname is generated correctly for display."""
-        mock_validate_rng.return_value = CompletedProcess(args=['jing'], returncode=0, stdout='', stderr='')
-        with patch.object(process_mod, 'registry') as mock_registry:
+        mock_validate_rng.return_value = CompletedProcess(
+            args=["jing"], returncode=0, stdout="", stderr=""
+        )
+        with patch.object(process_mod, "registry") as mock_registry:
             mock_registry.registry = []
 
             # This test primarily verifies the shortname logic doesn't crash
@@ -222,13 +230,15 @@ class TestProcessValidation:
             # The result should be 0 since no checks are registered (all succeed)
             assert result == 0
 
-    @patch.object(process_mod, 'validate_rng', new_callable=AsyncMock)
+    @patch.object(process_mod, "validate_rng", new_callable=AsyncMock)
     async def test_process_with_multiple_files_and_iterator(
         self, mock_validate_rng, mock_context, valid_xml_file
     ):
         """Test that processing multiple files works with an iterator."""
-        mock_validate_rng.return_value = CompletedProcess(args=['jing'], returncode=0, stdout='', stderr='')
-        with patch.object(process_mod, 'registry') as mock_registry:
+        mock_validate_rng.return_value = CompletedProcess(
+            args=["jing"], returncode=0, stdout="", stderr=""
+        )
+        with patch.object(process_mod, "registry") as mock_registry:
             mock_registry.registry = []
 
             # This test primarily verifies the shortname logic doesn't crash
@@ -237,27 +247,29 @@ class TestProcessValidation:
             # The result should be 0 since no checks are registered (all succeed)
             assert result == 0
 
-    @patch.object(process_mod, 'validate_rng', new_callable=AsyncMock)
+    @patch.object(process_mod, "validate_rng", new_callable=AsyncMock)
     async def test_process_stitch_validation_fails_on_duplicates(
         self, mock_validate_rng, mock_context, tmp_path, capsys
     ):
         """Test `process` fails if stitch validation finds duplicate product IDs."""
-        mock_validate_rng.return_value = CompletedProcess(args=['jing'], returncode=0, stdout='', stderr='')
+        mock_validate_rng.return_value = CompletedProcess(
+            args=["jing"], returncode=0, stdout="", stderr=""
+        )
 
-        file1: Path = tmp_path / 'file1.xml'
+        file1: Path = tmp_path / "file1.xml"
         file1.write_text('<product productid="sles"><docset setid="15-sp4"/></product>')
-        file2: Path = tmp_path / 'file2.xml'
+        file2: Path = tmp_path / "file2.xml"
         file2.write_text('<product productid="sles"><docset setid="15-sp5"/></product>')
 
-        with patch.object(process_mod, 'registry') as mock_registry:
+        with patch.object(process_mod, "registry") as mock_registry:
             mock_registry.registry = []
             result = await process_mod.process(mock_context, [file1, file2])
 
         assert result == 1
         captured = capsys.readouterr()
         # Check for parts of the message to avoid issues with ANSI color codes
-        assert 'Stitch-file validation failed:' in captured.err
-        assert 'Duplicate product IDs found: sles' in captured.err
+        assert "Stitch-file validation failed:" in captured.err
+        assert "Duplicate product IDs found: sles" in captured.err
 
 
 class TestValidateCommand:
@@ -266,56 +278,56 @@ class TestValidateCommand:
     def test_validate_no_envconfig_in_context(self, runner):
         """Test validate command when no envconfig is found."""
         with runner.isolated_filesystem():
-            Path('test.xml').write_text('<?xml version="1.0"?><root></root>')
+            Path("test.xml").write_text('<?xml version="1.0"?><root></root>')
             # When no context object is passed, a default one is created,
             # which has envconfig=None, triggering the error.
-            result = runner.invoke(validate, ['test.xml'], obj=DocBuildContext())
+            result = runner.invoke(validate, ["test.xml"], obj=DocBuildContext())
 
             assert result.exit_code != 0
             assert isinstance(result.exception, ValueError)
-            assert 'No envconfig found in context' in str(result.exception)
+            assert "No envconfig found in context" in str(result.exception)
 
     def test_validate_no_paths_in_envconfig(self, runner):
         """Test validate command when no paths are found in envconfig."""
         with runner.isolated_filesystem():
-            Path('test.xml').write_text('<?xml version="1.0"?><root></root>')
-            context = DocBuildContext(envconfig={'some_other_key': 'value'})
-            result = runner.invoke(validate, ['test.xml'], obj=context)
+            Path("test.xml").write_text('<?xml version="1.0"?><root></root>')
+            context = DocBuildContext(envconfig={"some_other_key": "value"})
+            result = runner.invoke(validate, ["test.xml"], obj=context)
 
             assert result.exit_code != 0
             assert isinstance(result.exception, ValueError)
-            assert 'No paths found in envconfig' in str(result.exception)
+            assert "No paths found in envconfig" in str(result.exception)
 
     def test_validate_no_config_dir_in_paths(self, runner):
         """Test validate command when no config_dir is found in paths."""
         with runner.isolated_filesystem():
-            Path('test.xml').write_text('<?xml version="1.0"?><root></root>')
-            context = DocBuildContext(envconfig={'paths': {'other_dir': '/path'}})
-            result = runner.invoke(validate, ['test.xml'], obj=context)
+            Path("test.xml").write_text('<?xml version="1.0"?><root></root>')
+            context = DocBuildContext(envconfig={"paths": {"other_dir": "/path"}})
+            result = runner.invoke(validate, ["test.xml"], obj=context)
 
             assert result.exit_code != 0
             assert isinstance(result.exception, ValueError)
-            assert 'Could not get a value from envconfig.paths.config_dir' in str(
+            assert "Could not get a value from envconfig.paths.config_dir" in str(
                 result.exception
             )
 
     def test_validate_uses_provided_files(self, runner):
         """Test validate uses XML files provided on the command line."""
         with runner.isolated_filesystem() as fs:
-            xml_file1 = Path(fs) / 'test1.xml'
-            xml_file1.write_text('<root/>')
-            xml_file2 = Path(fs) / 'another.xml'
-            xml_file2.write_text('<root/>')
+            xml_file1 = Path(fs) / "test1.xml"
+            xml_file1.write_text("<root/>")
+            xml_file2 = Path(fs) / "another.xml"
+            xml_file2.write_text("<root/>")
 
             # A config_dir is still needed to pass the initial checks.
-            config_dir = Path(fs) / 'config'
+            config_dir = Path(fs) / "config"
             config_dir.mkdir()
             context = DocBuildContext(
-                envconfig={'paths': {'config_dir': str(config_dir)}}
+                envconfig={"paths": {"config_dir": str(config_dir)}}
             )
 
             with patch.object(
-                process_mod, 'process', new_callable=AsyncMock
+                process_mod, "process", new_callable=AsyncMock
             ) as mock_process:
                 mock_process.return_value = 0
 
@@ -326,32 +338,32 @@ class TestValidateCommand:
                 mock_process.assert_awaited_once()
                 assert result.exit_code == 0
 
-                passed_xmlfiles = mock_process.call_args.kwargs['xmlfiles']
+                passed_xmlfiles = mock_process.call_args.kwargs["xmlfiles"]
                 assert passed_xmlfiles == (xml_file1, xml_file2)
 
     def test_validate_finds_files_in_config_dir(self, runner):
         """Test validate finds XML files in config_dir when none are provided."""
         with runner.isolated_filesystem() as fs:
-            config_dir = Path(fs) / 'config'
+            config_dir = Path(fs) / "config"
             config_dir.mkdir()
-            xml_file1 = config_dir / 'test1.xml'
-            xml_file1.write_text('<root/>')
-            xml_file2 = config_dir / 'another.xml'
-            xml_file2.write_text('<root/>')
+            xml_file1 = config_dir / "test1.xml"
+            xml_file1.write_text("<root/>")
+            xml_file2 = config_dir / "another.xml"
+            xml_file2.write_text("<root/>")
             # This one should not be picked up by rglob('[a-z]*.xml')
-            (config_dir / 'Test3.xml').write_text('<root/>')
+            (config_dir / "Test3.xml").write_text("<root/>")
 
             context = DocBuildContext(
-                envconfig={'paths': {'config_dir': str(config_dir)}}
+                envconfig={"paths": {"config_dir": str(config_dir)}}
             )
 
             with patch.object(
-                process_mod, 'process', new_callable=AsyncMock
+                process_mod, "process", new_callable=AsyncMock
             ) as mock_process:
                 mock_process.return_value = 0
                 result = runner.invoke(validate, [], obj=context)
 
                 assert result.exit_code == 0
                 mock_process.assert_awaited_once()
-                passed_xmlfiles = mock_process.call_args.kwargs['xmlfiles']
+                passed_xmlfiles = mock_process.call_args.kwargs["xmlfiles"]
                 assert set(passed_xmlfiles) == {xml_file1, xml_file2}

--- a/tests/cli/cmd_validate/validate/test_process_validation.py
+++ b/tests/cli/cmd_validate/validate/test_process_validation.py
@@ -1,8 +1,9 @@
-from subprocess import CompletedProcess
-import shutil
-import pytest
 from pathlib import Path
+import shutil
+from subprocess import CompletedProcess
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
 
 import docbuild.cli.cmd_validate.process as process_mod
 from docbuild.cli.context import DocBuildContext
@@ -14,24 +15,24 @@ def is_jing_installed():
 
 async def test_run_command():
     """Test the run_command function."""
-    command = ['echo', 'Hello, World!']
+    command = ["echo", "Hello, World!"]
 
     process = await process_mod.run_command(command)
 
-    assert (process.returncode == 0,
-            f'Expected return code 0, got {process.returncode}')
-    assert (process.stdout.strip() == 'Hello, World!',
-            f'Unexpected stdout: {process.stdout}')
-    assert process.stderr == '', f'Unexpected stderr: {process.stderr}'
+    assert process.returncode == 0, \
+        f"Expected return code 0, got {process.returncode}"
+    assert process.stdout.strip() == "Hello, World!", \
+        f"Unexpected stdout: {process.stdout}"
+    assert process.stderr == "", f"Unexpected stderr: {process.stderr}"
 
 
 @pytest.mark.skipif(not is_jing_installed(), reason="jing command not found")
 async def test_validate_rng_with_rng_suffix(tmp_path: Path):
     """Test validate_rng with a schema file having a .rng suffix."""
-    xmlfile = tmp_path / Path('file.xml')
+    xmlfile = tmp_path / Path("file.xml")
     xmlfile.write_text("""<root/>""")
 
-    rng_schema = tmp_path / Path('schema.rng')
+    rng_schema = tmp_path / Path("schema.rng")
     rng_schema.write_text("""<?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
   <start><element name="root"><text/></element></start>
@@ -39,33 +40,33 @@ async def test_validate_rng_with_rng_suffix(tmp_path: Path):
 
     proc = await process_mod.validate_rng(xmlfile, rng_schema)
 
-    assert proc.returncode == 0, f'Expected return code 0, got {proc.returncode}'
+    assert proc.returncode == 0, f"Expected return code 0, got {proc.returncode}"
 
 
 @pytest.mark.skipif(not is_jing_installed(), reason="jing command not found")
 async def test_validate_rng_with_invalid_xml(tmp_path: Path):
     """Test validate_rng with an invalid XML file."""
-    xmlfile = tmp_path / Path('file.xml')
+    xmlfile = tmp_path / Path("file.xml")
     xmlfile.write_text("""<wrong_root/>""")
 
-    rng_schema = tmp_path / Path('schema.rng')
+    rng_schema = tmp_path / Path("schema.rng")
     rng_schema.write_text("""<?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
     <start><element name="root"><text/></element></start>
 </grammar>""")
 
     proc = await process_mod.validate_rng(xmlfile, rng_schema)
-    assert proc.returncode != 0, f'Expected non-zero return code, got {proc.returncode}'
+    assert proc.returncode != 0, f"Expected non-zero return code, got {proc.returncode}"
     assert 'error: element "wrong_root"' in (proc.stdout + proc.stderr)
 
 
 @pytest.mark.skipif(not is_jing_installed(), reason="jing command not found")
 async def test_validate_rng_without_xinclude(tmp_path: Path):
     """Test validate_rng with xinclude set to False."""
-    xmlfile = tmp_path / Path('file.xml')
+    xmlfile = tmp_path / Path("file.xml")
     xmlfile.write_text("""<root/>""")
 
-    rng_schema = tmp_path / Path('schema.rng')
+    rng_schema = tmp_path / Path("schema.rng")
     rng_schema.write_text("""<?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
     <start><element name="root"><text/></element></start>
@@ -73,16 +74,16 @@ async def test_validate_rng_without_xinclude(tmp_path: Path):
 
     proc = await process_mod.validate_rng(xmlfile, rng_schema, xinclude=False)
 
-    assert proc.returncode == 0, f'Expected return code 0, got {proc.returncode}'
+    assert proc.returncode == 0, f"Expected return code 0, got {proc.returncode}"
 
 
 @pytest.mark.skipif(not is_jing_installed(), reason="jing command not found")
 async def test_validate_rng_with_invalid_xml_without_xinclude(tmp_path: Path):
     """Test validate_rng with xinclude set to False."""
-    xmlfile = tmp_path / Path('file.xml')
+    xmlfile = tmp_path / Path("file.xml")
     xmlfile.write_text("""<wrong_root/>""")
 
-    rng_schema = tmp_path / Path('schema.rng')
+    rng_schema = tmp_path / Path("schema.rng")
     rng_schema.write_text("""<?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
     <start><element name="root"><text/></element></start>
@@ -90,7 +91,7 @@ async def test_validate_rng_with_invalid_xml_without_xinclude(tmp_path: Path):
 
     proc = await process_mod.validate_rng(xmlfile, rng_schema, xinclude=False)
 
-    assert proc.returncode != 0, f'Expected non-zero return code, got {proc.returncode}'
+    assert proc.returncode != 0, f"Expected non-zero return code, got {proc.returncode}"
     assert 'element "wrong_root" not allowed anywhere' in (proc.stdout + proc.stderr)
 
 
@@ -98,27 +99,30 @@ async def test_validate_rng_jing_failure():
     """Test validate_rng when jing fails."""
     xmlfile = MagicMock(spec=Path)
     rng_schema = MagicMock(spec=Path)
-    xmlfile.__str__.return_value = '/mocked/path/to/file.xml'
-    rng_schema.__str__.return_value = '/mocked/path/to/schema.rng'
+    xmlfile.__str__.return_value = "/mocked/path/to/file.xml"
+    rng_schema.__str__.return_value = "/mocked/path/to/schema.rng"
 
     with patch.object(
         process_mod,
-        'run_command',
-        new=AsyncMock(return_value=CompletedProcess(
-                      args=['jing', xmlfile, rng_schema],
-                      returncode=1,
-                      stdout='Error in jing',
-                      stderr=''))
+        "run_command",
+        new=AsyncMock(
+            return_value=CompletedProcess(
+                args=["jing", xmlfile, rng_schema],
+                returncode=1,
+                stdout="Error in jing",
+                stderr="",
+            )
+        ),
     ) as mock_run_command:
         proc = await process_mod.validate_rng(
             xmlfile, rng_schema_path=rng_schema, xinclude=False, idcheck=False
         )
 
-        assert proc.returncode != 0, 'Expected validation to fail.'
-        assert proc.stdout == 'Error in jing', f'Unexpected stdout: {proc.stdout}'
+        assert proc.returncode != 0, "Expected validation to fail."
+        assert proc.stdout == "Error in jing", f"Unexpected stdout: {proc.stdout}"
 
         mock_run_command.assert_called_once_with(
-            ['jing', str(rng_schema), str(xmlfile)]
+            ["jing", str(rng_schema), str(xmlfile)]
         )
 
 
@@ -126,87 +130,95 @@ async def test_validate_rng_command_not_found():
     """Test validate_rng when a command is not found and has a filename."""
     xmlfile = MagicMock(spec=Path)
     rng_schema = MagicMock(spec=Path)
-    xmlfile.__str__.return_value = '/mocked/path/to/file.xml'
-    rng_schema.__str__.return_value = '/mocked/path/to/schema.rng'
+    xmlfile.__str__.return_value = "/mocked/path/to/file.xml"
+    rng_schema.__str__.return_value = "/mocked/path/to/schema.rng"
 
-    error = FileNotFoundError(2, 'No such file or directory')
-    error.filename = 'jing'
+    error = FileNotFoundError(2, "No such file or directory")
+    error.filename = "jing"
 
     with patch.object(
-        process_mod, 'run_command', new_callable=AsyncMock, side_effect=error
+        process_mod, "run_command", new_callable=AsyncMock, side_effect=error
     ):
         proc = await process_mod.validate_rng(
             xmlfile, rng_schema_path=rng_schema, xinclude=False
         )
 
-    assert proc.returncode != 0, 'Expected validation to fail.'
-    assert proc.stderr == 'jing command not found. Please install it to run validation.'
+    assert proc.returncode != 0, "Expected validation to fail."
+    assert proc.stderr == "jing command not found. Please install it to run validation."
 
 
 async def test_validate_rng_command_not_found_no_filename():
     """Test validate_rng when FileNotFoundError has no filename attribute."""
     xmlfile = MagicMock(spec=Path)
     rng_schema = MagicMock(spec=Path)
-    error = FileNotFoundError(2, 'No such file or directory')
+    error = FileNotFoundError(2, "No such file or directory")
     error.filename = None
 
     with patch.object(
-        process_mod, 'run_command', new_callable=AsyncMock, side_effect=error
+        process_mod, "run_command", new_callable=AsyncMock, side_effect=error
     ):
-        proc = await process_mod.validate_rng(
-            xmlfile, rng_schema, xinclude=False
-        )
+        proc = await process_mod.validate_rng(xmlfile, rng_schema, xinclude=False)
 
-    assert proc.returncode != 0, 'Expected validation to fail.'
+    assert proc.returncode != 0, "Expected validation to fail."
     assert (
-        proc.stderr == 'xmllint/jing command not found. Please install it to run validation.'
+        proc.stderr
+        == "xmllint/jing command not found. Please install it to run validation."
     )
 
 
 async def test_process_file_with_validation_issues(capsys, tmp_path):
     with patch.object(
         process_mod,
-        'validate_rng',
-        new=AsyncMock(return_value=CompletedProcess(args=['jing'], returncode=1, stdout='', stderr='Validation error')),
-    ) as mock_validate_rng:
-        dir_path = tmp_path / 'path' / 'to'
+        "validate_rng",
+        new=AsyncMock(
+            return_value=CompletedProcess(
+                args=["jing"], returncode=1, stdout="", stderr="Validation error"
+            )
+        ),
+    ):
+        dir_path = tmp_path / "path" / "to"
         dir_path.mkdir(parents=True)
-        xmlfile = dir_path / 'file.xml'
+        xmlfile = dir_path / "file.xml"
         xmlfile.touch()
 
         mock_context = Mock(spec=DocBuildContext)
         mock_context.verbose = 2
-        mock_context.validation_method = 'jing'  # <-- Use 'jing' or 'lxml'
+        mock_context.validation_method = "jing"  # <-- Use 'jing' or 'lxml'
 
         result = await process_mod.process_file(xmlfile, mock_context, 40)
 
         assert result == 10  # RNG validation failure code
 
 
-
 async def test_process_file_with_xmlsyntax_error(capsys, tmp_path):
-    dir_path = tmp_path / 'path' / 'to'
+    dir_path = tmp_path / "path" / "to"
     dir_path.mkdir(parents=True)
-    xmlfile = dir_path / 'file.xml'
+    xmlfile = dir_path / "file.xml"
     xmlfile.write_text("""<root><invalid></root>""")
 
     mock_context = Mock(spec=DocBuildContext)
     mock_context.verbose = 2
-    mock_context.validation_method = 'jing'
+    mock_context.validation_method = "jing"
 
     with (
         patch.object(
             process_mod.etree,
-            'parse',
+            "parse",
             new=Mock(
                 side_effect=process_mod.etree.XMLSyntaxError(
-                    'XML syntax error', None, 0, 0, 'fake.xml'
+                    "XML syntax error", None, 0, 0, "fake.xml"
                 )
             ),
-        ) as mock_etree_parse,
+        ),
         patch.object(
-            process_mod, 'validate_rng', new=AsyncMock(return_value=CompletedProcess(args=['jing'], returncode=0, stdout='', stderr=''))
-        ) as mock_validate_rng,
+            process_mod,
+            "validate_rng",
+            new=AsyncMock(
+                return_value=CompletedProcess(
+                    args=["jing"], returncode=0, stdout="", stderr=""
+                )
+            ),
+        ),
     ):
         result = await process_mod.process_file(xmlfile, mock_context, 40)
 

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -2,9 +2,9 @@ from docbuild.cli.cmd_cli import cli
 
 
 def test_help_option(runner):
-    result = runner.invoke(cli, ['--help'])
+    result = runner.invoke(cli, ["--help"])
     assert result.exit_code == 0
-    assert 'Usage:' in result.output
+    assert "Usage:" in result.output
     # assert "-v" in result.output
     # assert "--version" in result.output
     # assert "-r" in result.output

--- a/tests/cli/test_verbosity.py
+++ b/tests/cli/test_verbosity.py
@@ -3,10 +3,10 @@ import pytest
 from docbuild.cli.cmd_cli import cli
 
 
-@pytest.mark.skip('Replace --role with --env-config')
+@pytest.mark.skip("Replace --role with --env-config")
 def test_verbosity_counts(context, fake_envfile, runner):
     mock = fake_envfile.mock
-    result = runner.invoke(cli, ['--role=production', '-vv', 'build'], obj=context)
+    result = runner.invoke(cli, ["--role=production", "-vv", "build"], obj=context)
 
     assert mock.call_count == 1
     assert result.exit_code == 0

--- a/tests/cli/test_version.py
+++ b/tests/cli/test_version.py
@@ -3,6 +3,6 @@ from docbuild.cli.cmd_cli import cli
 
 
 def test_version_option(runner):
-    result = runner.invoke(cli, ['--version'])
+    result = runner.invoke(cli, ["--version"])
     assert result.exit_code == 0
     assert __version__ in result.output

--- a/tests/config/app/test_app_replace_placeholders.py
+++ b/tests/config/app/test_app_replace_placeholders.py
@@ -1,6 +1,7 @@
-from typing import Any
 import re
+from typing import Any
 
+from pydantic import ValidationError
 import pytest
 
 from docbuild.config.app import (
@@ -10,58 +11,57 @@ from docbuild.config.app import (
     replace_placeholders,
 )
 from docbuild.models.config.app import AppConfig
-from pydantic import ValidationError
 
 
 def test_replace_placeholders():
     config = {
-        'server': {'name': 'example.com', 'url': 'https://{server.name}'},
-        'paths': {
-            'config_dir': '/etc/myapp',
-            'tmp': {'tmp_base_dir': '/tmp/myapp'},
-            'full_tmp_path': '{paths.tmp.tmp_base_dir}/session',
+        "server": {"name": "example.com", "url": "https://{server.name}"},
+        "paths": {
+            "config_dir": "/etc/myapp",
+            "tmp": {"tmp_base_dir": "/tmp/myapp"},
+            "full_tmp_path": "{paths.tmp.tmp_base_dir}/session",
         },
-        'logging': {
-            'log_dir': '{paths.config_dir}/logs',
-            'tmp_base_dir': '/var/tmp',
+        "logging": {
+            "log_dir": "{paths.config_dir}/logs",
+            "tmp_base_dir": "/var/tmp",
             # Should resolve within this section if key exists:
-            'temp_dir': '{tmp_base_dir}',
+            "temp_dir": "{tmp_base_dir}",
         },
     }
 
     expected = {
-        'server': {'name': 'example.com', 'url': 'https://example.com'},
-        'paths': {
-            'config_dir': '/etc/myapp',
-            'tmp': {'tmp_base_dir': '/tmp/myapp'},
-            'full_tmp_path': '/tmp/myapp/session',
+        "server": {"name": "example.com", "url": "https://example.com"},
+        "paths": {
+            "config_dir": "/etc/myapp",
+            "tmp": {"tmp_base_dir": "/tmp/myapp"},
+            "full_tmp_path": "/tmp/myapp/session",
         },
-        'logging': {
-            'log_dir': '/etc/myapp/logs',
-            'tmp_base_dir': '/var/tmp',
-            'temp_dir': '/var/tmp',
+        "logging": {
+            "log_dir": "/etc/myapp/logs",
+            "tmp_base_dir": "/var/tmp",
+            "temp_dir": "/var/tmp",
         },
     }
 
     result = replace_placeholders(config)
-    assert result == expected, f'Expected {expected}, but got {result}'
+    assert result == expected, f"Expected {expected}, but got {result}"
 
 
 def test_missing_key_in_current_section():
     config = {
-        'database': {
-            'host': 'localhost',
+        "database": {
+            "host": "localhost",
             # 'user' is missing in this section
-            'url': 'postgres://{user}@{host}/mydb',
+            "url": "postgres://{user}@{host}/mydb",
         },
-        'user': 'admin',
+        "user": "admin",
     }
 
     with pytest.raises(
         PlaceholderResolutionError,
         match=re.escape(
             "While resolving '{user}' in 'url': key 'user' "
-            'not found in current section.',
+            "not found in current section.",
         ),
     ):
         replace_placeholders(config)
@@ -69,12 +69,12 @@ def test_missing_key_in_current_section():
 
 def test_unresolved_key_in_config():
     config = {
-        'server': {'name': 'example.com', 'url': 'https://{server.name}'},
-        'paths': {
-            'config_dir': '/etc/myapp',
-            'tmp': {'tmp_base_dir': '/tmp/myapp'},
+        "server": {"name": "example.com", "url": "https://{server.name}"},
+        "paths": {
+            "config_dir": "/etc/myapp",
+            "tmp": {"tmp_base_dir": "/tmp/myapp"},
             # 'session' is missing in this section
-            'full_tmp_path': '{paths.tmp.session}/session',
+            "full_tmp_path": "{paths.tmp.session}/session",
         },
     }
 
@@ -90,50 +90,50 @@ def test_unresolved_key_in_config():
 
 def test_placeholders_in_list():
     config = {
-        'paths': {
-            'config_dir': '/etc/myapp',
+        "paths": {
+            "config_dir": "/etc/myapp",
         },
-        'resources': {
-            'files': [
-                '{paths.config_dir}/app.yaml',
-                '{paths.config_dir}/db.yaml',
-                'static/style.css',
+        "resources": {
+            "files": [
+                "{paths.config_dir}/app.yaml",
+                "{paths.config_dir}/db.yaml",
+                "static/style.css",
             ],
         },
     }
 
     expected = {
-        'paths': {
-            'config_dir': '/etc/myapp',
+        "paths": {
+            "config_dir": "/etc/myapp",
         },
-        'resources': {
-            'files': ['/etc/myapp/app.yaml', '/etc/myapp/db.yaml', 'static/style.css'],
+        "resources": {
+            "files": ["/etc/myapp/app.yaml", "/etc/myapp/db.yaml", "static/style.css"],
         },
     }
 
     result = replace_placeholders(config)
-    assert result == expected, f'Expected {expected}, but got {result}'
+    assert result == expected, f"Expected {expected}, but got {result}"
 
 
 def test_literal_values_are_untouched():
     config = {
-        'defaults': {'enabled': True, 'retries': 3, 'timeout': 5.5, 'optional': None},
+        "defaults": {"enabled": True, "retries": 3, "timeout": 5.5, "optional": None},
     }
 
     expected = {
-        'defaults': {'enabled': True, 'retries': 3, 'timeout': 5.5, 'optional': None},
+        "defaults": {"enabled": True, "retries": 3, "timeout": 5.5, "optional": None},
     }
 
     result = replace_placeholders(config)
-    assert result == expected, f'Expected {expected}, but got {result}'
+    assert result == expected, f"Expected {expected}, but got {result}"
 
 
 def test_placeholder_path_is_not_dict():
     config = {
-        'server': {'name': 'myserver', 'ip': '127.0.0.1'},
-        'paths': {
-            'tmp': 'not_a_dict',
-            'path': '{paths.tmp.value}',  # .value should fail
+        "server": {"name": "myserver", "ip": "127.0.0.1"},
+        "paths": {
+            "tmp": "not_a_dict",
+            "path": "{paths.tmp.value}",  # .value should fail
         },
     }
 
@@ -141,7 +141,7 @@ def test_placeholder_path_is_not_dict():
         PlaceholderResolutionError,
         match=re.escape(
             "While resolving '{paths.tmp.value}' in 'path': 'paths.tmp.value' is not "
-            'a dictionary (got type str).',
+            "a dictionary (got type str).",
         ),
     ):
         replace_placeholders(config)
@@ -149,77 +149,77 @@ def test_placeholder_path_is_not_dict():
 
 def test_chained_placeholder_resolution():
     data = {
-        'paths': {
-            'tmp': {
-                'tmp_base_dir': '/tmp/docbuild',
-                'tmp_dir': '{tmp_base_dir}/doc-example-com',
-                'tmp_deliverable_dir': '{tmp_dir}/deliverable/',
+        "paths": {
+            "tmp": {
+                "tmp_base_dir": "/tmp/docbuild",
+                "tmp_dir": "{tmp_base_dir}/doc-example-com",
+                "tmp_deliverable_dir": "{tmp_dir}/deliverable/",
             },
         },
     }
 
     result: dict[str, Any] = replace_placeholders(data)
-    tmp = result['paths']['tmp']
-    assert tmp['tmp_base_dir'] == '/tmp/docbuild'
-    assert tmp['tmp_dir'] == '/tmp/docbuild/doc-example-com'
-    assert tmp['tmp_deliverable_dir'] == '/tmp/docbuild/doc-example-com/deliverable/'
+    tmp = result["paths"]["tmp"]
+    assert tmp["tmp_base_dir"] == "/tmp/docbuild"
+    assert tmp["tmp_dir"] == "/tmp/docbuild/doc-example-com"
+    assert tmp["tmp_deliverable_dir"] == "/tmp/docbuild/doc-example-com/deliverable/"
 
 
 def test_too_many_nested_placeholder_expansions():
     data = {
-        'section': {
-            'a': '{b}',
-            'b': '{a}',
+        "section": {
+            "a": "{b}",
+            "b": "{a}",
         },
     }
     with pytest.raises(
-        CircularReferenceError, match='Too many nested placeholder expansions'
+        CircularReferenceError, match="Too many nested placeholder expansions"
     ):
         replace_placeholders(data)
 
 
 def test_chained_cross_section_placeholders():
     config = {
-        'build': {
-            'output': '{paths.tmp_deliverable_dir}',
+        "build": {
+            "output": "{paths.tmp_deliverable_dir}",
         },
-        'paths': {
-            'tmp_base_dir': '/tmp/docbuild',
-            'tmp_dir': '{tmp_base_dir}/doc-example-com',
-            'tmp_deliverable_dir': '{paths.tmp_dir}/deliverable/',
+        "paths": {
+            "tmp_base_dir": "/tmp/docbuild",
+            "tmp_dir": "{tmp_base_dir}/doc-example-com",
+            "tmp_deliverable_dir": "{paths.tmp_dir}/deliverable/",
         },
     }
 
     result = replace_placeholders(config)
-    assert result['build']['output'] == '/tmp/docbuild/doc-example-com/deliverable/'
+    assert result["build"]["output"] == "/tmp/docbuild/doc-example-com/deliverable/"
 
 
 def test_escaped_braces():
-    config = {'section': {'key': 'This is a literal brace: {{not_a_placeholder}}'}}
+    config = {"section": {"key": "This is a literal brace: {{not_a_placeholder}}"}}
     result = replace_placeholders(config)
-    assert result['section']['key'] == 'This is a literal brace: {not_a_placeholder}'
+    assert result["section"]["key"] == "This is a literal brace: {not_a_placeholder}"
 
 
 def test_replace_placeholders_max_recursion_error():
     """Test that max recursion depth is enforced."""
     # Create a config with circular references that will cause infinite recursion
     config = {
-        'a': '{b}',
-        'b': '{c}',
-        'c': '{d}',
-        'd': '{e}',
-        'e': '{f}',
-        'f': '{g}',
-        'g': '{h}',
-        'h': '{i}',
-        'i': '{j}',
-        'j': '{k}',
-        'k': '{a}',  # Circular reference back to 'a'
+        "a": "{b}",
+        "b": "{c}",
+        "c": "{d}",
+        "d": "{e}",
+        "e": "{f}",
+        "f": "{g}",
+        "g": "{h}",
+        "h": "{i}",
+        "i": "{j}",
+        "j": "{k}",
+        "k": "{a}",  # Circular reference back to 'a'
     }
 
     # This should raise ValueError due to max recursion depth
     with pytest.raises(
-        CircularReferenceError, match='Too many nested placeholder expansions in key'
+        CircularReferenceError, match="Too many nested placeholder expansions in key"
     ):
         replace_placeholders(config, max_recursion_depth=5)
 
@@ -227,13 +227,13 @@ def test_replace_placeholders_max_recursion_error():
 def test_replace_placeholders_list_with_non_processable_items():
     """Test that list items that are not dict/list/str are skipped."""
     config = {
-        'mixed_list': [
-            'string_item',  # This will be processed (str)
+        "mixed_list": [
+            "string_item",  # This will be processed (str)
             42,  # This will be skipped (int)
             3.14,  # This will be skipped (float)
             True,  # This will be skipped (bool)
             None,  # This will be skipped (NoneType)
-            {'nested': 'dict'},  # This will be processed (dict)
+            {"nested": "dict"},  # This will be processed (dict)
             [1, 2, 3],  # This will be processed (list)
         ]
     }
@@ -243,17 +243,17 @@ def test_replace_placeholders_list_with_non_processable_items():
 
     # The structure should remain the same since no placeholders to replace
     assert result == config
-    assert result['mixed_list'][1] == 42  # int unchanged
-    assert result['mixed_list'][2] == 3.14  # float unchanged
-    assert result['mixed_list'][3] is True  # bool unchanged
-    assert result['mixed_list'][4] is None  # None unchanged
+    assert result["mixed_list"][1] == 42  # int unchanged
+    assert result["mixed_list"][2] == 3.14  # float unchanged
+    assert result["mixed_list"][3] is True  # bool unchanged
+    assert result["mixed_list"][4] is None  # None unchanged
 
 
 def test_placeholder_resolution_error_is_keyerror():
     """Test that PlaceholderResolutionError is a subclass of KeyError."""
     config = {
-        'section': {
-            'value': '{missing_key}',
+        "section": {
+            "value": "{missing_key}",
         },
     }
 
@@ -267,7 +267,8 @@ def test_placeholder_resolution_error_is_keyerror():
 
 def test_placeholder_wrong_type():
     config = 42
-    assert replace_placeholders(config) == 42, 'Non-dict input should return unchanged'
+    assert replace_placeholders(config) == 42, "Non-dict input should return unchanged"
+
 
 def test_appconfig_resolve_placeholders_non_dict_validator_runs():
     """Ensure the AppConfig model validator runs for non-dict input.
@@ -281,13 +282,14 @@ def test_appconfig_resolve_placeholders_non_dict_validator_runs():
     with pytest.raises(ValidationError):
         AppConfig.model_validate(123)
 
+
 # @pytest.mark.skip(reason="Private method test; not typically needed.")
 def test_get_container_name_with_none_key():
     """Test _get_container_name when _current_key is None."""
-    config = {'test': 'value'}
+    config = {"test": "value"}
     resolver = PlaceholderResolver(config)
     # This should return 'unknown' via the public accessor
-    assert resolver.get_container_name() == 'unknown'
+    assert resolver.get_container_name() == "unknown"
 
 
 def test_list_items_are_processed_and_resolved():
@@ -296,19 +298,19 @@ def test_list_items_are_processed_and_resolved():
     This targets the branch that appends list items to the processing stack.
     """
     config = {
-        'global': {'val': 'G'},
-        'items': [
-            {'inner': '{global.val}'},
-            '{global.val}',
+        "global": {"val": "G"},
+        "items": [
+            {"inner": "{global.val}"},
+            "{global.val}",
             42,  # non-processable should be left untouched
         ],
     }
 
     result = replace_placeholders(config)
 
-    assert result['items'][0]['inner'] == 'G'
-    assert result['items'][1] == 'G'
-    assert result['items'][2] == 42
+    assert result["items"][0]["inner"] == "G"
+    assert result["items"][1] == "G"
+    assert result["items"][2] == 42
 
 
 def test_nested_list_processing_appends_stack_items():
@@ -319,13 +321,13 @@ def test_nested_list_processing_appends_stack_items():
     inner `stack.append((value, i, context))` line is executed.
     """
     config = {
-        'seq': [
-            {'inner': '{global.v}'},
-            '{global.v}',
+        "seq": [
+            {"inner": "{global.v}"},
+            "{global.v}",
         ],
-        'global': {'v': 'VAL'},
+        "global": {"v": "VAL"},
     }
 
     out = replace_placeholders(config)
-    assert out['seq'][0]['inner'] == 'VAL'
-    assert out['seq'][1] == 'VAL'
+    assert out["seq"][0]["inner"] == "VAL"
+    assert out["seq"][1] == "VAL"

--- a/tests/config/app/test_deep_merge.py
+++ b/tests/config/app/test_deep_merge.py
@@ -4,16 +4,16 @@ from docbuild.config.merge import deep_merge
 
 
 @pytest.mark.parametrize(
-    'thedicts,expected',
+    "thedicts,expected",
     [
         # 1
-        ([{'a': 1}, {'a': 2}], {'a': 2}),
+        ([{"a": 1}, {"a": 2}], {"a": 2}),
         # 2
-        ([{'a': 1, 'b': 2}, {'a': 2}], {'a': 2, 'b': 2}),
+        ([{"a": 1, "b": 2}, {"a": 2}], {"a": 2, "b": 2}),
         # 3
         (
-            [{'db': {'host': 'localhost', 'port': 1234}}, {'db': {'port': 5432}}],
-            {'db': {'host': 'localhost', 'port': 5432}},
+            [{"db": {"host": "localhost", "port": 1234}}, {"db": {"port": 5432}}],
+            {"db": {"host": "localhost", "port": 5432}},
         ),
         #
     ],

--- a/tests/config/app/test_load_app_config.py
+++ b/tests/config/app/test_load_app_config.py
@@ -11,14 +11,14 @@ def test_load_single_config_file(tmp_path):
     name = "demo"
     """
 
-    config_dir = tmp_path / 'config1'
+    config_dir = tmp_path / "config1"
     config_dir.mkdir()
     config_file = config_dir / APP_CONFIG_FILENAME
     config_file.write_text(config_toml)
 
     config = load_single_config(config_file)
 
-    assert config == {'server': {'name': 'demo'}}
+    assert config == {"server": {"name": "demo"}}
 
 
 def test_load_multiple_config_files(tmp_path):
@@ -33,8 +33,8 @@ def test_load_multiple_config_files(tmp_path):
     version = "1.0"
     """
 
-    dir1 = tmp_path / 'dir1'
-    dir2 = tmp_path / 'dir2'
+    dir1 = tmp_path / "dir1"
+    dir2 = tmp_path / "dir2"
     dir1.mkdir()
     dir2.mkdir()
 
@@ -51,12 +51,12 @@ def test_load_multiple_config_files(tmp_path):
         dir1 / APP_CONFIG_FILENAME,
         dir2 / APP_CONFIG_FILENAME,
     )
-    assert config == {'server': {'name': 'demo', 'debug': True, 'version': '1.0'}}
+    assert config == {"server": {"name": "demo", "debug": True, "version": "1.0"}}
 
 
 def test_load_config_with_default_paths(tmp_path):
     # Prepare a default config directory with the expected config file
-    default_dir = tmp_path / 'default_config'
+    default_dir = tmp_path / "default_config"
     default_dir.mkdir()
     config_toml = """
     [app]
@@ -70,15 +70,15 @@ def test_load_config_with_default_paths(tmp_path):
     )
 
     assert cfgfiles == (default_dir / APP_CONFIG_FILENAME,)
-    assert config == {'app': {'default_used': True}}
+    assert config == {"app": {"default_used": True}}
 
 
 def test_when_path_does_not_exist(monkeypatch):
-    non_existing_path = 'non_existing_dir'
+    non_existing_path = "non_existing_dir"
 
     mock = MagicMock()
     mock.return_value = (tuple(), {})
-    monkeypatch.setattr(docbuild.config.load, 'load_and_merge_configs', mock)
+    monkeypatch.setattr(docbuild.config.load, "load_and_merge_configs", mock)
 
     cfgfiles, config = load_and_merge_configs(
         [APP_CONFIG_FILENAME],

--- a/tests/config/test_loadconfigs.py
+++ b/tests/config/test_loadconfigs.py
@@ -5,7 +5,7 @@ from docbuild.constants import APP_CONFIG_FILENAME, APP_NAME
 
 
 def test_load_app_single_config(tmp_path):
-    configpath = tmp_path / 'etc' / APP_NAME
+    configpath = tmp_path / "etc" / APP_NAME
     configpath.mkdir(parents=True)
     (configpath / APP_CONFIG_FILENAME).write_text(
         """[server]
@@ -16,12 +16,12 @@ port = 1234
 
     cfgfiles, config = load_and_merge_configs([APP_CONFIG_FILENAME], configpath)
     assert cfgfiles == tuple([configpath / APP_CONFIG_FILENAME])
-    assert config == {'server': {'name': 'localhost', 'port': 1234}}
+    assert config == {"server": {"name": "localhost", "port": 1234}}
 
 
 def test_load_app_multiple_configs(tmp_path):
-    system_path = tmp_path / 'etc' / APP_NAME
-    user_path = tmp_path / 'home' / 'test' / '.config' / APP_NAME
+    system_path = tmp_path / "etc" / APP_NAME
+    user_path = tmp_path / "home" / "test" / ".config" / APP_NAME
     local_path = tmp_path
 
     system_path.mkdir(parents=True)
@@ -57,14 +57,14 @@ port = 4321""",
         local_path / APP_CONFIG_FILENAME,
     )
     assert config == {
-        'server': {'name': 'localhost', 'port': 4321},
-        'db': {'name': 'mydatabase'},
+        "server": {"name": "localhost", "port": 4321},
+        "db": {"name": "mydatabase"},
     }
 
 
 def test_load_app_with_one_config_not_exists(tmp_path):
-    system_path = tmp_path / 'etc' / APP_NAME
-    missing_path = tmp_path / 'home' / 'test' / '.config' / APP_NAME
+    system_path = tmp_path / "etc" / APP_NAME
+    missing_path = tmp_path / "home" / "test" / ".config" / APP_NAME
 
     system_path.mkdir(parents=True)
     missing_path.mkdir(parents=True)
@@ -82,11 +82,11 @@ port = 1234
         missing_path,
     )
     assert cfgfiles == (system_path / APP_CONFIG_FILENAME,)
-    assert config == {'server': {'name': 'localhost', 'port': 1234}}
+    assert config == {"server": {"name": "localhost", "port": 1234}}
 
 
 def test_load_app_with_empty_args(tmp_path):
-    system_path = tmp_path / 'etc' / APP_NAME
+    system_path = tmp_path / "etc" / APP_NAME
 
     system_path.mkdir(parents=True)
 
@@ -101,7 +101,7 @@ port = 1234
         system_path,
     )
     assert cfgfiles == (system_path / APP_CONFIG_FILENAME,)
-    assert config == {'server': {'name': 'localhost', 'port': 1234}}
+    assert config == {"server": {"name": "localhost", "port": 1234}}
 
 
 def test_load_app_with_empty_paths(tmp_path):

--- a/tests/config/xml/test_check.py
+++ b/tests/config/xml/test_check.py
@@ -102,10 +102,10 @@ def assert_results(string, messages: list[str]) -> None:
 # -----------------------
 def test_check_in_registry():
     """Test that the check functions are registered correctly."""
-    assert len(register_check.registry) > 0, 'No checks registered'
+    assert len(register_check.registry) > 0, "No checks registered"
     for func in register_check.registry:
-        assert callable(func), f'{func.__name__} is not callable'
-        assert func.__name__.startswith('check_'), (
+        assert callable(func), f"{func.__name__} is not callable"
+        assert func.__name__.startswith("check_"), (
             f'{func.__name__} does not start with "check_"'
         )
 
@@ -116,7 +116,7 @@ def test_check_dc_in_language(xmlnode):
 
 
 def test_check_dc_in_language_double_dc(xmlnode):
-    language = xmlnode.find('.//builddocs/language')
+    language = xmlnode.find(".//builddocs/language")
     first_child = language[0] if language is not None and len(language) > 0 else None
 
     # Append the first deliverable
@@ -126,9 +126,9 @@ def test_check_dc_in_language_double_dc(xmlnode):
     result = check_dc_in_language(xmlnode)
     success, messages = result.success, result.messages
     assert not success
-    assert_results('non-unique values', messages)
-    assert_results('DC-GNOME-getting-started', messages)
-    assert_results('docset=1 language=en-us', messages)
+    assert_results("non-unique values", messages)
+    assert_results("DC-GNOME-getting-started", messages)
+    assert_results("docset=1 language=en-us", messages)
 
 
 # ----
@@ -138,15 +138,15 @@ def test_check_duplicated_categoryid(xmlnode):
 
 def test_check_duplicated_categoryid_with_duplicates(xmlnode):
     # Add a second category with the same categoryid
-    new_category = E.category(categoryid='container')
+    new_category = E.category(categoryid="container")
     # we don't care about the order yet:
     xmlnode.append(new_category)
 
     result = check_duplicated_categoryid(xmlnode)
     success, messages = result.success, result.messages
     assert not success
-    assert_results('non-unique categoryid values', messages)
-    assert_results('container', messages)
+    assert_results("non-unique categoryid values", messages)
+    assert_results("container", messages)
 
 
 # ----
@@ -155,7 +155,7 @@ def test_check_duplicated_format_in_extralinks(xmlnode):
 
 
 def test_check_duplicated_format_in_extralinks_with_duplicates(xmlnode):
-    language = xmlnode.find('.//external/link/language')
+    language = xmlnode.find(".//external/link/language")
     first_child = language[0] if language is not None and len(language) > 0 else None
 
     new_url = copy.deepcopy(first_child)
@@ -164,8 +164,8 @@ def test_check_duplicated_format_in_extralinks_with_duplicates(xmlnode):
     result = check_duplicated_format_in_extralinks(xmlnode)
     success, messages = result.success, result.messages
     assert not success
-    assert_results('Duplicated format attributes found', messages)
-    assert_results('docset=1', messages)
+    assert_results("Duplicated format attributes found", messages)
+    assert_results("docset=1", messages)
 
 
 # ----
@@ -176,24 +176,24 @@ def test_check_duplicated_linkid(xmlnode):
 def test_check_duplicated_linkid_with_duplicates(xmlnode):
     """Test that duplicate linkid values within the same docset are detected."""
     # Add a second link with the same linkid within the same external element
-    external = xmlnode.find('.//external')
-    new_link = etree.Element('link', attrib={'linkid': 'fake-link'}, nsmap=None)
+    external = xmlnode.find(".//external")
+    new_link = etree.Element("link", attrib={"linkid": "fake-link"}, nsmap=None)
 
     # Add a language element to make it a valid link structure
-    language = etree.SubElement(new_link, 'language', attrib=None, nsmap=None)
-    language.set('lang', 'en-us')
-    url = etree.SubElement(language, 'url', attrib=None, nsmap=None)
-    url.set('href', 'https://example.com/duplicate')
-    url.set('format', 'html')
+    language = etree.SubElement(new_link, "language", attrib=None, nsmap=None)
+    language.set("lang", "en-us")
+    url = etree.SubElement(language, "url", attrib=None, nsmap=None)
+    url.set("href", "https://example.com/duplicate")
+    url.set("format", "html")
 
     external.append(new_link)
 
     result = check_duplicated_linkid(xmlnode)
     success, messages = result.success, result.messages
     assert not success
-    assert_results('non-unique linkid values', messages)
-    assert_results('fake-link', messages)
-    assert_results('docset=1', messages)
+    assert_results("non-unique linkid values", messages)
+    assert_results("fake-link", messages)
+    assert_results("docset=1", messages)
 
 
 # ----
@@ -202,7 +202,7 @@ def test_check_duplicated_url_in_extralinks(xmlnode):
 
 
 def test_check_duplicated_url_in_extralinks_with_duplicates(xmlnode):
-    language = xmlnode.find('.//external/link/language')
+    language = xmlnode.find(".//external/link/language")
     first_child = language[0] if language is not None and len(language) > 0 else None
 
     new_url = copy.deepcopy(first_child)
@@ -212,8 +212,8 @@ def test_check_duplicated_url_in_extralinks_with_duplicates(xmlnode):
     result = check_duplicated_url_in_extralinks(xmlnode)
     success, messages = result.success, result.messages
     assert not success
-    assert_results('non-unique href values', messages)
-    assert_results('href', messages)
+    assert_results("non-unique href values", messages)
+    assert_results("href", messages)
 
 
 # ----
@@ -222,20 +222,20 @@ def test_check_enabled_format(xmlnode):
 
 
 def test_check_enabled_format_with_atleast_one(xmlnode):
-    language = xmlnode.find('.//builddocs/language')
+    language = xmlnode.find(".//builddocs/language")
     # Add a new deliverable with no formats enabled
     new_deli = E.deliverable(
-        E.dc('DC-fake-deliverable'),
-        E.format(**{'html': '0', 'pdf': '0', 'single-html': '0', 'epub': '0'}),
+        E.dc("DC-fake-deliverable"),
+        E.format(**{"html": "0", "pdf": "0", "single-html": "0", "epub": "0"}),
     )
     language.append(new_deli)
 
     result = check_enabled_format(xmlnode)
     success, messages = result.success, result.messages
     assert not success
-    assert_results('No enabled format', messages)
-    assert_results('deliverable=DC-fake-deliverable', messages)
-    assert_results('docset=1', messages)
+    assert_results("No enabled format", messages)
+    assert_results("deliverable=DC-fake-deliverable", messages)
+    assert_results("docset=1", messages)
 
 
 # ----
@@ -244,51 +244,50 @@ def test_check_format_subdeliverable(xmlnode):
 
 
 @pytest.mark.parametrize(
-    'formats',
+    "formats",
     [
         # 0
-        {'pdf': '1', 'epub': '0'},
+        {"pdf": "1", "epub": "0"},
         # 1
-        {'pdf': '0', 'epub': '1'},
+        {"pdf": "0", "epub": "1"},
         # 2
-        {'pdf': '1', 'epub': '1'},
+        {"pdf": "1", "epub": "1"},
     ],
 )
 def test_format_subdeliverable(formats, xmlnode, caplog):
     """Test that the check_format_subdeliverable function works as expected."""
     # Add a subdeliverable with no formats enabled
-    language = xmlnode.find('.//builddocs/language')
-    dct_formats = {'html': '1', 'single-html': '0'} | formats
+    language = xmlnode.find(".//builddocs/language")
+    dct_formats = {"html": "1", "single-html": "0"} | formats
     new_deli = E.deliverable(
-        E.dc('DC-fake-subdeliverable'),
+        E.dc("DC-fake-subdeliverable"),
         E.format(**dct_formats),
-        E.subdeliverable('book-subdeliverable'),
+        E.subdeliverable("book-subdeliverable"),
     )
     language.append(new_deli)
 
     result = check_format_subdeliverable(xmlnode)
     success, messages = result.success, result.messages
     assert not success
-    assert_results('deliverable that has subdeliverables', messages)
-    assert_results('deliverable=DC-fake-subdeliverable', messages)
-    assert_results('docset=1', messages)
-    assert_results('language=en-us', messages)
+    assert_results("deliverable that has subdeliverables", messages)
+    assert_results("deliverable=DC-fake-subdeliverable", messages)
+    assert_results("docset=1", messages)
+    assert_results("language=en-us", messages)
 
 
 def test_format_subdeliverable_no_format(xmlnode, caplog):
-    language = xmlnode.find('.//builddocs/language')
+    language = xmlnode.find(".//builddocs/language")
     # dct_formats = {'html': '1', 'single-html': '0'} | formats
     new_deli = E.deliverable(
-        E.dc('DC-fake-subdeliverable'),
+        E.dc("DC-fake-subdeliverable"),
         # E.format(**dct_formats),
-        E.subdeliverable('book-subdeliverable'),
+        E.subdeliverable("book-subdeliverable"),
     )
     language.append(new_deli)
 
     result = check_format_subdeliverable(xmlnode)
-    success, messages = result.success, result.messages
+    success, _ = result.success, result.messages
     assert success
-    # assert messages
 
 
 # ----
@@ -297,14 +296,14 @@ def test_check_lang_code_in_category(xmlnode):
 
 
 def test_check_lang_code_in_category_duplicate_lang(xmlnode):
-    category = xmlnode.find('./category')
-    new_language = E.language(lang='en-us', default='1', title='Containerization')
+    category = xmlnode.find("./category")
+    new_language = E.language(lang="en-us", default="1", title="Containerization")
     category.append(new_language)
 
     result = check_lang_code_in_category(xmlnode)
     success, messages = result.success, result.messages
     assert not success
-    assert_results('have non-unique lang', messages)
+    assert_results("have non-unique lang", messages)
     assert_results("category 'container'", messages)
 
 
@@ -314,15 +313,15 @@ def test_check_lang_code_in_desc(xmlnode):
 
 
 def test_check_lang_code_in_desc_duplicate_lang(xmlnode):
-    desc = xmlnode.find('./desc')
-    new_desc = E.desc(lang='en-us', default='1', title='Fake title')
+    desc = xmlnode.find("./desc")
+    new_desc = E.desc(lang="en-us", default="1", title="Fake title")
     desc.addnext(new_desc)
 
     result = check_lang_code_in_desc(xmlnode)
     success, messages = result.success, result.messages
     assert not success
-    assert_results('have non-unique lang', messages)
-    assert_results('Found duplicates:', messages)
+    assert_results("have non-unique lang", messages)
+    assert_results("Found duplicates:", messages)
 
 
 # ----
@@ -331,15 +330,15 @@ def test_check_lang_code_in_docset(xmlnode):
 
 
 def test_check_lang_code_in_docset_duplicate_lang(xmlnode):
-    docset = xmlnode.find('./docset/builddocs/language')
-    new_language = E.language(lang='en-us', default='1')
+    docset = xmlnode.find("./docset/builddocs/language")
+    new_language = E.language(lang="en-us", default="1")
     docset.addnext(new_language)
 
     result = check_lang_code_in_docset(xmlnode)
     success, messages = result.success, result.messages
     assert not success
-    assert_results('have non-unique lang', messages)
-    assert_results('Found duplicates:', messages)
+    assert_results("have non-unique lang", messages)
+    assert_results("Found duplicates:", messages)
 
 
 # ----
@@ -350,15 +349,15 @@ def test_check_lang_code_in_extralinks(xmlnode):
 
 def test_check_lang_code_in_extralinks_duplicate_lang(xmlnode):
     """Test that the check_lang_code_in_extralinks function works as expected."""
-    language = xmlnode.find('.//external/link/language')
-    new_language = E.language(lang='en-us', default='1', title='Fake title')
+    language = xmlnode.find(".//external/link/language")
+    new_language = E.language(lang="en-us", default="1", title="Fake title")
     language.addnext(new_language)
 
     result = check_lang_code_in_extralinks(xmlnode)
     success, messages = result.success, result.messages
     assert not success
-    assert_results('have non-unique lang', messages)
-    assert_results('Found duplicates:', messages)
+    assert_results("have non-unique lang", messages)
+    assert_results("Found duplicates:", messages)
 
 
 # ----
@@ -367,15 +366,15 @@ def test_check_lang_code_in_overridedesc(xmlnode):
 
 
 def test_check_lang_code_in_overridedesc_duplicate_lang(xmlnode):
-    overridedesc = xmlnode.find('.//overridedesc/desc')
-    new_desc = E.desc(lang='en-us', default='1', title='Fake title')
+    overridedesc = xmlnode.find(".//overridedesc/desc")
+    new_desc = E.desc(lang="en-us", default="1", title="Fake title")
     overridedesc.addnext(new_desc)
 
     result = check_lang_code_in_overridedesc(xmlnode)
     success, messages = result.success, result.messages
     assert not success
-    assert_results('have non-unique lang', messages)
-    assert_results('Found duplicates:', messages)
+    assert_results("have non-unique lang", messages)
+    assert_results("Found duplicates:", messages)
 
 
 # ----
@@ -427,8 +426,8 @@ def test_check_subdeliverable_in_deliverable_duplicate_subdeliverable():
     result = check_subdeliverable_in_deliverable(node)
     success, messages = result.success, result.messages
     assert not success
-    assert_results('book-1', messages)
-    assert_results('docset=1/language=en-us', messages)
+    assert_results("book-1", messages)
+    assert_results("docset=1/language=en-us", messages)
 
 
 # ---
@@ -438,26 +437,26 @@ def test_check_translation_deliverables(xmlnode):
 
 def test_check_translation_deliverables_invalid(xmlnode, caplog):
     # Add a deliverable with a non-translation DC
-    language = xmlnode.find('./docset/builddocs/language')
+    language = xmlnode.find("./docset/builddocs/language")
     builddocs = language.getparent()
     builddocs.remove(language)
 
     new_deli_en_us = E.language(
         E.deliverable(
-            E.dc('DC-fake-all'),
-            E.format(html='1', pdf='1', single_html='0'),
-            E.subdeliverable('book-1'),
+            E.dc("DC-fake-all"),
+            E.format(html="1", pdf="1", single_html="0"),
+            E.subdeliverable("book-1"),
         ),
-        default='1',
-        lang='en-us',
+        default="1",
+        lang="en-us",
     )
     new_deli_de_de = E.language(
         E.deliverable(
-            E.dc('DC-fake-all'),
+            E.dc("DC-fake-all"),
             # no format!
-            E.subdeliverable('book-2'),  # is not available in en-us
+            E.subdeliverable("book-2"),  # is not available in en-us
         ),
-        lang='de-de',
+        lang="de-de",
     )
     builddocs.append(new_deli_en_us)
     builddocs.append(new_deli_de_de)
@@ -466,35 +465,35 @@ def test_check_translation_deliverables_invalid(xmlnode, caplog):
     result = check_translation_deliverables(xmlnode)
     success, messages = result.success, result.messages
     assert not success
-    assert_results('DC-fake-all', messages)
+    assert_results("DC-fake-all", messages)
     assert_results("The subdeliverable 'book-2'", messages)
-    assert_results('docset=1/language=de-de/deliverable=DC-fake-all', messages)
+    assert_results("docset=1/language=de-de/deliverable=DC-fake-all", messages)
 
 
 def test_check_translation_deliverables_valid_with_subdeliverables(xmlnode):
     # First remove the existing language node
     # and add a new one with valid deliverables.
     # This is to simulate a valid case with multiple languages and subdeliverables.
-    language = xmlnode.find('./docset/builddocs/language')
+    language = xmlnode.find("./docset/builddocs/language")
     builddocs = language.getparent()
     builddocs.remove(language)
 
     new_deli_en_us = E.language(
         E.deliverable(
-            E.dc('DC-fake-all'),
-            E.format(html='1', pdf='1', single_html='0'),
-            E.subdeliverable('book-1'),
+            E.dc("DC-fake-all"),
+            E.format(html="1", pdf="1", single_html="0"),
+            E.subdeliverable("book-1"),
         ),
-        default='1',
-        lang='en-us',
+        default="1",
+        lang="en-us",
     )
     new_deli_de_de = E.language(
         E.deliverable(
-            E.dc('DC-fake-all'),
+            E.dc("DC-fake-all"),
             # no format!
-            E.subdeliverable('book-1'),
+            E.subdeliverable("book-1"),
         ),
-        lang='de-de',
+        lang="de-de",
     )
     builddocs.append(new_deli_en_us)
     builddocs.append(new_deli_de_de)
@@ -510,13 +509,13 @@ def test_check_valid_languages(xmlnode):
 
 def test_check_valid_languages_invalid_language(xmlnode):
     # Add an invalid language code
-    language = xmlnode.find('.//builddocs/language')
-    new_language = E.language(lang='invalid-lang', default='1')
+    language = xmlnode.find(".//builddocs/language")
+    new_language = E.language(lang="invalid-lang", default="1")
     language.addnext(new_language)
 
     result = check_valid_languages(xmlnode)
     success, messages = result.success, result.messages
     assert not success
-    assert_results('invalid language code', messages)
-    assert_results('invalid-lang', messages)
-    assert_results('docset=1', messages)
+    assert_results("invalid language code", messages)
+    assert_results("invalid-lang", messages)
+    assert_results("docset=1", messages)

--- a/tests/config/xml/test_list.py
+++ b/tests/config/xml/test_list.py
@@ -46,48 +46,48 @@ def node() -> etree._ElementTree:
 
 
 @pytest.mark.parametrize(
-    'doctypes, dc_files',
+    "doctypes, dc_files",
     [
         # 0
-        (None, ['DC-SLES-administration', 'DC-SLES-deployment', 'DC-SLES-autoyast']),
+        (None, ["DC-SLES-administration", "DC-SLES-deployment", "DC-SLES-autoyast"]),
         # 1
         (
-            [Doctype.from_str('*/*@supported,beta/en-us')],
-            ['DC-SLES-administration', 'DC-SLES-deployment', 'DC-SLES-autoyast'],
+            [Doctype.from_str("*/*@supported,beta/en-us")],
+            ["DC-SLES-administration", "DC-SLES-deployment", "DC-SLES-autoyast"],
         ),
         # 2
         (
-            [Doctype.from_str('sles/*@supported,beta/en-us')],
-            ['DC-SLES-administration', 'DC-SLES-deployment', 'DC-SLES-autoyast'],
+            [Doctype.from_str("sles/*@supported,beta/en-us")],
+            ["DC-SLES-administration", "DC-SLES-deployment", "DC-SLES-autoyast"],
         ),
         # 3
         (
-            [Doctype.from_str('sles/*@supported,beta/en-us,de-de')],
+            [Doctype.from_str("sles/*@supported,beta/en-us,de-de")],
             [
-                'DC-SLES-administration',
-                'DC-SLES-deployment',
-                'DC-SLES-administration',
-                'DC-SLES-autoyast',
+                "DC-SLES-administration",
+                "DC-SLES-deployment",
+                "DC-SLES-administration",
+                "DC-SLES-autoyast",
             ],
         ),
         # 4
         (
-            [Doctype.from_str('sles/15sp4,15sp5/en-us')],
-            ['DC-SLES-administration', 'DC-SLES-deployment', 'DC-SLES-autoyast'],
+            [Doctype.from_str("sles/15sp4,15sp5/en-us")],
+            ["DC-SLES-administration", "DC-SLES-deployment", "DC-SLES-autoyast"],
         ),
         # 5
         (
-            [Doctype.from_str('sles/*/*')],
+            [Doctype.from_str("sles/*/*")],
             [
-                'DC-SLES-administration',
-                'DC-SLES-deployment',
-                'DC-SLES-administration',
-                'DC-SLES-autoyast',
+                "DC-SLES-administration",
+                "DC-SLES-deployment",
+                "DC-SLES-administration",
+                "DC-SLES-autoyast",
             ],
         ),
         # 6
         (
-            [Doctype.from_str('smart/*/en-us')],
+            [Doctype.from_str("smart/*/en-us")],
             [],
         ),
     ],

--- a/tests/config/xml/test_references.py
+++ b/tests/config/xml/test_references.py
@@ -54,8 +54,8 @@ def xml_tree() -> etree._Element:
 
 def add_ref(tree: etree._Element, attrs: dict[str, str]) -> etree._Element:
     """Add a <ref> element to the test tree and return it."""
-    internal_node = tree.find('.//internal')
-    ref_element = etree.SubElement(internal_node, 'ref', attrib=attrs)
+    internal_node = tree.find(".//internal")
+    ref_element = etree.SubElement(internal_node, "ref", attrib=attrs)
     return ref_element
 
 
@@ -63,10 +63,10 @@ class TestCheckRefToSubdeliverable:
     def test_valid_ref(self, xml_tree):
         """Test a valid reference to a subdeliverable."""
         attrs = {
-            'product': 'p1',
-            'docset': 'ds1',
-            'dc': 'DC-1',
-            'subdeliverable': 'sub-1',
+            "product": "p1",
+            "docset": "ds1",
+            "dc": "DC-1",
+            "subdeliverable": "sub-1",
         }
         ref = add_ref(xml_tree, attrs)
         assert check_ref_to_subdeliverable(ref, attrs) is None
@@ -74,87 +74,87 @@ class TestCheckRefToSubdeliverable:
     def test_invalid_ref_does_not_exist(self, xml_tree):
         """Test an invalid reference to a non-existent subdeliverable."""
         attrs = {
-            'product': 'p1',
-            'docset': 'ds1',
-            'dc': 'DC-1',
-            'subdeliverable': 'invalid',
+            "product": "p1",
+            "docset": "ds1",
+            "dc": "DC-1",
+            "subdeliverable": "invalid",
         }
         ref = add_ref(xml_tree, attrs)
         result = check_ref_to_subdeliverable(ref, attrs)
         assert result is not None
-        assert 'Referenced subdeliverable does not exist' in result
+        assert "Referenced subdeliverable does not exist" in result
 
 
 class TestCheckRefToDeliverable:
     def test_valid_ref(self, xml_tree):
         """Test a valid reference to a deliverable without subdeliverables."""
-        attrs = {'product': 'p1', 'docset': 'ds1', 'dc': 'DC-2'}
+        attrs = {"product": "p1", "docset": "ds1", "dc": "DC-2"}
         ref = add_ref(xml_tree, attrs)
         assert check_ref_to_deliverable(ref, attrs) is None
 
     def test_invalid_ref_has_subdeliverables(self, xml_tree):
         """Test reference to a deliverable that has subdeliverables."""
-        attrs = {'product': 'p1', 'docset': 'ds1', 'dc': 'DC-1'}
+        attrs = {"product": "p1", "docset": "ds1", "dc": "DC-1"}
         ref = add_ref(xml_tree, attrs)
         result = check_ref_to_deliverable(ref, attrs)
         assert result is not None
-        assert 'Referenced deliverable has subdeliverables' in result
+        assert "Referenced deliverable has subdeliverables" in result
 
     def test_invalid_ref_does_not_exist(self, xml_tree):
         """Test reference to a deliverable that does not exist."""
-        attrs = {'product': 'p1', 'docset': 'ds1', 'dc': 'invalid-dc'}
+        attrs = {"product": "p1", "docset": "ds1", "dc": "invalid-dc"}
         ref = add_ref(xml_tree, attrs)
         result = check_ref_to_deliverable(ref, attrs)
         assert result is not None
-        assert 'Referenced deliverable does not exist' in result
+        assert "Referenced deliverable does not exist" in result
 
 
 class TestCheckRefToLink:
     def test_valid_ref(self, xml_tree):
         """Test a valid reference to an external link."""
-        attrs = {'product': 'p1', 'docset': 'ds1', 'link': 'link-1'}
+        attrs = {"product": "p1", "docset": "ds1", "link": "link-1"}
         ref = add_ref(xml_tree, attrs)
         assert check_ref_to_link(ref, attrs) is None
 
     def test_invalid_ref_does_not_exist(self, xml_tree):
         """Test reference to a link that does not exist."""
-        attrs = {'product': 'p1', 'docset': 'ds1', 'link': 'invalid-link'}
+        attrs = {"product": "p1", "docset": "ds1", "link": "invalid-link"}
         ref = add_ref(xml_tree, attrs)
         result = check_ref_to_link(ref, attrs)
         assert result is not None
-        assert 'Referenced external link does not exist' in result
+        assert "Referenced external link does not exist" in result
 
 
 class TestCheckRefToDocset:
     def test_valid_ref(self, xml_tree):
         """Test a valid reference to a docset."""
-        attrs = {'product': 'p1', 'docset': 'ds2'}
+        attrs = {"product": "p1", "docset": "ds2"}
         ref = add_ref(xml_tree, attrs)
         assert check_ref_to_docset(ref, attrs) is None
 
     def test_invalid_ref_does_not_exist(self, xml_tree):
         """Test reference to a docset that does not exist."""
-        attrs = {'product': 'p1', 'docset': 'invalid-ds'}
+        attrs = {"product": "p1", "docset": "invalid-ds"}
         ref = add_ref(xml_tree, attrs)
         result = check_ref_to_docset(ref, attrs)
         assert result is not None
-        assert 'Referenced docset does not exist' in result
+        assert "Referenced docset does not exist" in result
 
 
 class TestCheckRefToProduct:
     def test_valid_ref(self, xml_tree):
         """Test a valid reference to a product."""
-        attrs = {'product': 'p2'}
+        attrs = {"product": "p2"}
         ref = add_ref(xml_tree, attrs)
         assert check_ref_to_product(ref, attrs) is None
 
     def test_invalid_ref_does_not_exist(self, xml_tree):
         """Test reference to a product that does not exist."""
-        attrs = {'product': 'invalid-p'}
+        attrs = {"product": "invalid-p"}
         ref = add_ref(xml_tree, attrs)
         result = check_ref_to_product(ref, attrs)
         assert result is not None
-        assert 'Referenced product does not exist' in result
+        assert "Referenced product does not exist" in result
 
 
 class TestCheckStitchedReferences:
@@ -164,15 +164,15 @@ class TestCheckStitchedReferences:
         """Test that no errors are returned for a file with all valid refs."""
         add_ref(
             xml_tree,
-            {'product': 'p1', 'docset': 'ds1', 'dc': 'DC-1', 'subdeliverable': 'sub-1'},
+            {"product": "p1", "docset": "ds1", "dc": "DC-1", "subdeliverable": "sub-1"},
         )
-        add_ref(xml_tree, {'product': 'p1', 'docset': 'ds1', 'dc': 'DC-2'})
-        add_ref(xml_tree, {'product': 'p1', 'docset': 'ds1', 'link': 'link-1'})
-        add_ref(xml_tree, {'product': 'p1', 'docset': 'ds2'})
-        add_ref(xml_tree, {'product': 'p2'})
+        add_ref(xml_tree, {"product": "p1", "docset": "ds1", "dc": "DC-2"})
+        add_ref(xml_tree, {"product": "p1", "docset": "ds1", "link": "link-1"})
+        add_ref(xml_tree, {"product": "p1", "docset": "ds2"})
+        add_ref(xml_tree, {"product": "p2"})
 
         errors = check_stitched_references(etree.ElementTree(xml_tree))
-        assert not errors, f'Expected no errors, but got: {errors}'
+        assert not errors, f"Expected no errors, but got: {errors}"
 
     def test_all_invalid_refs(self, xml_tree):
         """Test that all invalid reference types are caught."""
@@ -180,17 +180,17 @@ class TestCheckStitchedReferences:
         add_ref(
             tree_copy,
             {
-                'product': 'p1',
-                'docset': 'ds1',
-                'dc': 'DC-1',
-                'subdeliverable': 'invalid',
+                "product": "p1",
+                "docset": "ds1",
+                "dc": "DC-1",
+                "subdeliverable": "invalid",
             },
         )
-        add_ref(tree_copy, {'product': 'p1', 'docset': 'ds1', 'dc': 'DC-1'})
-        add_ref(tree_copy, {'product': 'p1', 'docset': 'ds1', 'dc': 'invalid-dc'})
-        add_ref(tree_copy, {'product': 'p1', 'docset': 'ds1', 'link': 'invalid-link'})
-        add_ref(tree_copy, {'product': 'p1', 'docset': 'invalid-ds'})
-        add_ref(tree_copy, {'product': 'invalid-p'})
+        add_ref(tree_copy, {"product": "p1", "docset": "ds1", "dc": "DC-1"})
+        add_ref(tree_copy, {"product": "p1", "docset": "ds1", "dc": "invalid-dc"})
+        add_ref(tree_copy, {"product": "p1", "docset": "ds1", "link": "invalid-link"})
+        add_ref(tree_copy, {"product": "p1", "docset": "invalid-ds"})
+        add_ref(tree_copy, {"product": "invalid-p"})
 
         errors = check_stitched_references(etree.ElementTree(tree_copy))
         assert len(errors) == 6
@@ -200,4 +200,4 @@ class TestCheckStitchedReferences:
         add_ref(xml_tree, {})  # Empty ref
         errors = check_stitched_references(etree.ElementTree(xml_tree))
         assert len(errors) == 1
-        assert 'This is a docserv-stitch bug' in errors[0]
+        assert "This is a docserv-stitch bug" in errors[0]

--- a/tests/config/xml/test_stitch.py
+++ b/tests/config/xml/test_stitch.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 
 from lxml import etree
 import pytest
@@ -67,21 +66,20 @@ class TestLoadCheckFunctions:
         # Should return functions that start with "check_"
         for func in functions:
             assert callable(func)
-            assert func.__name__.startswith('check_')
+            assert func.__name__.startswith("check_")
 
 
 class TestStitchfile:
-
     async def test_create_stitchfile_with_xml_files(self, tmp_path):
         """Test create_stitchfile with XML files in directory."""
         # This will cover lines 52-58
         # Create some XML files
-        xml1 = tmp_path / 'config1.xml'
+        xml1 = tmp_path / "config1.xml"
         xml1.write_text("""<product productid="test1">
 <name>Product 1</name>
 </product>""")
 
-        xml2 = tmp_path / 'config2.xml'
+        xml2 = tmp_path / "config2.xml"
         xml2.write_text("""<product productid="test2">
 <name>Product 2</name>
 </product>""")
@@ -91,12 +89,12 @@ class TestStitchfile:
 
         assert isinstance(result, etree._ElementTree)
         root = result.getroot()
-        assert root.tag == 'docservconfig'
+        assert root.tag == "docservconfig"
 
         # Should contain both XML files as children
         children = list(root)
         assert len(children) == 2
-        assert all(child.tag == 'product' for child in children)
+        assert all(child.tag == "product" for child in children)
 
     def test_check_stitchfile_valid_refs(self, xmlnode):
         """Test check_stitchfile with valid references."""
@@ -105,14 +103,17 @@ class TestStitchfile:
 
     def test_check_stitchfile_invalid_product_ref(self, xmlnode):
         """Test check_stitchfile with an invalid product reference."""
-        internal_node = xmlnode.find('.//internal')
+        internal_node = xmlnode.find(".//internal")
         # Add a ref to a product that does not exist
-        etree.SubElement(internal_node,
-                         'ref',
-                         attrib={'product': 'invalid-product',
-                                 'docset': 'unknown',
-                                 'dc': 'DC-unknown',
-                                 })
+        etree.SubElement(
+            internal_node,
+            "ref",
+            attrib={
+                "product": "invalid-product",
+                "docset": "unknown",
+                "dc": "DC-unknown",
+            },
+        )
         result = check_stitchfile(xmlnode)
         assert not result
 
@@ -131,7 +132,7 @@ class TestStitchfile:
         xml_file.write_text(invalid_xml_content)
 
         with pytest.raises(
-            ValueError, match='Unresolved references found in stitch file'
+            ValueError, match="Unresolved references found in stitch file"
         ):
             await create_stitchfile([xml_file], with_ref_check=True)
 
@@ -159,8 +160,8 @@ class TestStitchfile:
         result = await create_stitchfile([xml_file], with_ref_check=False)
         assert isinstance(result, etree._ElementTree)
         root = result.getroot()
-        assert root.tag == 'docservconfig'
-        assert len(root.findall('product')) == 1
+        assert root.tag == "docservconfig"
+        assert len(root.findall("product")) == 1
 
     async def test_create_stitchfile_with_valid_refs_does_not_raise(
         self, product_xml_string, tmp_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 """Pytest fixtures and global logging mock."""
 
 from collections.abc import Callable, Generator
-import os
 from pathlib import Path
 from typing import Any, NamedTuple
 from unittest.mock import MagicMock, Mock
@@ -22,38 +21,44 @@ from tests.common import changedir
 
 # Adding info to test report header
 # https://docs.pytest.org/en/stable/example/simple.html#adding-info-to-test-report-header
-def pytest_report_header(config: pytest.Config):
+def pytest_report_header(config: pytest.Config) -> str:
+    """Add DocBuild version to the pytest report header."""
     from docbuild.__about__ import __version__
 
-    return f'DocBuild Version: {__version__}'
+    return f"DocBuild Version: {__version__}"
 
 
 # --- Global Fixture to Mute Logging Setup (Debugging Step) ---
 @pytest.fixture(autouse=True, scope="function")
-def mock_setup_logging_globally(monkeypatch):
-    """Mocks out the setup_logging call to prevent any initialization side-effects in tests."""
+def mock_setup_logging_globally(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Mock out the setup_logging call.
+
+    To prevent any initialization side-effects in tests.
+    """
     mock_func = MagicMock()
     # This prevents docbuild.logging.setup_logging from ever running during tests.
     monkeypatch.setattr(docbuild.logging, "setup_logging", mock_func)
     return mock_func
 
+
 # --- Original Fixtures ---
 
-@pytest.fixture(scope='function')
+
+@pytest.fixture(scope="function")
 def runner() -> CliRunner:
     """Provide a CliRunner instance for testing."""
     return CliRunner()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def default_env_config_filename(tmp_path: Path) -> Path:
     """Provide a default env config file path."""
     envfile = tmp_path / DEFAULT_ENV_CONFIG_FILENAME
-    envfile.write_text('')
+    envfile.write_text("")
     return envfile
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def env_content(default_env_config_filename: Path) -> Path:
     """Provide a default content for the env config file."""
     content = """# Test file
@@ -103,6 +108,7 @@ def context() -> DocBuildContext:
 
 # --- Mocking fixtures
 
+
 class MockEnvConfig(NamedTuple):
     """Named tuple to hold the fake env file and mock."""
 
@@ -120,7 +126,7 @@ class MockCombinedConfig(NamedTuple):
 
 
 def make_path_mock(
-    path: str = '',
+    path: str = "",
     return_values: dict | None = None,
     side_effects: dict | None = None,
     attributes: dict | None = None,
@@ -129,7 +135,7 @@ def make_path_mock(
     from pathlib import Path
     from unittest.mock import MagicMock
 
-    path_obj = Path(path) if path else Path('mocked')
+    path_obj = Path(path) if path else Path("mocked")
     mock = MagicMock(spec=Path)
 
     # Path-like behavior
@@ -175,18 +181,18 @@ def fake_confiles(
 ) -> Generator[MockEnvConfig, None, None]:
     """Patch the `docbuild.cli.cli.load_and_merge_configs` function."""
     with changedir(tmp_path):
-        fakefile = Path('fake_config.toml')
+        fakefile = Path("fake_config.toml")
         mock = MagicMock(
             return_value=(
                 [fakefile],
                 {
-                    'fake_config_key': 'fake_config_value',
+                    "fake_config_key": "fake_config_value",
                 },
             ),
         )
         monkeypatch.setattr(
             load_mod,
-            'load_and_merge_configs',
+            "load_and_merge_configs",
             mock,
         )
         yield MockEnvConfig(fakefile, mock)
@@ -199,7 +205,7 @@ def fake_validate_options(
 ) -> Generator[MockCombinedConfig, None, None]:
     """Patch the `docbuild.cli.validate_options` function."""
     with changedir(tmp_path):
-        fakefile = Path('fake_validate_options.toml').absolute()
+        fakefile = Path("fake_validate_options.toml").absolute()
 
         mock = MagicMock()
         mock.return_value = None
@@ -207,19 +213,19 @@ def fake_validate_options(
         mock_load_and_merge_configs = MagicMock()
         mock_load_and_merge_configs.return_value = (
             [fakefile],
-            {'fake_key': 'fake_value'},
+            {"fake_key": "fake_value"},
         )
         monkeypatch.setattr(
             cli_module,
-            'load_and_merge_configs',
+            "load_and_merge_configs",
             mock_load_and_merge_configs,
         )
 
         mock_load_single_config = MagicMock()
-        mock_load_single_config.return_value = {'fake_key': 'fake_value'}
+        mock_load_single_config.return_value = {"fake_key": "fake_value"}
         monkeypatch.setattr(
             cli_module,
-            'load_single_config',
+            "load_single_config",
             mock_load_single_config,
         )
 
@@ -248,9 +254,9 @@ def env_config_file(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def fake_handle_config(monkeypatch: pytest.MonkeyPatch) -> Callable[
-    [Callable[[Any], tuple]], None
-]:
+def fake_handle_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[Callable[[Any], tuple]], None]:
     """Return a helper that installs a resolver as the `handle_config` implementation.
 
     The resolver should be a callable accepting `user_path` and returning
@@ -261,7 +267,8 @@ def fake_handle_config(monkeypatch: pytest.MonkeyPatch) -> Callable[
     """
 
     def install(resolver: Callable[[Any], tuple]) -> None:
-        monkeypatch.setattr(cli, 'handle_config',
-                            lambda user_path, *a, **kw: resolver(user_path))
+        monkeypatch.setattr(
+            cli, "handle_config", lambda user_path, *a, **kw: resolver(user_path)
+        )
 
     return install

--- a/tests/models/config/test_app.py
+++ b/tests/models/config/test_app.py
@@ -1,30 +1,34 @@
 """Tests for the AppConfig Pydantic model and its validation logic."""
 
-import pytest
 from unittest.mock import Mock
+
 from pydantic import ValidationError
+import pytest
 
-from docbuild.models.config.app import AppConfig
 from docbuild.models.config import app as app_module
-
+from docbuild.models.config.app import AppConfig
 
 # --- Helper Fixtures ---
+
 
 @pytest.fixture
 def mock_replace_placeholders(monkeypatch):
     """Mock the replace_placeholders utility to confirm it was invoked."""
-    mock = Mock(return_value={
-        'logging': {'version': 1},
-        'feature': 'flag',
-        'path_with_placeholder': 'resolved/path/APP_NAME_VALUE',
-    })
+    mock = Mock(
+        return_value={
+            "logging": {"version": 1},
+            "feature": "flag",
+            "path_with_placeholder": "resolved/path/APP_NAME_VALUE",
+        }
+    )
 
-    # Patch the actual symbol used inside AppConfig’s module
+    # Patch the actual symbol used inside AppConfig's module
     monkeypatch.setattr(app_module, "replace_placeholders", mock)
     return mock
 
 
 # --- Test Cases ---
+
 
 def test_appconfig_initializes_with_defaults():
     """Ensure AppConfig initializes correctly with default logging configuration."""
@@ -33,22 +37,22 @@ def test_appconfig_initializes_with_defaults():
     assert isinstance(config, AppConfig)
     assert config.logging.version == 1
     assert isinstance(config.logging.root.handlers, list)
-    assert config.logging.root.level == 'DEBUG'
+    assert config.logging.root.level == "DEBUG"
 
 
 def test_appconfig_accepts_valid_data():
     """Ensure AppConfig accepts and validates well-formed configuration data."""
     valid_data = {
-        'logging': {
-            'version': 1,
-            'handlers': {
-                'file_handler': {'class': 'logging.FileHandler', 'level': 'INFO'},
+        "logging": {
+            "version": 1,
+            "handlers": {
+                "file_handler": {"class": "logging.FileHandler", "level": "INFO"},
             },
-            'formatters': {
-                'simple': {'format': '(%s)'},
+            "formatters": {
+                "simple": {"format": "(%s)"},
             },
-            'loggers': {
-                'app_logger': {'handlers': ['file_handler']},
+            "loggers": {
+                "app_logger": {"handlers": ["file_handler"]},
             },
         },
     }
@@ -56,16 +60,17 @@ def test_appconfig_accepts_valid_data():
     config = AppConfig.from_dict(valid_data)
 
     assert config.logging.version == 1
-    assert config.logging.handlers['file_handler'].level == 'INFO'
-    assert config.logging.loggers['app_logger'].handlers == ['file_handler']
+    assert config.logging.handlers["file_handler"].level == "INFO"
+    assert config.logging.loggers["app_logger"].handlers == ["file_handler"]
 
 
 def test_appconfig_placeholder_resolution_is_called(mock_replace_placeholders):
     """Verify that the model validator triggers placeholder resolution."""
     data = {
-        'logging': {'version': 1},
-        'path_with_placeholder': 'some/path/{APP_NAME}',  # Placeholder triggers resolution logic
-        'feature': 'flag',
+        "logging": {"version": 1},
+        # Placeholder triggers resolution logic:
+        "path_with_placeholder": "some/path/{APP_NAME}",
+        "feature": "flag",
     }
 
     AppConfig.from_dict(data)
@@ -76,82 +81,86 @@ def test_appconfig_placeholder_resolution_is_called(mock_replace_placeholders):
 def test_appconfig_rejects_typo_in_logger_spec():
     """Reject configurations with unexpected keys in LoggerConfig."""
     invalid_data = {
-        'logging': {
-            'version': 1,
-            'loggers': {
-                'app_logger': {
-                    'level': 'DEBUG',
-                    'propogate': True,  # typo: should be 'propagate'
+        "logging": {
+            "version": 1,
+            "loggers": {
+                "app_logger": {
+                    "level": "DEBUG",
+                    "propogate": True,  # typo: should be 'propagate'
                 },
             },
         },
     }
 
-    with pytest.raises(ValidationError, match='Extra inputs are not permitted'):
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
         AppConfig.from_dict(invalid_data)
 
 
 def test_appconfig_rejects_invalid_log_version():
     """Reject invalid logging version (must be Literal[1])."""
-    invalid_data = {'logging': {'version': 2}}
+    invalid_data = {"logging": {"version": 2}}
 
-    with pytest.raises(ValidationError, match='Input should be 1'):
+    with pytest.raises(ValidationError, match="Input should be 1"):
         AppConfig.from_dict(invalid_data)
 
 
 def test_appconfig_rejects_unresolved_placeholder():
     """Raise error if a configuration placeholder cannot be resolved."""
     unresolved_data = {
-        'logging': {'version': 1},
-        'path': '{UNRESOLVED_VAR}',
+        "logging": {"version": 1},
+        "path": "{UNRESOLVED_VAR}",
     }
 
-    with pytest.raises(ValueError, match='Configuration placeholder error'):
+    with pytest.raises(ValueError, match="Configuration placeholder error"):
         AppConfig.from_dict(unresolved_data)
 
 
 # --- Cross-Reference Validation Tests ---
 
+
 def test_appconfig_valid_cross_reference():
     """Allow valid handler and logger cross-references."""
     valid_data = {
-        'logging': {
-            'version': 1,
-            'handlers': {
-                'h1': {'class': 'logging.StreamHandler'},
-                'h2': {'class': 'logging.FileHandler'},
+        "logging": {
+            "version": 1,
+            "handlers": {
+                "h1": {"class": "logging.StreamHandler"},
+                "h2": {"class": "logging.FileHandler"},
             },
-            'loggers': {
-                'app_logger': {'level': 'DEBUG', 'handlers': ['h1', 'h2']},
+            "loggers": {
+                "app_logger": {"level": "DEBUG", "handlers": ["h1", "h2"]},
             },
-            'root': {
-                'level': 'INFO',
-                'handlers': ['h2'],
+            "root": {
+                "level": "INFO",
+                "handlers": ["h2"],
             },
         },
     }
 
     config = AppConfig.from_dict(valid_data)
 
-    assert config.logging.loggers['app_logger'].handlers == ['h1', 'h2']
-    assert config.logging.root.handlers == ['h2']
+    assert config.logging.loggers["app_logger"].handlers == ["h1", "h2"]
+    assert config.logging.root.handlers == ["h2"]
 
 
 def test_appconfig_rejects_missing_handler_reference():
     """Raise error when a logger references a handler that doesn't exist."""
     invalid_data = {
-        'logging': {
-            'version': 1,
-            'handlers': {'h1': {'class': 'logging.StreamHandler'}},
-            'loggers': {
-                'app_logger': {'level': 'DEBUG', 'handlers': ['h1', 'file_log']},
+        "logging": {
+            "version": 1,
+            "handlers": {"h1": {"class": "logging.StreamHandler"}},
+            "loggers": {
+                "app_logger": {"level": "DEBUG", "handlers": ["h1", "file_log"]},
             },
         },
     }
 
     with pytest.raises(
         ValueError,
-        match="logger 'app_logger': The following handler names are referenced but not defined: file_log",
+        match=(
+            "logger 'app_logger': "
+            "The following handler names are referenced but not defined: file_log"
+        ),
     ):
         AppConfig.from_dict(invalid_data)
 
@@ -159,13 +168,13 @@ def test_appconfig_rejects_missing_handler_reference():
 def test_appconfig_rejects_missing_formatter_reference():
     """Raise error when a handler references a non-existent formatter."""
     invalid_data = {
-        'logging': {
-            'version': 1,
-            'formatters': {'simple': {'format': '%(message)s'}},
-            'handlers': {
-                'h1': {
-                    'class': 'logging.StreamHandler',
-                    'formatter': 'detailed',  # formatter not defined
+        "logging": {
+            "version": 1,
+            "formatters": {"simple": {"format": "%(message)s"}},
+            "handlers": {
+                "h1": {
+                    "class": "logging.StreamHandler",
+                    "formatter": "detailed",  # formatter not defined
                 },
             },
         },
@@ -173,6 +182,9 @@ def test_appconfig_rejects_missing_formatter_reference():
 
     with pytest.raises(
         ValueError,
-        match="Configuration error in handler 'h1': Formatter 'detailed' is referenced but not defined",
+        match=(
+            "Configuration error in handler 'h1': "
+            "Formatter 'detailed' is referenced but not defined"
+        ),
     ):
         AppConfig.from_dict(invalid_data)

--- a/tests/models/config/test_env.py
+++ b/tests/models/config/test_env.py
@@ -1,53 +1,67 @@
 """Unit tests for the EnvConfig Pydantic models."""
 
+from ipaddress import IPv4Address
 from pathlib import Path
 from typing import Any
-import os
-from unittest.mock import Mock
 
+from pydantic import ValidationError
 import pytest
-from pydantic import ValidationError, HttpUrl, IPvAnyAddress
-from ipaddress import IPv4Address
 
-from docbuild.models.config.env import EnvConfig, Env_Server
 import docbuild.config.app as config_app_mod
-
+from docbuild.models.config.env import EnvConfig
 
 # --- Fixture Setup ---
 
-def _mock_successful_placeholder_resolver(data: dict[str, Any]) -> dict[str, Any]:
-    """Mocks the placeholder resolver to return a guaranteed clean, resolved dictionary."""
 
+def _mock_successful_placeholder_resolver(data: dict[str, Any]) -> dict[str, Any]:
+    """Mock the placeholder resolver to return a clean, resolved dictionary."""
     resolved_data = data.copy()
 
     # Define resolved paths based on the EnvConfig structure
-    tmp_general = '/var/tmp/docbuild/doc-example-com'
+    tmp_general = "/var/tmp/docbuild/doc-example-com"
 
-    resolved_data['paths']['config_dir'] = '/etc/docbuild'
-    resolved_data['paths']['root_config_dir'] = '/etc/docbuild'
-    resolved_data['paths']['jinja_dir'] = '/etc/docbuild/jinja-doc-suse-com'
-    resolved_data['paths']['server_rootfiles_dir'] = '/etc/docbuild/server-root-files-doc-suse-com'
-    resolved_data['paths']['repo_dir'] = '/var/cache/docbuild/repos/permanent-full/'
-    resolved_data['paths']['temp_repo_dir'] = '/var/cache/docbuild/repos/temporary-branches/'
-    resolved_data['paths']['base_cache_dir'] = '/var/cache/docserv'
-    resolved_data['paths']['base_server_cache_dir'] = '/var/cache/docserv/doc-example-com'
-    resolved_data['paths']['meta_cache_dir'] = '/var/cache/docbuild/doc-example-com/meta'
-    resolved_data['paths']['base_tmp_dir'] = '/var/tmp/docbuild'
-    resolved_data['paths']['tmp']['tmp_base_dir'] = '/var/tmp/docbuild'
-    resolved_data['paths']['tmp']['tmp_path'] = tmp_general
-    resolved_data['paths']['tmp']['tmp_deliverable_path'] = tmp_general + '/deliverable'
-    resolved_data['paths']['tmp']['tmp_metadata_dir'] = tmp_general + '/metadata'
-    resolved_data['paths']['tmp']['tmp_build_dir'] = tmp_general + '/build/{{product}}-{{docset}}-{{lang}}'
-    resolved_data['paths']['tmp']['tmp_out_path'] = tmp_general + '/out'
-    resolved_data['paths']['tmp']['log_path'] = tmp_general + '/log'
-    resolved_data['paths']['tmp']['tmp_deliverable_name'] = '{{product}}_{{docset}}_{{lang}}_XXXXXX'
-    resolved_data['paths']['target']['target_path'] = 'doc@10.100.100.100:/srv/docs'
-    resolved_data['paths']['target']['backup_path'] = Path('/data/docbuild/external-builds/')
+    resolved_data["paths"]["config_dir"] = "/etc/docbuild"
+    resolved_data["paths"]["root_config_dir"] = "/etc/docbuild"
+    resolved_data["paths"]["jinja_dir"] = "/etc/docbuild/jinja-doc-suse-com"
+    resolved_data["paths"]["server_rootfiles_dir"] = (
+        "/etc/docbuild/server-root-files-doc-suse-com"
+    )
+    resolved_data["paths"]["repo_dir"] = "/var/cache/docbuild/repos/permanent-full/"
+    resolved_data["paths"]["temp_repo_dir"] = (
+        "/var/cache/docbuild/repos/temporary-branches/"
+    )
+    resolved_data["paths"]["base_cache_dir"] = "/var/cache/docserv"
+    resolved_data["paths"]["base_server_cache_dir"] = (
+        "/var/cache/docserv/doc-example-com"
+    )
+    resolved_data["paths"]["meta_cache_dir"] = (
+        "/var/cache/docbuild/doc-example-com/meta"
+    )
+    resolved_data["paths"]["base_tmp_dir"] = "/var/tmp/docbuild"
+    resolved_data["paths"]["tmp"]["tmp_base_dir"] = "/var/tmp/docbuild"
+    resolved_data["paths"]["tmp"]["tmp_path"] = tmp_general
+    resolved_data["paths"]["tmp"]["tmp_deliverable_path"] = tmp_general + "/deliverable"
+    resolved_data["paths"]["tmp"]["tmp_metadata_dir"] = tmp_general + "/metadata"
+    resolved_data["paths"]["tmp"]["tmp_build_dir"] = (
+        tmp_general + "/build/{{product}}-{{docset}}-{{lang}}"
+    )
+    resolved_data["paths"]["tmp"]["tmp_out_path"] = tmp_general + "/out"
+    resolved_data["paths"]["tmp"]["log_path"] = tmp_general + "/log"
+    resolved_data["paths"]["tmp"]["tmp_deliverable_name"] = (
+        "{{product}}_{{docset}}_{{lang}}_XXXXXX"
+    )
+    resolved_data["paths"]["target"]["target_path"] = "doc@10.100.100.100:/srv/docs"
+    resolved_data["paths"]["target"]["backup_path"] = Path(
+        "/data/docbuild/external-builds/"
+    )
 
     # Ensure mandatory top-level fields (like 'build') are present
     resolved_data.setdefault(
-        'build',
-        {'daps': {'command': 'daps', 'meta': 'daps meta'}, 'container': {'container': 'registry.example.com/container'}}
+        "build",
+        {
+            "daps": {"command": "daps", "meta": "daps meta"},
+            "container": {"container": "registry.example.com/container"},
+        },
     )
 
     return resolved_data
@@ -55,83 +69,79 @@ def _mock_successful_placeholder_resolver(data: dict[str, Any]) -> dict[str, Any
 
 @pytest.fixture(autouse=True)
 def mock_placeholder_resolution(monkeypatch):
-    """Mocks the replace_placeholders utility used inside EnvConfig."""
-
+    """Mock the replace_placeholders utility used inside EnvConfig."""
     monkeypatch.setattr(
-        config_app_mod,
-        'replace_placeholders',
-        _mock_successful_placeholder_resolver
+        config_app_mod, "replace_placeholders", _mock_successful_placeholder_resolver
     )
 
 
 @pytest.fixture
 def mock_valid_raw_env_data(tmp_path: Path) -> dict[str, Any]:
-    """
-    Provides a minimal, valid dictionary representing env.toml data (using aliases).
-    Includes ALL mandatory path fields and a nested xslt-params structure.
-    """
+    """Provide a minimal, valid dictionary representing env.toml data.
 
+    It uses aliases. Includes ALL mandatory path fields and a nested
+    xslt-params structure.
+    """
     nested_xslt_params = {
-        'external': {'js': {'onlineonly': '/docserv/res/extra.js'}},
-        'show': {'edit': {'link': 1}},
-        'twittercards': {'twitter': {'account': '@SUSE'}},
-        'generate': {'json-ld': 1},
-        'search': {'description': {'length': 118}},
-        'socialmedia': {'description': {'length': 65}},
+        "external": {"js": {"onlineonly": "/docserv/res/extra.js"}},
+        "show": {"edit": {"link": 1}},
+        "twittercards": {"twitter": {"account": "@SUSE"}},
+        "generate": {"json-ld": 1},
+        "search": {"description": {"length": 118}},
+        "socialmedia": {"description": {"length": 65}},
     }
 
     return {
-        'server': {
-            'name': 'doc-example-com',
-            'role': 'production',
-            'host': '127.0.0.1',
-            'enable_mail': True,
+        "server": {
+            "name": "doc-example-com",
+            "role": "production",
+            "host": "127.0.0.1",
+            "enable_mail": True,
         },
-        'config': {
-            'default_lang': 'en-us',
-            'languages': ['en-us', 'de-de'],
-            'canonical_url_domain': 'https://docs.example.com',
+        "config": {
+            "default_lang": "en-us",
+            "languages": ["en-us", "de-de"],
+            "canonical_url_domain": "https://docs.example.com",
         },
-        'paths': {
-            'config_dir': str(tmp_path / 'config'),
-            'root_config_dir': '/etc/docbuild',
-            'jinja_dir': '/etc/docbuild/jinja',
-            'server_rootfiles_dir': '/etc/docbuild/rootfiles',
-            'base_server_cache_dir': '/var/cache/docserv/server',
-            'base_tmp_dir': '/var/tmp/docbuild',
-            'repo_dir': '/var/cache/docbuild/repos/permanent-full/',
-            'temp_repo_dir': '/var/cache/docbuild/repos/temporary-branches/',
-            'base_cache_dir': '/var/cache/docserv',
-            'meta_cache_dir': '/var/cache/docbuild/doc-example-com/meta',
-
-            'tmp': {
-                'tmp_base_dir': '/var/tmp/docbuild',
-                'tmp_dir': '{tmp_base_dir}/doc-example-com',
-                'tmp_deliverable_dir': '{tmp_dir}/deliverable/',
-                'tmp_build_dir': '{tmp_dir}/build/{{product}}-{{docset}}-{{lang}}',
-                'tmp_out_dir': '{tmp_dir}/out/',
-                'log_dir': '{tmp_dir}/log',
-                'tmp_metadata_dir': '{tmp_dir}/metadata',
-                'tmp_deliverable_name': '{{product}}_{{docset}}_{{lang}}_XXXXXX',
+        "paths": {
+            "config_dir": str(tmp_path / "config"),
+            "root_config_dir": "/etc/docbuild",
+            "jinja_dir": "/etc/docbuild/jinja",
+            "server_rootfiles_dir": "/etc/docbuild/rootfiles",
+            "base_server_cache_dir": "/var/cache/docserv/server",
+            "base_tmp_dir": "/var/tmp/docbuild",
+            "repo_dir": "/var/cache/docbuild/repos/permanent-full/",
+            "temp_repo_dir": "/var/cache/docbuild/repos/temporary-branches/",
+            "base_cache_dir": "/var/cache/docserv",
+            "meta_cache_dir": "/var/cache/docbuild/doc-example-com/meta",
+            "tmp": {
+                "tmp_base_dir": "/var/tmp/docbuild",
+                "tmp_dir": "{tmp_base_dir}/doc-example-com",
+                "tmp_deliverable_dir": "{tmp_dir}/deliverable/",
+                "tmp_build_dir": "{tmp_dir}/build/{{product}}-{{docset}}-{{lang}}",
+                "tmp_out_dir": "{tmp_dir}/out/",
+                "log_dir": "{tmp_dir}/log",
+                "tmp_metadata_dir": "{tmp_dir}/metadata",
+                "tmp_deliverable_name": "{{product}}_{{docset}}_{{lang}}_XXXXXX",
             },
-            'target': {
-                'target_dir': 'doc@10.100.100.100:/srv/docs',
-                'backup_dir': Path('/data/docbuild/external-builds/'),
-            }
+            "target": {
+                "target_dir": "doc@10.100.100.100:/srv/docs",
+                "backup_dir": Path("/data/docbuild/external-builds/"),
+            },
         },
-        'build': {
-            'daps': {'command': 'daps', 'meta': 'daps meta'},
-            'container': {'container': 'registry.example.com/container'},
+        "build": {
+            "daps": {"command": "daps", "meta": "daps meta"},
+            "container": {"container": "registry.example.com/container"},
         },
-        'xslt-params': nested_xslt_params, # <-- Use nested structure
+        "xslt-params": nested_xslt_params,  # <-- Use nested structure
     }
 
 
 # --- Unit Test Cases ---
 
+
 def test_envconfig_full_success(mock_valid_raw_env_data: dict[str, Any]):
     """Test successful validation of the entire EnvConfig schema."""
-
     config = EnvConfig.from_dict(mock_valid_raw_env_data)
 
     assert isinstance(config, EnvConfig)
@@ -140,112 +150,109 @@ def test_envconfig_full_success(mock_valid_raw_env_data: dict[str, Any]):
     assert isinstance(config.paths.base_cache_dir, Path)
 
     assert config.paths.tmp.tmp_path.is_absolute()
-    assert config.paths.tmp.tmp_path.name == 'doc-example-com'
+    assert config.paths.tmp.tmp_path.name == "doc-example-com"
 
     # Check that the field with runtime placeholders is correctly handled as a string
     assert isinstance(config.paths.tmp.tmp_build_dir, str)
 
     # Check XSLT params: should now contain the nested structure
-    assert 'external' in config.xslt_params
-    assert isinstance(config.xslt_params['external'], dict)
-    assert config.xslt_params['show']['edit']['link'] == 1
+    assert "external" in config.xslt_params
+    assert isinstance(config.xslt_params["external"], dict)
+    assert config.xslt_params["show"]["edit"]["link"] == 1
 
 
 def test_envconfig_type_coercion_ip_host(mock_valid_raw_env_data: dict[str, Any]):
     """Test that the host field handles IPvAnyAddress correctly."""
-
     data = mock_valid_raw_env_data.copy()
-    data['server']['host'] = '192.168.1.1'
+    data["server"]["host"] = "192.168.1.1"
 
     config = EnvConfig.from_dict(data)
 
     assert isinstance(config.server.host, IPv4Address)
-    assert str(config.server.host) == '192.168.1.1'
+    assert str(config.server.host) == "192.168.1.1"
 
 
 def test_envconfig_strictness_extra_field_forbid(tmp_path: Path, monkeypatch: Any):
     """Test that extra fields are forbidden on the top-level EnvConfig model."""
-
     # This test checks for 'extra = forbid' behavior. The autouse mock for placeholder
     # resolution interferes by replacing paths with non-existent ones, causing a
     # premature validation failure. We override it with a simple pass-through.
-    monkeypatch.setattr(config_app_mod, 'replace_placeholders', lambda data: data)
+    monkeypatch.setattr(config_app_mod, "replace_placeholders", lambda data: data)
 
     # Prepare all directories that are validated for existence and writability.
     # The EnvConfig model uses EnsureWritableDirectory for several path fields.
     paths_to_create = [
         tmp_path,
-        tmp_path / 'config',
-        tmp_path / 'deliverable',
-        tmp_path / 'metadata',
-        tmp_path / 'out',
-        tmp_path / 'log',
-        tmp_path / 'backup',
+        tmp_path / "config",
+        tmp_path / "deliverable",
+        tmp_path / "metadata",
+        tmp_path / "out",
+        tmp_path / "log",
+        tmp_path / "backup",
     ]
     for p in paths_to_create:
         p.mkdir(exist_ok=True)
 
     raw_data = {
-        'build': {
-            'daps': {'command': 'daps', 'meta': 'daps meta'},
-            'container': {'container': 'registry.example.com/container'},
+        "build": {
+            "daps": {"command": "daps", "meta": "daps meta"},
+            "container": {"container": "registry.example.com/container"},
         },
-        'server': {
-            'name': 'D',
-            'role': 'production',
-            'host': '1.1.1.1',
-            'enable_mail': True,
+        "server": {
+            "name": "D",
+            "role": "production",
+            "host": "1.1.1.1",
+            "enable_mail": True,
         },
-        'config': {
-            'default_lang': 'en-us',
-            'languages': ['en-us'],
-            'canonical_url_domain': 'https://a.b',
+        "config": {
+            "default_lang": "en-us",
+            "languages": ["en-us"],
+            "canonical_url_domain": "https://a.b",
         },
-        'paths': {
-            'config_dir': str(tmp_path / 'config'),
-            'root_config_dir': str(tmp_path),
-            'jinja_dir': str(tmp_path),
-            'server_rootfiles_dir': str(tmp_path),
-            'repo_dir': str(tmp_path),
-            'temp_repo_dir': str(tmp_path),
-            'base_cache_dir': str(tmp_path),
-            'base_server_cache_dir': str(tmp_path),
-            'meta_cache_dir': str(tmp_path),
-            'base_tmp_dir': str(tmp_path),
-            'tmp': {
-                'tmp_base_dir': str(tmp_path),
-                'tmp_dir': str(tmp_path),
-                'tmp_deliverable_dir': str(tmp_path / 'deliverable'),
-                'tmp_metadata_dir': str(tmp_path / 'metadata'),
-                'tmp_build_dir': str(tmp_path / 'build/{{product}}'),
-                'tmp_out_dir': str(tmp_path / 'out'),
-                'log_dir': str(tmp_path / 'log'),
-                'tmp_deliverable_name': 'main',
+        "paths": {
+            "config_dir": str(tmp_path / "config"),
+            "root_config_dir": str(tmp_path),
+            "jinja_dir": str(tmp_path),
+            "server_rootfiles_dir": str(tmp_path),
+            "repo_dir": str(tmp_path),
+            "temp_repo_dir": str(tmp_path),
+            "base_cache_dir": str(tmp_path),
+            "base_server_cache_dir": str(tmp_path),
+            "meta_cache_dir": str(tmp_path),
+            "base_tmp_dir": str(tmp_path),
+            "tmp": {
+                "tmp_base_dir": str(tmp_path),
+                "tmp_dir": str(tmp_path),
+                "tmp_deliverable_dir": str(tmp_path / "deliverable"),
+                "tmp_metadata_dir": str(tmp_path / "metadata"),
+                "tmp_build_dir": str(tmp_path / "build/{{product}}"),
+                "tmp_out_dir": str(tmp_path / "out"),
+                "log_dir": str(tmp_path / "log"),
+                "tmp_deliverable_name": "main",
             },
-            'target': {
-                'target_dir': '/srv',  # Not validated for existence
-                'backup_dir': str(tmp_path / 'backup'),
+            "target": {
+                "target_dir": "/srv",  # Not validated for existence
+                "backup_dir": str(tmp_path / "backup"),
             },
         },
-        'xslt-params': {'test': 1},
-        'typo_section': {'key': 'value'},
+        "xslt-params": {"test": 1},
+        "typo_section": {"key": "value"},
     }
 
     with pytest.raises(ValidationError) as excinfo:
         EnvConfig.from_dict(raw_data)
 
-    locs = excinfo.value.errors()[0]['loc']
-    assert ('typo_section',) == tuple(locs)
+    locs = excinfo.value.errors()[0]["loc"]
+    assert ("typo_section",) == tuple(locs)
 
 
 def test_envconfig_invalid_role_fails(mock_valid_raw_env_data: dict[str, Any]):
     """Test that an invalid role string is rejected by ServerRole enum."""
-
     data = mock_valid_raw_env_data.copy()
-    data['server']['role'] = 'testing_invalid'
+    data["server"]["role"] = "testing_invalid"
 
     with pytest.raises(ValidationError) as excinfo:
         EnvConfig.from_dict(data)
 
-    locs = excinfo.value.errors()[0]['loc']
-    assert ('server', 'role') == tuple(locs)
+    locs = excinfo.value.errors()[0]["loc"]
+    assert ("server", "role") == tuple(locs)

--- a/tests/models/test_deliverable.py
+++ b/tests/models/test_deliverable.py
@@ -7,7 +7,7 @@ import pytest
 from docbuild.models.deliverable import Deliverable
 from docbuild.models.metadata import Metadata
 
-DATADIR = Path(__file__).absolute().parent.parent / 'data'
+DATADIR = Path(__file__).absolute().parent.parent / "data"
 
 
 @pytest.fixture
@@ -58,10 +58,10 @@ def node() -> etree._ElementTree:
     return node.getroottree()  # .getiterator("deliverable")
 
 
-def get_deliverables(node, *, lang: str = 'en-us'):
+def get_deliverables(node, *, lang: str = "en-us"):
     """Get all deliverable elements from the XML node."""
     yield from node.xpath(
-        f'/product/docset/builddocs/language[@lang={lang!r}]/deliverable',
+        f"/product/docset/builddocs/language[@lang={lang!r}]/deliverable",
     )
 
 
@@ -74,7 +74,7 @@ def deliverable(node: etree._ElementTree) -> Generator[etree._Element, None, Non
 @pytest.fixture
 def deliverable_de(node: etree._Element) -> Generator[etree._Element, None, None]:
     """Fixture to yield German deliverable elements from the XML node."""
-    return get_deliverables(node, lang='de-de')
+    return get_deliverables(node, lang="de-de")
 
 
 @pytest.fixture
@@ -84,36 +84,36 @@ def firstnode(deliverable: etree._Element) -> etree._Element:
 
 # ---------------------
 def test_deliverable_productid(firstnode: Deliverable):
-    assert firstnode.productid == 'sles'
+    assert firstnode.productid == "sles"
 
 
 def test_deliverable_docsetid(firstnode: Deliverable):
-    assert firstnode.docsetid == '15-SP6'
+    assert firstnode.docsetid == "15-SP6"
 
 
 def test_deliverable_lang(firstnode: Deliverable):
-    assert firstnode.lang == 'en-us'
+    assert firstnode.lang == "en-us"
 
 
 def test_deliverable_language(firstnode: Deliverable):
-    assert firstnode.language == 'en'
+    assert firstnode.language == "en"
 
 
 def test_deliverable_product_docset(firstnode: Deliverable):
-    assert firstnode.product_docset == 'sles/15-SP6'
+    assert firstnode.product_docset == "sles/15-SP6"
 
 
 def test_deliverable_pdlang(firstnode: Deliverable):
-    assert firstnode.pdlang == 'sles/15-SP6/en-us'
+    assert firstnode.pdlang == "sles/15-SP6/en-us"
 
 
 def test_deliverable_pdlangdc(firstnode: Deliverable):
-    assert firstnode.pdlangdc == 'sles/15-SP6/en-us:DC-SLES-administration'
+    assert firstnode.pdlangdc == "sles/15-SP6/en-us:DC-SLES-administration"
 
 
 def test_deliverable_full_id(firstnode: Deliverable):
     assert firstnode.full_id == (
-        'sles/15-SP6/maintenance_SLE15SP6/en-us:DC-SLES-administration'
+        "sles/15-SP6/maintenance_SLE15SP6/en-us:DC-SLES-administration"
     )
 
 
@@ -122,16 +122,16 @@ def test_deliverable_lang_is_default(firstnode: Deliverable):
 
 
 def test_deliverable_docsuite(firstnode: Deliverable):
-    assert firstnode.docsuite == 'sles/15-SP6/en-us:DC-SLES-administration'
+    assert firstnode.docsuite == "sles/15-SP6/en-us:DC-SLES-administration"
 
 
 def test_deliverable_branch(firstnode: Deliverable):
-    assert firstnode.branch == 'maintenance/SLE15SP6'
+    assert firstnode.branch == "maintenance/SLE15SP6"
 
 
 def test_deliverable_branch_german(deliverable_de: etree._Element):
     firstnode = Deliverable(next(deliverable_de))
-    assert firstnode.branch == 'maintenance/SLE15SP6'
+    assert firstnode.branch == "maintenance/SLE15SP6"
 
 
 def test_deliverable_no_branch_found(node: etree._ElementTree):
@@ -143,52 +143,52 @@ def test_deliverable_no_branch_found(node: etree._ElementTree):
         branch[0].getparent().remove(branch[0])
 
     deliverables = get_deliverables(node)
-    with pytest.raises(ValueError, match='No branch found for this deliverable'):
+    with pytest.raises(ValueError, match="No branch found for this deliverable"):
         deli = Deliverable(next(deliverables))
         deli.branch  # noqa: B018 This should raise an error
 
 
 def test_deliverable_subdir(firstnode: Deliverable):
-    assert firstnode.subdir == ''
+    assert firstnode.subdir == ""
 
 
 def test_deliverable_no_subdir_found(deliverable_de: etree._Element):
     deli = Deliverable(next(deliverable_de))
-    assert deli.subdir == 'l10n/sles/de-de'
+    assert deli.subdir == "l10n/sles/de-de"
 
 
 def test_deliverable_git(firstnode: Deliverable):
-    assert firstnode.git.url == 'https://github.com/suse/doc-sle.git'
+    assert firstnode.git.url == "https://github.com/suse/doc-sle.git"
 
 
 def test_deliverable_no_git_found(node: etree._ElementTree):
     git = node.xpath(
-        '/product/docset[1]/builddocs/git',
+        "/product/docset[1]/builddocs/git",
     )
     # Remove the git element to simulate no error
     if git:
         git[0].getparent().remove(git[0])
 
     deliverables = get_deliverables(node)
-    with pytest.raises(ValueError, match='No git remote found'):
+    with pytest.raises(ValueError, match="No git remote found"):
         deli = Deliverable(next(deliverables))
         deli.git  #  noqa: B018 This should raise an error
 
 
 def test_deliverable_dcfile(firstnode: Deliverable):
-    assert firstnode.dcfile == 'DC-SLES-administration'
+    assert firstnode.dcfile == "DC-SLES-administration"
 
 
 def test_deliverable_basefile(firstnode: Deliverable):
-    assert firstnode.basefile == 'SLES-administration'
+    assert firstnode.basefile == "SLES-administration"
 
 
 def test_deliverable_format(firstnode: Deliverable):
     assert firstnode.format == {
-        'epub': False,
-        'html': False,
-        'pdf': True,
-        'single-html': True,
+        "epub": False,
+        "html": False,
+        "pdf": True,
+        "single-html": True,
     }
 
 
@@ -201,7 +201,7 @@ def test_deliverable_no_format_found(node: etree._ElementTree):
         format_elem[0].getparent().remove(format_elem[0])
 
     deliverables = get_deliverables(node)
-    with pytest.raises(ValueError, match='No format found for'):
+    with pytest.raises(ValueError, match="No format found for"):
         deli = Deliverable(next(deliverables))
         deli.format  #  noqa: B018 This should raise an error
 
@@ -211,16 +211,16 @@ def test_deliverable_node(firstnode: Deliverable):
 
 
 def test_deliverable_productname(firstnode: Deliverable):
-    assert firstnode.productname == 'SUSE Linux Enterprise Server'
+    assert firstnode.productname == "SUSE Linux Enterprise Server"
 
 
 def test_deliverable_acronym(firstnode: Deliverable):
-    assert firstnode.acronym == 'SLES'
+    assert firstnode.acronym == "SLES"
 
 
 def test_deliverable_no_acronym_found(node: etree._ElementTree):
     acronym_elem = node.xpath(
-        '/product/acronym',
+        "/product/acronym",
     )
     # Remove the acronym element to simulate no error
     if acronym_elem:
@@ -228,42 +228,42 @@ def test_deliverable_no_acronym_found(node: etree._ElementTree):
 
     deliverables = get_deliverables(node)
     deli = Deliverable(next(deliverables))
-    assert deli.acronym == ''
+    assert deli.acronym == ""
 
 
 def test_deliverable_version(firstnode: Deliverable):
-    assert firstnode.version == '15 SP6'
+    assert firstnode.version == "15 SP6"
 
 
 def test_deliverable_lifecycle(firstnode: Deliverable):
-    assert firstnode.lifecycle == 'supported'
+    assert firstnode.lifecycle == "supported"
 
 
 def test_deliverable_relpath(firstnode: Deliverable):
-    assert firstnode.relpath == 'en-us/sles/15-SP6'
+    assert firstnode.relpath == "en-us/sles/15-SP6"
 
 
 def test_deliverable_repo_path(firstnode: Deliverable):
-    assert firstnode.repo_path == Path('https___github_com_suse_doc_sle_git')
+    assert firstnode.repo_path == Path("https___github_com_suse_doc_sle_git")
 
 
 def test_deliverable_zip_path(firstnode: Deliverable):
-    assert firstnode.zip_path == 'en-us/sles/15-SP6/sles-15-SP6-en-us.zip'
+    assert firstnode.zip_path == "en-us/sles/15-SP6/sles-15-SP6-en-us.zip"
 
 
 def test_deliverable_html_path(firstnode: Deliverable):
-    assert firstnode.html_path == '/sles/15-SP6/html/SLES-administration/'
+    assert firstnode.html_path == "/sles/15-SP6/html/SLES-administration/"
 
 
 def test_deliverable_base_format_path(deliverable_de: etree._Element):
     deli = Deliverable(next(deliverable_de))
     deli.meta = Metadata(
-        rootid='foo',
+        rootid="foo",
         # productid="sles",
         # docsetid="15-SP6",
         # lang="de-de"
     )
-    assert deli.html_path == '/de-de/sles/15-SP6/html/foo/'
+    assert deli.html_path == "/de-de/sles/15-SP6/html/foo/"
 
 
 def test_deliverable_base_format_path_rootid_none(deliverable_de: etree._Element):
@@ -275,22 +275,20 @@ def test_deliverable_base_format_path_rootid_none(deliverable_de: etree._Element
         # lang="de-de"
     )
     # If rootid is None, fallback to the deliverable's basefile
-    assert deli.html_path == (
-        '/de-de/sles/15-SP6/html/SLES-administration/'
-    )
+    assert deli.html_path == ("/de-de/sles/15-SP6/html/SLES-administration/")
 
 
 def test_deliverable_singlehtml_path(firstnode: Deliverable):
-    assert firstnode.singlehtml_path == '/sles/15-SP6/single-html/SLES-administration/'
+    assert firstnode.singlehtml_path == "/sles/15-SP6/single-html/SLES-administration/"
 
 
 def test_deliverable_pdf_path(firstnode: Deliverable):
-    assert firstnode.pdf_path == '/sles/15-SP6/pdf/SLES-administration_en.pdf'
+    assert firstnode.pdf_path == "/sles/15-SP6/pdf/SLES-administration_en.pdf"
 
 
 def test_deliverable_pdf_path_german(deliverable_de: etree._Element):
     deli = Deliverable(next(deliverable_de))
-    assert deli.pdf_path == '/de-de/sles/15-SP6/pdf/SLES-administration_de.pdf'
+    assert deli.pdf_path == "/de-de/sles/15-SP6/pdf/SLES-administration_de.pdf"
 
 
 def test_deliverable_product_node(firstnode: Deliverable):
@@ -306,7 +304,7 @@ def test_deliverable_metafile(firstnode: Deliverable):
 
 
 def test_deliverable_metafile_setter(firstnode: Deliverable):
-    firstnode.metafile = 'metafile'
+    firstnode.metafile = "metafile"
     assert firstnode.metafile is not None
 
 
@@ -315,8 +313,8 @@ def test_deliverable_meta(firstnode: Deliverable):
 
 
 def test_deliverable_meta_setter_wrong_type(firstnode: Deliverable):
-    with pytest.raises(TypeError, match='Expected type Metadata, but got'):
-        firstnode.meta = 'not-a-metadata-instance'
+    with pytest.raises(TypeError, match="Expected type Metadata, but got"):
+        firstnode.meta = "not-a-metadata-instance"
 
 
 def test_deliverable_hash(firstnode: Deliverable):

--- a/tests/models/test_doctype.py
+++ b/tests/models/test_doctype.py
@@ -9,30 +9,30 @@ from docbuild.models.product import Product
 
 def test_valid_doctype():
     doctype = Doctype(
-        product='sles', docset='15-SP6', lifecycle='supported', langs=['en-us']
+        product="sles", docset="15-SP6", lifecycle="supported", langs=["en-us"]
     )
     assert doctype.product == Product.sles
-    assert doctype.docset == ['15-SP6']
+    assert doctype.docset == ["15-SP6"]
     assert doctype.lifecycle == LifecycleFlag.supported
-    assert doctype.langs == [LanguageCode(language='en-us')]
+    assert doctype.langs == [LanguageCode(language="en-us")]
 
 
 def test_str_in_doctype():
     doctype = Doctype(
-        product='sles',
-        docset='15-SP6',
-        lifecycle='supported',
-        langs=['en-us'],
+        product="sles",
+        docset="15-SP6",
+        lifecycle="supported",
+        langs=["en-us"],
     )
-    assert str(doctype) == 'sles/15-SP6@supported/en-us'
+    assert str(doctype) == "sles/15-SP6@supported/en-us"
 
 
 def test_repr_in_doctype():
     doctype = Doctype(
-        product='sles',
-        docset='15-SP6',
-        lifecycle='supported',
-        langs=['en-us'],
+        product="sles",
+        docset="15-SP6",
+        lifecycle="supported",
+        langs=["en-us"],
     )
     assert repr(doctype) == (
         "Doctype(product='sles', docset=[15-SP6], lifecycle='supported', langs=[en-us])"
@@ -41,88 +41,116 @@ def test_repr_in_doctype():
 
 def test_string_langs_in_doctype():
     doctype = Doctype(
-        product='sles',
-        docset='15-SP6',
-        lifecycle='supported',
-        langs='en-us',
+        product="sles",
+        docset="15-SP6",
+        lifecycle="supported",
+        langs="en-us",
     )
-    assert doctype.langs == [LanguageCode(language='en-us')]
+    assert doctype.langs == [LanguageCode(language="en-us")]
 
 
 def test_multiplestrings_langs_in_doctype():
     doctype = Doctype(
-        product='sles',
-        docset='15-SP6',
-        lifecycle='supported',
-        langs='en-us,de-de',
+        product="sles",
+        docset="15-SP6",
+        lifecycle="supported",
+        langs="en-us,de-de",
     )
-    assert doctype.langs == [LanguageCode(language='de-de'), LanguageCode(language='en-us')]
+    assert doctype.langs == [
+        LanguageCode(language="de-de"),
+        LanguageCode(language="en-us"),
+    ]
 
 
 @pytest.mark.parametrize(
-    'string,expected',
+    "string,expected",
     [
         (
-            'sles/15-SP6/en-us',
+            "sles/15-SP6/en-us",
             (
                 Product.sles,
-                ['15-SP6'],
+                ["15-SP6"],
                 LifecycleFlag.unknown,
-                [LanguageCode(language='en-us')],
+                [LanguageCode(language="en-us")],
             ),
         ),
         (
-            'sles/15-SP5,15-SP6/en-us',
+            "sles/15-SP5,15-SP6/en-us",
             (
                 Product.sles,
-                ['15-SP5', '15-SP6'],
+                ["15-SP5", "15-SP6"],
                 LifecycleFlag.unknown,
-                [LanguageCode(language='en-us')],
+                [LanguageCode(language="en-us")],
             ),
         ),
         (
-            '//en-us',
-            (Product.ALL, ['*'], LifecycleFlag.unknown, [LanguageCode(language='en-us')]),
+            "//en-us",
+            (
+                Product.ALL,
+                ["*"],
+                LifecycleFlag.unknown,
+                [LanguageCode(language="en-us")],
+            ),
         ),
         (
-            '/*/*/en-us',
-            (Product.ALL, ['*'], LifecycleFlag.unknown, [LanguageCode(language='en-us')]),
+            "/*/*/en-us",
+            (
+                Product.ALL,
+                ["*"],
+                LifecycleFlag.unknown,
+                [LanguageCode(language="en-us")],
+            ),
         ),
         (
-            '*//en-us',
-            (Product.ALL, ['*'], LifecycleFlag.unknown, [LanguageCode(language='en-us')]),
+            "*//en-us",
+            (
+                Product.ALL,
+                ["*"],
+                LifecycleFlag.unknown,
+                [LanguageCode(language="en-us")],
+            ),
         ),
         (
-            '/*/en-us',
-            (Product.ALL, ['*'], LifecycleFlag.unknown, [LanguageCode(language='en-us')]),
+            "/*/en-us",
+            (
+                Product.ALL,
+                ["*"],
+                LifecycleFlag.unknown,
+                [LanguageCode(language="en-us")],
+            ),
         ),
         (
-            '*/*/en-us',
-            (Product.ALL, ['*'], LifecycleFlag.unknown, [LanguageCode(language='en-us')]),
+            "*/*/en-us",
+            (
+                Product.ALL,
+                ["*"],
+                LifecycleFlag.unknown,
+                [LanguageCode(language="en-us")],
+            ),
         ),
         (
-            '*/@beta/en-us',
-            (Product.ALL, ['*'], LifecycleFlag.beta, [LanguageCode(language='en-us')]),
+            "*/@beta/en-us",
+            (Product.ALL, ["*"], LifecycleFlag.beta, [LanguageCode(language="en-us")]),
         ),
         (
-            '*/*@beta/en-us',
-            (Product.ALL, ['*'], LifecycleFlag.beta, [LanguageCode(language='en-us')]),
+            "*/*@beta/en-us",
+            (Product.ALL, ["*"], LifecycleFlag.beta, [LanguageCode(language="en-us")]),
         ),
         (
-            'sles/*@beta/en-us',
-            (Product.sles, ['*'], LifecycleFlag.beta, [LanguageCode(language='en-us')]),
+            "sles/*@beta/en-us",
+            (Product.sles, ["*"], LifecycleFlag.beta, [LanguageCode(language="en-us")]),
         ),
         (
-            '/sles/*@beta/en-us',
-            (Product.sles, ['*'], LifecycleFlag.beta, [LanguageCode(language='en-us')]),
+            "/sles/*@beta/en-us",
+            (Product.sles, ["*"], LifecycleFlag.beta, [LanguageCode(language="en-us")]),
         ),
         (
-            '/*/*@supported/*',
-            (Product.ALL, ['*'], LifecycleFlag.supported, [LanguageCode(language='*')]),
+            "/*/*@supported/*",
+            (Product.ALL, ["*"], LifecycleFlag.supported, [LanguageCode(language="*")]),
         ),
         (
-            '/*/*/*',
-            (Product.ALL, ['*'], LifecycleFlag.unknown, [LanguageCode(language='*')]),
+            "/*/*/*",
+            (Product.ALL, ["*"], LifecycleFlag.unknown, [LanguageCode(language="*")]),
         ),
     ],
 )
@@ -137,90 +165,90 @@ def test_valid_string_from_string(string, expected):
 
 def test_invalid_string_from_string():
     with pytest.raises(ValueError):
-        Doctype.from_str('nonsense')
+        Doctype.from_str("nonsense")
 
 
 def test_contains_with_doctypes():
-    dt1 = Doctype.from_str('sles/15-SP6/en-us')
-    dt2 = Doctype.from_str('sles/*/en-us')
+    dt1 = Doctype.from_str("sles/15-SP6/en-us")
+    dt2 = Doctype.from_str("sles/*/en-us")
     assert dt1 in dt2
 
 
 def test_eq_with_doctypes():
-    dt1 = Doctype.from_str('sles/15-SP6/en-us')
-    dt2 = Doctype.from_str('sles/15-SP6/en-us')
+    dt1 = Doctype.from_str("sles/15-SP6/en-us")
+    dt2 = Doctype.from_str("sles/15-SP6/en-us")
     assert dt1 == dt2
 
 
 def test_lt_with_doctypes():
-    dt1 = Doctype.from_str('sles/15-SP6/en-us')
-    dt2 = Doctype.from_str('sles/15-SP7/en-us')
+    dt1 = Doctype.from_str("sles/15-SP6/en-us")
+    dt2 = Doctype.from_str("sles/15-SP7/en-us")
     assert dt1 < dt2
 
 
 def test_compare_with_doctype_and_invalid_type():
-    dt = Doctype.from_str('sles/15-SP6/en-us')
-    result = dt.__contains__('not-a-doctype')  # type: ignore
+    dt = Doctype.from_str("sles/15-SP6/en-us")
+    result = dt.__contains__("not-a-doctype")  # type: ignore
     assert result is NotImplemented
 
 
 def test_eq_with_doctype_and_invalid_type():
-    dt = Doctype.from_str('sles/15-SP6/en-us')
-    result = dt.__eq__('not-a-doctype')  # type: ignore
+    dt = Doctype.from_str("sles/15-SP6/en-us")
+    result = dt.__eq__("not-a-doctype")  # type: ignore
     assert result == NotImplemented
 
 
 def test_lt_with_doctype_and_invalid_type():
-    dt = Doctype.from_str('sles/15-SP6/en-us')
-    result = dt.__lt__('not-a-doctype')  # type: ignore
+    dt = Doctype.from_str("sles/15-SP6/en-us")
+    result = dt.__lt__("not-a-doctype")  # type: ignore
     assert result == NotImplemented
 
 
 def test_hash_with_doctype():
-    dt1 = Doctype.from_str('sles/15-SP6/en-us')
-    dt2 = Doctype.from_str('sles/15-SP6/en-us')
+    dt1 = Doctype.from_str("sles/15-SP6/en-us")
+    dt2 = Doctype.from_str("sles/15-SP6/en-us")
     assert hash(dt1) == hash(dt2)
 
 
 def test_coerce_lifecycle_to_doctype():
     dt1 = Doctype(
-        product='sles',
-        docset='15-SP5',
+        product="sles",
+        docset="15-SP5",
         lifecycle=LifecycleFlag.supported,
-        langs='en-us',
+        langs="en-us",
     )
     assert dt1.lifecycle == LifecycleFlag.supported
 
 
 def test_sorted_docsets_in_doctype():
-    dt1 = Doctype.from_str('sles/15-SP6,15-SP2,16-SP0/en-us')
-    assert dt1.docset == ['15-SP2', '15-SP6', '16-SP0']
+    dt1 = Doctype.from_str("sles/15-SP6,15-SP2,16-SP0/en-us")
+    assert dt1.docset == ["15-SP2", "15-SP6", "16-SP0"]
 
 
 def test_sorted_langs_in_doctype():
-    dt1 = Doctype.from_str('sles/15-SP6/en-us,zh-cn,de-de')
+    dt1 = Doctype.from_str("sles/15-SP6/en-us,zh-cn,de-de")
     assert dt1.langs == [
-        LanguageCode(language='de-de'),
-        LanguageCode(language='en-us'),
-        LanguageCode(language='zh-cn'),
+        LanguageCode(language="de-de"),
+        LanguageCode(language="en-us"),
+        LanguageCode(language="zh-cn"),
     ]
 
 
 def test_sorted_docsets_in_doctype_instantiation():
     dt1 = Doctype(
-        product='sles',
-        docset=['16-SP0', '15-SP7'],
+        product="sles",
+        docset=["16-SP0", "15-SP7"],
         lifecycle=LifecycleFlag.supported,
-        langs='en-us',
+        langs="en-us",
     )
-    assert dt1.docset == ['15-SP7', '16-SP0']
+    assert dt1.docset == ["15-SP7", "16-SP0"]
 
 
 def test_sorted_langs_in_doctype_instantiation():
-    langs = ['en-us', 'de-de']
+    langs = ["en-us", "de-de"]
     dt1 = Doctype(
-        product='sles',
-        docset='15-SP6',
+        product="sles",
+        docset="15-SP6",
         lifecycle=LifecycleFlag.supported,
         langs=langs,
     )
@@ -228,11 +256,11 @@ def test_sorted_langs_in_doctype_instantiation():
 
 
 @pytest.mark.parametrize(
-    'string,xpath',
+    "string,xpath",
     [
         # 1: product + one docset + a single language
         (
-            'sles/15-SP6/en-us',
+            "sles/15-SP6/en-us",
             (
                 "product[@productid='sles']"
                 "/docset[@setid='15-SP6']"
@@ -241,12 +269,12 @@ def test_sorted_langs_in_doctype_instantiation():
         ),
         # 2: product + all docsets + a single language
         (
-            'sles//en-us',
+            "sles//en-us",
             ("product[@productid='sles']/docset/builddocs/language[@lang='en-us']"),
         ),
         # 3: product + one docset + one lifecycle + multiple languages
         (
-            'sles/15-SP6@supported/en-us,de-de',
+            "sles/15-SP6@supported/en-us,de-de",
             (
                 "product[@productid='sles']"
                 "/docset[@setid='15-SP6'][@lifecycle='supported']"
@@ -255,7 +283,7 @@ def test_sorted_langs_in_doctype_instantiation():
         ),
         # 4: product + one docset + multiple lifecycles + one language
         (
-            'sles/15-SP7@supported,beta/de-de',
+            "sles/15-SP7@supported,beta/de-de",
             (
                 "product[@productid='sles']"
                 "/docset[@setid='15-SP7'][@lifecycle='supported' or @lifecycle='beta']"
@@ -264,17 +292,17 @@ def test_sorted_langs_in_doctype_instantiation():
         ),
         # 5: product + one docset + multiple lifecycles + all languages
         (
-            'sles/15-SP6@supported/*',
+            "sles/15-SP6@supported/*",
             (
                 "product[@productid='sles']"
                 "/docset[@setid='15-SP6'][@lifecycle='supported']"
-                '/builddocs/language'
+                "/builddocs/language"
             ),
         ),
         # 6: many products + many docsets + many lifecycles + English
-        ('//en-us', "product/docset/builddocs/language[@lang='en-us']"),
+        ("//en-us", "product/docset/builddocs/language[@lang='en-us']"),
         # 7: all products, docsets, lifecycles, and languages
-        ('//*', 'product/docset/builddocs/language'),
+        ("//*", "product/docset/builddocs/language"),
     ],
 )
 def test_xpath_in_doctype(string, xpath):

--- a/tests/models/test_language.py
+++ b/tests/models/test_language.py
@@ -5,9 +5,9 @@ from docbuild.constants import ALLOWED_LANGUAGES
 from docbuild.models.language import LanguageCode
 
 
-@pytest.mark.parametrize('language', sorted(ALLOWED_LANGUAGES))
+@pytest.mark.parametrize("language", sorted(ALLOWED_LANGUAGES))
 def test_valid_language(language):
-    lang, country = language.split('-')
+    lang, country = language.split("-")
     thelang = LanguageCode(language=language)
     assert thelang.language == language
     assert thelang.lang == lang
@@ -15,95 +15,95 @@ def test_valid_language(language):
 
 
 def test_wildcard_language():
-    thelang = LanguageCode(language='*')
-    assert thelang.language == '*'
-    assert thelang.lang == '*'
-    assert thelang.country == '*'
+    thelang = LanguageCode(language="*")
+    assert thelang.language == "*"
+    assert thelang.lang == "*"
+    assert thelang.country == "*"
 
 
 def test_unknown_language():
-    with pytest.raises(ValidationError, match='validation error'):
-        LanguageCode(language='de-ch')
+    with pytest.raises(ValidationError, match="validation error"):
+        LanguageCode(language="de-ch")
 
 
 def test_language_with_underscore():
-    thelang = LanguageCode(language='de_de')
-    assert thelang.language == 'de-de'
-    assert thelang.lang == 'de'
-    assert thelang.country == 'de'
+    thelang = LanguageCode(language="de_de")
+    assert thelang.language == "de-de"
+    assert thelang.lang == "de"
+    assert thelang.country == "de"
 
 
 def test_str_in_language():
-    thelang = LanguageCode(language='de_de')
-    assert str(thelang) == 'de-de'
+    thelang = LanguageCode(language="de_de")
+    assert str(thelang) == "de-de"
 
 
 def test_repr_in_language():
-    thelang = LanguageCode(language='de-de')
+    thelang = LanguageCode(language="de-de")
     assert repr(thelang) == "LanguageCode(language='de-de')"
 
 
 def test_compare_two_uneqal_languages():
-    lang1 = LanguageCode(language='en-us')
-    lang2 = LanguageCode(language='de-de')
+    lang1 = LanguageCode(language="en-us")
+    lang2 = LanguageCode(language="de-de")
     assert lang1 != lang2
     assert lang2 != lang1
 
 
 def test_compare_two_eqal_languages():
-    lang1 = LanguageCode(language='de-de')
-    lang2 = LanguageCode(language='de-de')
+    lang1 = LanguageCode(language="de-de")
+    lang2 = LanguageCode(language="de-de")
     assert lang1 == lang2
     assert lang2 == lang1
 
 
 def test_compare_with_all_language():
-    lang1 = LanguageCode(language='*')
-    lang2 = LanguageCode(language='de-de')
+    lang1 = LanguageCode(language="*")
+    lang2 = LanguageCode(language="de-de")
     assert lang1 != lang2
     assert lang2 != lang1
 
 
 def test_compare_with_one_language_and_with_different_object():
-    lang1 = LanguageCode(language='*')
+    lang1 = LanguageCode(language="*")
     lang2 = object()
     assert lang1 != lang2
 
 
 def test_language_code_is_frozen():
-    lang = LanguageCode(language='en-us')
+    lang = LanguageCode(language="en-us")
 
-    with pytest.raises(ValidationError, match='.*frozen_instance.*'):
-        lang.language = 'de-de'
+    with pytest.raises(ValidationError, match=".*frozen_instance.*"):
+        lang.language = "de-de"
 
 
 def test_language_code_is_hashable():
-    lang = LanguageCode(language='en-us')
+    lang = LanguageCode(language="en-us")
     s = {lang}
     assert lang in s
 
 
 def test_compare_languagecode_with_str():
-    lang1 = LanguageCode(language='de-de')
-    lang2 = 'de-de'
+    lang1 = LanguageCode(language="de-de")
+    lang2 = "de-de"
     assert lang1 == lang2
     assert lang2 == lang1
 
 
 @pytest.mark.parametrize(
-    'languages,expected',
+    "languages,expected",
     [
         # 1
-        (('en-us', 'de-de'), ('de-de', 'en-us')),
+        (("en-us", "de-de"), ("de-de", "en-us")),
         # 2
-        (('zh-cn', 'de-de'), ('de-de', 'zh-cn')),
+        (("zh-cn", "de-de"), ("de-de", "zh-cn")),
         # 3
         (
-            ('pt-br', 'es-es', 'ja-jp', 'fr-fr', 'ko-kr'),
-            ('es-es', 'fr-fr', 'ja-jp', 'ko-kr', 'pt-br'),
+            ("pt-br", "es-es", "ja-jp", "fr-fr", "ko-kr"),
+            ("es-es", "fr-fr", "ja-jp", "ko-kr", "pt-br"),
         ),
         # 4 Special case with "*": ALL comes always first
-        (('en-us', '*', 'de-de'), ('*', 'de-de', 'en-us')),
+        (("en-us", "*", "de-de"), ("*", "de-de", "en-us")),
     ],
 )
 def test_sorting_languages(languages, expected):
@@ -112,33 +112,33 @@ def test_sorting_languages(languages, expected):
 
 
 def test_compare_two_langs():
-    lang1 = LanguageCode(language='de-de')
-    lang2 = 'en-us'
+    lang1 = LanguageCode(language="de-de")
+    lang2 = "en-us"
     assert lang1 < lang2
 
 
 def test_compare_two_langs_with_asterisk():
-    lang1 = LanguageCode(language='*')
-    lang2 = LanguageCode(language='de-de')
+    lang1 = LanguageCode(language="*")
+    lang2 = LanguageCode(language="de-de")
     assert lang1 < lang2
 
 
 def test_compare_two_asterisks():
-    lang1 = LanguageCode(language='*')
-    lang2 = LanguageCode(language='*')
+    lang1 = LanguageCode(language="*")
+    lang2 = LanguageCode(language="*")
     assert not lang1 < lang2
 
 
 def test_compare_with_unknown_type():
-    lang1 = LanguageCode(language='de-de')
+    lang1 = LanguageCode(language="de-de")
     lang2 = object()
     with pytest.raises(TypeError):
         assert lang1 < lang2
 
 
 def test_language_matches():
-    lang1 = LanguageCode(language='de-de')
-    assert lang1.matches('*')
+    lang1 = LanguageCode(language="de-de")
+    assert lang1.matches("*")
 
 
 def test_language_code_init_with_invalid_type_raises_error():
@@ -162,4 +162,3 @@ def test_convert_str_to_dict_accepts_string() -> None:
     # ensure computed properties work as expected
     assert lc.lang == "en"
     assert lc.country == "us"
-

--- a/tests/models/test_lifecycle.py
+++ b/tests/models/test_lifecycle.py
@@ -6,7 +6,7 @@ from docbuild.constants import ALLOWED_LIFECYCLES
 from docbuild.models.lifecycle import LifecycleFlag
 
 
-@pytest.mark.parametrize('lifecycle', ALLOWED_LIFECYCLES)
+@pytest.mark.parametrize("lifecycle", ALLOWED_LIFECYCLES)
 def test_valid_lifecycles(lifecycle):
     instance = getattr(LifecycleFlag, lifecycle)
     assert instance.name == lifecycle
@@ -14,16 +14,16 @@ def test_valid_lifecycles(lifecycle):
 
 def test_unknown_lifecycle():
     instance = LifecycleFlag.unknown
-    assert instance.name == 'unknown'
+    assert instance.name == "unknown"
     assert instance.value == 0
     instance = LifecycleFlag(0)
-    assert instance.name == 'unknown'
+    assert instance.name == "unknown"
 
 
 def test_lifecycle_flag_from_str_with_empty_string():
-    instance = LifecycleFlag.from_str('')
+    instance = LifecycleFlag.from_str("")
     assert instance == LifecycleFlag.unknown
-    assert instance.name == 'unknown'
+    assert instance.name == "unknown"
     assert instance.value == 0
 
 
@@ -32,18 +32,18 @@ def all_non_empty_combinations(items):
 
 
 @pytest.mark.parametrize(
-    'input_str',
-    ['|'.join(combo) for combo in all_non_empty_combinations(ALLOWED_LIFECYCLES)],
+    "input_str",
+    ["|".join(combo) for combo in all_non_empty_combinations(ALLOWED_LIFECYCLES)],
 )
 def test_lifecycle_flag_from_str(input_str):
     lifecycle = LifecycleFlag.from_str(input_str)  # type: ignore
 
-    assert set(i.name for i in lifecycle) == set(input_str.split('|'))
+    assert set(i.name for i in lifecycle) == set(input_str.split("|"))
 
 
 @pytest.mark.parametrize(
-    'input_str',
-    ['|'.join(combo) for combo in all_non_empty_combinations(ALLOWED_LIFECYCLES)],
+    "input_str",
+    ["|".join(combo) for combo in all_non_empty_combinations(ALLOWED_LIFECYCLES)],
 )
 def test_contains_for_lifecycle(input_str):
     lifecycle = LifecycleFlag.from_str(input_str)
@@ -52,7 +52,7 @@ def test_contains_for_lifecycle(input_str):
 
 def test_contains_with_invalidvalue_for_lifecycle():
     with pytest.raises(ValueError):
-        assert 'nonexistent' in LifecycleFlag.beta
+        assert "nonexistent" in LifecycleFlag.beta
 
 
 def test_contains_with_lifecycle_for_lifecycle():
@@ -60,13 +60,13 @@ def test_contains_with_lifecycle_for_lifecycle():
 
 
 def test_non_string_non_flag_returns_not_implemented():
-    lifecycle = LifecycleFlag.from_str('supported')
+    lifecycle = LifecycleFlag.from_str("supported")
     assert (42 in lifecycle) is False  # triggers fallback, returns False
 
 
 def test_contains_other_lifecycle_flag():
-    lifecycle = LifecycleFlag.from_str('supported|beta')
-    other_lifecycle = LifecycleFlag.from_str('beta')
+    lifecycle = LifecycleFlag.from_str("supported|beta")
+    other_lifecycle = LifecycleFlag.from_str("beta")
 
     # Should return True as `beta` is in `supported|beta`
     assert other_lifecycle in lifecycle

--- a/tests/models/test_metadata.py
+++ b/tests/models/test_metadata.py
@@ -20,36 +20,36 @@ series = Linux"""
     def fake_open(self, *args, **kwargs):
         return StringIO(fake_content)
 
-    monkeypatch.setattr(metadata_module.Path, 'open', fake_open)
+    monkeypatch.setattr(metadata_module.Path, "open", fake_open)
 
     meta = metadata_module.Metadata()
-    meta.read('dummy/path')
-    assert meta.title == 'Example Title'
-    assert meta.subtitle == 'Example Subtitle'
-    assert meta.seo_title == 'Example SEO Title'
-    assert meta.seo_social_descr == 'Example Social Description'
-    assert meta.seo_description == 'Example Description'
-    assert meta.dateModified == '2023-10-01'
-    assert meta.rootid == 'root123'
-    assert meta.series == 'Linux'
+    meta.read("dummy/path")
+    assert meta.title == "Example Title"
+    assert meta.subtitle == "Example Subtitle"
+    assert meta.seo_title == "Example SEO Title"
+    assert meta.seo_social_descr == "Example Social Description"
+    assert meta.seo_description == "Example Description"
+    assert meta.dateModified == "2023-10-01"
+    assert meta.rootid == "root123"
+    assert meta.series == "Linux"
     assert meta.products == [
-        {'name': 'SUSE Linux Enterprise Server', 'versions': ['15 SP6']}
+        {"name": "SUSE Linux Enterprise Server", "versions": ["15 SP6"]}
     ]
 
 
 @pytest.mark.parametrize(
-    'option, key, value',
+    "option, key, value",
     [
-        ('series', 'series', None),
-        ('date', 'dateModified', ''),
-        ('subtitle', 'subtitle', ''),
-        ('seo-title', 'seo_title', None),
-        ('seo-social-descr', 'seo_social_descr', ''),
-        ('seo-description', 'seo_description', ''),
-        ('rootid', 'rootid', None),
-        ('tasks', 'tasks', []),
-        ('productname', 'products', []),
-        ('task', 'tasks', ['']),
+        ("series", "series", None),
+        ("date", "dateModified", ""),
+        ("subtitle", "subtitle", ""),
+        ("seo-title", "seo_title", None),
+        ("seo-social-descr", "seo_social_descr", ""),
+        ("seo-description", "seo_description", ""),
+        ("rootid", "rootid", None),
+        ("tasks", "tasks", []),
+        ("productname", "products", []),
+        ("task", "tasks", [""]),
     ],
 )
 def test_metadata_without_key(option, key, value, monkeypatch):
@@ -58,8 +58,8 @@ def test_metadata_without_key(option, key, value, monkeypatch):
     def fake_open(self, *args, **kwargs):
         return StringIO(fake_content)
 
-    monkeypatch.setattr(metadata_module.Path, 'open', fake_open)
+    monkeypatch.setattr(metadata_module.Path, "open", fake_open)
 
     meta = metadata_module.Metadata()
-    meta.read('dummy/path')
+    meta.read("dummy/path")
     assert getattr(meta, key) == value

--- a/tests/models/test_path.py
+++ b/tests/models/test_path.py
@@ -1,50 +1,53 @@
 """Tests for the custom Pydantic path model."""
 
 import os
-import stat
 from pathlib import Path
-from typing import Any
-from unittest.mock import Mock
 
-import pytest
 from pydantic import BaseModel, ValidationError
+import pytest
 
 # Import the custom type under test
 from docbuild.models.path import EnsureWritableDirectory
 
-
 # --- Test Setup ---
+
 
 # Define a simple Pydantic model to test the custom type integration
 class PathTestModel(BaseModel):
     """Model using the custom path type for testing validation."""
+
     writable_dir: EnsureWritableDirectory
 
 
 # --- Test Cases ---
 
+
 def test_writable_directory_success_exists(tmp_path: Path):
-    """Test successful validation when the directory already exists and is writable."""
-    existing_dir = tmp_path / 'existing_test_dir'
+    """Test validation succeeds for an existing, writable directory."""
+    existing_dir = tmp_path / "existing_test_dir"
     existing_dir.mkdir()
 
     # Validation should succeed and return the custom type instance
-    model = PathTestModel(writable_dir=existing_dir) # type: ignore
+    model = PathTestModel(writable_dir=existing_dir)  # type: ignore
 
     assert isinstance(model.writable_dir, EnsureWritableDirectory)
     assert Path(str(model.writable_dir)).resolve() == existing_dir.resolve()
-    assert model.writable_dir.is_dir() # Test __getattr__ functionality
+    assert model.writable_dir.is_dir()  # Test __getattr__ functionality
 
 
 def test_writable_directory_success_create_new(tmp_path: Path):
-    """Test successful validation when the directory must be created."""
-    new_dir = tmp_path / 'non_existent' / 'deep' / 'path'
+    """Test validation succeeds and creates a new directory.
+
+    This test ensures that if the provided path does not exist, it is
+    automatically created with the necessary parent directories.
+    """
+    new_dir = tmp_path / "non_existent" / "deep" / "path"
 
     # Assert precondition: Path does not exist
     assert not new_dir.exists()
 
     # Validation should trigger auto-creation
-    model = PathTestModel(writable_dir=new_dir) # type: ignore
+    model = PathTestModel(writable_dir=new_dir)  # type: ignore
 
     # Assert postcondition: Path now exists and is a directory
     assert model.writable_dir.exists()
@@ -53,70 +56,81 @@ def test_writable_directory_success_create_new(tmp_path: Path):
 
 
 def test_writable_directory_path_expansion(monkeypatch, tmp_path: Path):
-    """Test that the path correctly expands user home directory (~)."""
+    """Test that the path correctly expands the user home directory (~)."""
     # 1. Setup Mock Home Directory
-    fake_home = tmp_path / 'fake_user_home'
+    fake_home = tmp_path / "fake_user_home"
     fake_home.mkdir()
 
-    test_path_str = '~/test_output'
+    test_path_str = "~/test_output"
 
     # 2. Mock Path.expanduser() to return the resolved path
-    expected_resolved_path = (fake_home / 'test_output').resolve()
-    monkeypatch.setenv('HOME', str(fake_home))
+    expected_resolved_path = (fake_home / "test_output").resolve()
+    monkeypatch.setenv("HOME", str(fake_home))
 
     # 3. Validation should resolve "~" before creation
-    model = PathTestModel(writable_dir=test_path_str) # type: ignore
+    model = PathTestModel(writable_dir=test_path_str)  # type: ignore
     # 4. Assertions
     # The attribute _path should match the expected resolved path
     assert Path(str(model.writable_dir)).resolve() == expected_resolved_path
 
 
 def test_writable_directory_failure_not_a_directory(tmp_path: Path):
-    """Test failure when the path exists but is a file."""
-    existing_file = tmp_path / 'a_file.txt'
-    existing_file.write_text('content')
+    """Test validation fails when the path exists but is a file."""
+    existing_file = tmp_path / "a_file.txt"
+    existing_file.write_text("content")
 
     with pytest.raises(ValidationError) as excinfo:
-        PathTestModel(writable_dir=existing_file) # type: ignore
+        PathTestModel(writable_dir=existing_file)  # type: ignore
 
-    assert 'Path exists but is not a directory' in excinfo.value.errors()[0]['msg']
+    assert "Path exists but is not a directory" in excinfo.value.errors()[0]["msg"]
 
 
 def test_writable_directory_failure_not_writable(tmp_path: Path, monkeypatch):
-    """Test failure when the directory lacks write permission (robust against root user)."""
-    read_only_dir = tmp_path / 'read_only_dir'
+    """Test validation fails when the directory lacks write permission.
+
+    This test is robust against being run by the root user by patching
+    ``os.access`` to simulate a write permission failure.
+    """
+    read_only_dir = tmp_path / "read_only_dir"
     read_only_dir.mkdir()
 
     _original_os_access = os.access
 
     # Patch os.access() to always report write permission is MISSING on this directory
     def fake_access(path, mode):
-        # If we are checking the specific read_only directory for WRITE permission, fail it.
+        # If we are checking the specific read_only directory for WRITE
+        # permission, fail it.
         if path == read_only_dir.resolve() and mode == os.W_OK:
             return False
 
         # Otherwise, call the safely stored original function.
         return _original_os_access(path, mode)
 
-    monkeypatch.setattr(os, 'access', fake_access)
+    monkeypatch.setattr(os, "access", fake_access)
 
     # The actual chmod is now primarily symbolic, the mock forces the logic path
     read_only_dir.chmod(0o444)
 
     try:
         with pytest.raises(ValidationError) as excinfo:
-            PathTestModel(writable_dir=read_only_dir) # type: ignore
+            PathTestModel(writable_dir=read_only_dir)  # type: ignore
 
-        assert 'Insufficient permissions for directory' in excinfo.value.errors()[0]['msg']
-        assert 'WRITE' in excinfo.value.errors()[0]['msg']
+        assert (
+            "Insufficient permissions for directory" in excinfo.value.errors()[0]["msg"]
+        )
+        assert "WRITE" in excinfo.value.errors()[0]["msg"]
     finally:
         # Restore permissions to ensure cleanup (Crucial for CI)
         read_only_dir.chmod(0o777)
 
 
 def test_writable_directory_failure_not_executable(tmp_path: Path, monkeypatch):
-    """Test failure when the directory lacks execute/search permission (robust against root user)."""
-    no_exec_dir = tmp_path / 'no_exec_dir'
+    """Test validation fails when the directory lacks execute permission.
+
+    This test is robust against being run by the root user by patching
+    ``os.access`` to simulate an execute/search permission failure.
+    """
+    no_exec_dir = tmp_path / "no_exec_dir"
     no_exec_dir.mkdir()
 
     _original_os_access = os.access
@@ -124,62 +138,65 @@ def test_writable_directory_failure_not_executable(tmp_path: Path, monkeypatch):
     # Patch os.access() to always report execute permission is MISSING
     def fake_access(path, mode):
         if path == no_exec_dir.resolve() and mode == os.X_OK:
-            return False # Force failure on execute check
+            return False  # Force failure on execute check
 
         # Otherwise, call the safely stored original function.
         return _original_os_access(path, mode)
 
-    monkeypatch.setattr(os, 'access', fake_access)
+    monkeypatch.setattr(os, "access", fake_access)
 
     # The actual chmod is now primarily symbolic, the mock forces the logic path
     no_exec_dir.chmod(0o666)
 
     try:
         with pytest.raises(ValidationError) as excinfo:
-            PathTestModel(writable_dir=no_exec_dir) # type: ignore
+            PathTestModel(writable_dir=no_exec_dir)  # type: ignore
 
-        assert 'Insufficient permissions for directory' in excinfo.value.errors()[0]['msg']
-        assert 'EXECUTE' in excinfo.value.errors()[0]['msg']
+        assert (
+            "Insufficient permissions for directory" in excinfo.value.errors()[0]["msg"]
+        )
+        assert "EXECUTE" in excinfo.value.errors()[0]["msg"]
     finally:
         # Restore permissions
         no_exec_dir.chmod(0o777)
 
 
 def test_writable_directory_failure_mkdir_os_error(monkeypatch, tmp_path: Path):
-    """
-    Test that an OSError raised during directory creation (mkdir) is correctly
-    caught and re-raised as a ValueError (100% coverage).
+    """Test that an OSError during directory creation is handled.
+
+    This ensures that if ``Path.mkdir()`` raises an ``OSError``, the exception
+    is caught and correctly reported as a Pydantic validation error.
     """
 
     # 1. Mock Path.mkdir to always raise an OSError when called
     def mock_mkdir(*args, **kwargs):
-        raise OSError(13, 'Simulated permission denied for mkdir')
+        raise OSError(13, "Simulated permission denied for mkdir")
 
-    monkeypatch.setattr(Path, 'mkdir', mock_mkdir)
+    monkeypatch.setattr(Path, "mkdir", mock_mkdir)
 
     # Create a Path object that is guaranteed not to exist yet
     non_existent_path = tmp_path / "new_path" / "fail"
 
     # 2. Action & Assertions
     with pytest.raises(ValidationError) as excinfo:
-        PathTestModel(writable_dir=non_existent_path) # type: ignore
+        PathTestModel(writable_dir=non_existent_path)  # type: ignore
 
     # Assert that the error is correctly wrapped in a ValueError/ValidationError
-    error_msg = excinfo.value.errors()[0]['msg']
-    assert 'Value error' in error_msg
-    assert 'Could not create directory' in error_msg
-    assert 'Simulated permission denied' in error_msg
+    error_msg = excinfo.value.errors()[0]["msg"]
+    assert "Value error" in error_msg
+    assert "Could not create directory" in error_msg
+    assert "Simulated permission denied" in error_msg
 
 
 def test_writable_directory_attribute_access(tmp_path: Path):
-    """Test that attributes of the underlying Path object are accessible via __getattr__."""
-    test_dir = tmp_path / 'test_attributes'
+    """Test that Path attributes are accessible via __getattr__."""
+    test_dir = tmp_path / "test_attributes"
     test_dir.mkdir()
 
-    model = PathTestModel(writable_dir=test_dir) # type: ignore
+    model = PathTestModel(writable_dir=test_dir)  # type: ignore
 
     # Test built-in Path attributes (via __getattr__)
-    assert model.writable_dir.name == 'test_attributes'
+    assert model.writable_dir.name == "test_attributes"
     assert model.writable_dir.is_absolute()
 
     # Test string representation
@@ -197,11 +214,9 @@ def test_writable_directory_attribute_access(tmp_path: Path):
     ids=["os.fspath", "Path constructor", "open and read"],
 )
 def test_fspath_protocol_compatibility(
-    request: pytest.FixtureRequest,
-    tmp_path: Path,
-    path_consumer, expected_factory
+    request: pytest.FixtureRequest, tmp_path: Path, path_consumer, expected_factory
 ):
-    """Test that EnsureWritableDirectory works with functions expecting os.PathLike."""
+    """Test that the type works with functions expecting ``os.PathLike``."""
     test_dir = tmp_path / "fspath_test"
     model = PathTestModel(writable_dir=test_dir)  # type: ignore
     custom_path_obj = model.writable_dir

--- a/tests/models/test_product.py
+++ b/tests/models/test_product.py
@@ -4,7 +4,7 @@ from docbuild.constants import ALLOWED_PRODUCTS
 from docbuild.models.product import Product
 
 
-@pytest.mark.parametrize('product', ALLOWED_PRODUCTS)
+@pytest.mark.parametrize("product", ALLOWED_PRODUCTS)
 def test_valid_product(product):
     instance = Product[product]
     assert instance.value == product
@@ -12,38 +12,38 @@ def test_valid_product(product):
 
 def test_access_all_productname_constants():
     instance = Product.ALL
-    assert instance.name == 'ALL'
-    assert instance.value == '*'
-    assert Product['ALL'] == Product.ALL
-    assert Product('*') == Product.ALL
+    assert instance.name == "ALL"
+    assert instance.value == "*"
+    assert Product["ALL"] == Product.ALL
+    assert Product("*") == Product.ALL
 
 
 def test_access_valid_productname_with_underscore():
-    assert Product['sle_ha'] == Product.sle_ha
+    assert Product["sle_ha"] == Product.sle_ha
 
 
 def test_access_valid_productname_with_dash():
-    assert Product['sle-ha'] == Product.sle_ha
+    assert Product["sle-ha"] == Product.sle_ha
 
 
 def test_access_valid_productname_uppercase_key():
     # Enum names are case-sensitive, this should fail
     with pytest.raises(KeyError):
-        Product['SLE-HA']
+        Product["SLE-HA"]
 
 
 def test_enum_productvalue_integrity():
-    assert Product.sle_ha.value == 'sle-ha'
+    assert Product.sle_ha.value == "sle-ha"
 
 
 def test_invalid_key_raises_keyerror_with_hint():
     with pytest.raises(KeyError) as excinfo:
-        Product['not-a-product']
-    assert 'not-a-product' in str(excinfo.value)
+        Product["not-a-product"]
+    assert "not-a-product" in str(excinfo.value)
 
 
 def test_invalid_values_raise_value_error():
     with pytest.raises(ValueError) as excinfo:
-        Product('unknown')
+        Product("unknown")
 
-    assert 'unknown' in str(excinfo.value)
+    assert "unknown" in str(excinfo.value)

--- a/tests/models/test_repo.py
+++ b/tests/models/test_repo.py
@@ -5,38 +5,38 @@ from docbuild.models.repo import Repo
 
 # Use different spellings/casings of the same URL to test normalization
 @pytest.fixture(
-    params=['https://github.com/org/repo.git', 'https://GitHub.com/ORG/repo.git']
+    params=["https://github.com/org/repo.git", "https://GitHub.com/ORG/repo.git"]
 )
 def repo_url(request) -> str:
     return request.param
 
 
 @pytest.mark.parametrize(
-    'input_value, name, url',
+    "input_value, name, url",
     [
         # 1
         (
-            'https://github.com/org/repo.git',
-            'org/repo',
-            'https://github.com/org/repo.git',
+            "https://github.com/org/repo.git",
+            "org/repo",
+            "https://github.com/org/repo.git",
         ),
         # 2
-        ('https://github.com/ORG/repo', 'org/repo', 'https://github.com/org/repo.git'),
+        ("https://github.com/ORG/repo", "org/repo", "https://github.com/org/repo.git"),
         # 3
-        ('https://github.com/org/repo', 'org/repo', 'https://github.com/org/repo.git'),
+        ("https://github.com/org/repo", "org/repo", "https://github.com/org/repo.git"),
         # 4
-        ('https://github.com/org/repo/', 'org/repo', 'https://github.com/org/repo.git'),
+        ("https://github.com/org/repo/", "org/repo", "https://github.com/org/repo.git"),
         # 5
         (
-            'https://github.com/ORG/repo_git.git/',
-            'org/repo_git',
-            'https://github.com/org/repo_git.git',
+            "https://github.com/ORG/repo_git.git/",
+            "org/repo_git",
+            "https://github.com/org/repo_git.git",
         ),
         # 6
         (
-            'https://GitHub.com/ORG/repo_git.git/',
-            'org/repo_git',
-            'https://github.com/org/repo_git.git',
+            "https://GitHub.com/ORG/repo_git.git/",
+            "org/repo_git",
+            "https://github.com/org/repo_git.git",
         ),
     ],
 )
@@ -47,27 +47,27 @@ def test_repo_https(input_value, name, url):
 
 
 @pytest.mark.parametrize(
-    'input_value, name, url',
+    "input_value, name, url",
     [
         # 1
-        ('git@github.com:org/repo.git', 'org/repo', 'https://github.com/org/repo.git'),
+        ("git@github.com:org/repo.git", "org/repo", "https://github.com/org/repo.git"),
         # 2
-        ('git@github.com:ORG/repo.git', 'org/repo', 'https://github.com/org/repo.git'),
+        ("git@github.com:ORG/repo.git", "org/repo", "https://github.com/org/repo.git"),
         # 3
-        ('git@github.com:org/repo', 'org/repo', 'https://github.com/org/repo.git'),
+        ("git@github.com:org/repo", "org/repo", "https://github.com/org/repo.git"),
         # 4
-        ('git@github.com:org/repo/', 'org/repo', 'https://github.com/org/repo.git'),
+        ("git@github.com:org/repo/", "org/repo", "https://github.com/org/repo.git"),
         # 5
         (
-            'git@github.com:org/repo_git/',
-            'org/repo_git',
-            'https://github.com/org/repo_git.git',
+            "git@github.com:org/repo_git/",
+            "org/repo_git",
+            "https://github.com/org/repo_git.git",
         ),
         # 6
         (
-            'git@GitHub.com:org/repo_git/',
-            'org/repo_git',
-            'https://github.com/org/repo_git.git',
+            "git@GitHub.com:org/repo_git/",
+            "org/repo_git",
+            "https://github.com/org/repo_git.git",
         ),
     ],
 )
@@ -78,21 +78,21 @@ def test_repo_ssh(input_value, name, url):
 
 
 @pytest.mark.parametrize(
-    'input_value, name, url',
+    "input_value, name, url",
     [
         # 1
-        ('gh://org/repo', 'org/repo', 'https://github.com/org/repo.git'),
+        ("gh://org/repo", "org/repo", "https://github.com/org/repo.git"),
         # 2
-        ('gh://ORG/repo', 'org/repo', 'https://github.com/org/repo.git'),
+        ("gh://ORG/repo", "org/repo", "https://github.com/org/repo.git"),
         # 3
-        ('gh://org/repo/', 'org/repo', 'https://github.com/org/repo.git'),
+        ("gh://org/repo/", "org/repo", "https://github.com/org/repo.git"),
         # 4
-        ('gh://org/repo.git', 'org/repo', 'https://github.com/org/repo.git'),
+        ("gh://org/repo.git", "org/repo", "https://github.com/org/repo.git"),
         # 5
         (
-            'gh://ORG/repo_git.git',
-            'org/repo_git',
-            'https://github.com/org/repo_git.git',
+            "gh://ORG/repo_git.git",
+            "org/repo_git",
+            "https://github.com/org/repo_git.git",
         ),
     ],
 )
@@ -103,26 +103,26 @@ def test_repo_abbreviation(input_value, name, url):
 
 
 @pytest.mark.parametrize(
-    'input_value, surl',
+    "input_value, surl",
     [
         # 1
-        ('https://github.com/org/repo.git', 'gh://org/repo'),
+        ("https://github.com/org/repo.git", "gh://org/repo"),
         # 2
-        ('https://gitlab.com/ORG/repo.git', 'gl://org/repo'),
+        ("https://gitlab.com/ORG/repo.git", "gl://org/repo"),
         # 3
-        ('git@github.com:org/repo.git', 'gh://org/repo'),
+        ("git@github.com:org/repo.git", "gh://org/repo"),
         # 4
-        ('gh://org/repo', 'gh://org/repo'),
+        ("gh://org/repo", "gh://org/repo"),
         # 5
-        ('gh://ORG/repo', 'gh://org/repo'),
+        ("gh://ORG/repo", "gh://org/repo"),
         # 6
-        ('gh://org/repo/', 'gh://org/repo'),
+        ("gh://org/repo/", "gh://org/repo"),
         # 7
-        ('gh://org/repo.git', 'gh://org/repo'),
+        ("gh://org/repo.git", "gh://org/repo"),
         # 8
-        ('gh://ORG/repo_git.git', 'gh://org/repo_git'),
+        ("gh://ORG/repo_git.git", "gh://org/repo_git"),
         # 9
-        ('GH://ORG/repo_git.git', 'gh://org/repo_git'),
+        ("GH://ORG/repo_git.git", "gh://org/repo_git"),
     ],
 )
 def test_repo_with_surl(input_value, surl):
@@ -132,18 +132,18 @@ def test_repo_with_surl(input_value, surl):
 
 def test_repo_with_unknown_abbreviation():
     with pytest.raises(ValueError):
-        Repo('fake://org/repo')
+        Repo("fake://org/repo")
 
 
 @pytest.mark.parametrize(
-    'input_value, name, url',
+    "input_value, name, url",
     [
         # 1
-        ('org/repo', 'org/repo', 'https://github.com/org/repo.git'),
+        ("org/repo", "org/repo", "https://github.com/org/repo.git"),
         # 2
-        ('ORG/repo', 'org/repo', 'https://github.com/org/repo.git'),
+        ("ORG/repo", "org/repo", "https://github.com/org/repo.git"),
         # 3
-        ('org/repo_git.git', 'org/repo_git', 'https://github.com/org/repo_git.git'),
+        ("org/repo_git.git", "org/repo_git", "https://github.com/org/repo_git.git"),
         # 4
     ],
 )
@@ -155,25 +155,25 @@ def test_repo_abbreviated(input_value, name, url):
 
 def test_repo_with_empty_value():
     with pytest.raises(ValueError):
-        Repo('')
+        Repo("")
 
 
 def test_repo_with_invalid_value():
     with pytest.raises(ValueError):
-        Repo('invalid-repo-value')
+        Repo("invalid-repo-value")
 
 
 def test_repo_compare_with_eq(repo_url):
     repo1 = Repo(repo_url)
-    repo2 = Repo('https://github.com/ORG/repo.git')
+    repo2 = Repo("https://github.com/ORG/repo.git")
     assert repo1 == repo2
-    assert 'org/repo' == repo1
+    assert "org/repo" == repo1
     assert object() != repo1
 
 
 def test_repo_compare_with_in(repo_url):
     repo = Repo(repo_url)
-    assert 'org/repo' in repo
+    assert "org/repo" in repo
     assert object() not in repo  # type: ignore
 
 
@@ -184,12 +184,12 @@ def test_repo_hash(repo_url):
 
 def test_repo_slug(repo_url):
     repo = Repo(repo_url)
-    assert repo.slug == 'https___github_com_org_repo_git'
+    assert repo.slug == "https___github_com_org_repo_git"
 
 
 def test_repo_surl(repo_url):
     repo = Repo(repo_url)
-    assert repo.surl == 'gh://org/repo'
+    assert repo.surl == "gh://org/repo"
 
 
 def test_repo_str(repo_url):

--- a/tests/models/test_serverroles.py
+++ b/tests/models/test_serverroles.py
@@ -4,16 +4,16 @@ from docbuild.constants import SERVER_ROLES
 from docbuild.models.serverroles import ServerRole
 
 
-@pytest.mark.parametrize('role', SERVER_ROLES)
+@pytest.mark.parametrize("role", SERVER_ROLES)
 def test_serverrole_with_call(role):
     assert ServerRole(role)
 
 
-@pytest.mark.parametrize('role', SERVER_ROLES)
+@pytest.mark.parametrize("role", SERVER_ROLES)
 def test_serverrole_with_predicate(role):
     assert ServerRole[role]
 
 
-@pytest.mark.parametrize('role', SERVER_ROLES)
+@pytest.mark.parametrize("role", SERVER_ROLES)
 def test_serverrole_with_uppercase(role):
     assert ServerRole(role) == ServerRole[role.upper()]

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -99,12 +99,9 @@ def test_file_logs_all_levels(logger, memory_handler):
 
 def test_setup_with_user_config(logger):
     """Test that user-provided logging configuration is correctly applied."""
-
     user_config = {
         "logging": {
-            "handlers": {
-                "console": {"level": "ERROR"}
-            },
+            "handlers": {"console": {"level": "ERROR"}},
             "root": {"level": "DEBUG"},
         }
     }
@@ -113,7 +110,7 @@ def test_setup_with_user_config(logger):
     setup_logging(cliverbosity=2, user_config=user_config)
 
     # Attach MemoryHandler to capture logs
-    memory_handler = MemoryHandler(capacity=10*1024, target=None)
+    memory_handler = MemoryHandler(capacity=10 * 1024, target=None)
     memory_handler.setLevel(logging.ERROR)  # **only capture ERROR and above**
     logger.addHandler(memory_handler)
     memory_handler.buffer.clear()
@@ -160,8 +157,9 @@ def test_setup_logging_creates_logfile_and_listener(tmp_path, monkeypatch):
     handlers = _LOGGING_STATE["handlers"].get()
 
     assert listener is not None
-    assert isinstance(handlers, list) and any(isinstance(h, logging.FileHandler)
-                                              for h in handlers)
+    assert isinstance(handlers, list) and any(
+        isinstance(h, logging.FileHandler) for h in handlers
+    )
 
     # Verify a logfile was created in the XDG_STATE_HOME directory
     files = list(tmp_path.glob(f"{APP_NAME}_*.log"))
@@ -176,35 +174,39 @@ def test_setup_logging_bad_formatter(monkeypatch, tmp_path):
     # A formatter that points to a non-existent class should raise on setup
     user_config = {
         "logging": {
-            "formatters": {"bad": {"class": "non.existent.Class",
-                                   "format": "%(message)s"}},
+            "formatters": {
+                "bad": {"class": "non.existent.Class", "format": "%(message)s"}
+            },
             "handlers": {"console": {"formatter": "bad"}},
         }
     }
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     _shutdown_logging()
-    with pytest.raises(Exception):
+    with pytest.raises(Exception):  # noqa: B017
         setup_logging(1, user_config)
     _shutdown_logging()
 
 
 def test_safe_emit_swallows_valueerror(monkeypatch):
     """Test that the safe_emit wrapper swallows ValueError exceptions."""
+
     # Replace the module's _original_emit with a function that raises ValueError
     def raising_emit(self, record):
         raise ValueError("boom")
 
-    monkeypatch.setattr('docbuild.logging._original_emit', raising_emit, raising=True)
+    monkeypatch.setattr("docbuild.logging._original_emit", raising_emit, raising=True)
 
     # Create a handler and a dummy record and call the (patched) StreamHandler.emit
     handler = logging.StreamHandler()
-    record = logging.LogRecord(name="test",
-                               level=logging.INFO,
-                               pathname=__file__,
-                               lineno=1,
-                               msg="x",
-                               args=(),
-                               exc_info=None)
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="x",
+        args=(),
+        exc_info=None,
+    )
 
     # Should not raise due to safe wrapper
     logging.StreamHandler.emit(handler, record)
@@ -212,6 +214,7 @@ def test_safe_emit_swallows_valueerror(monkeypatch):
 
 def test_shutdown_joins_background_threads():
     """Test that _shutdown_logging joins background threads."""
+
     # Create a short-lived background thread and register it
     def worker():
         time.sleep(0.05)
@@ -245,7 +248,10 @@ def test_shutdown_skips_not_alive_threads():
 
 
 def test_register_background_thread_initializes_none():
-    """When the ContextVar is None, `register_background_thread` should initialize it."""
+    """Test that register_background_thread initializes the ContextVar.
+
+    When the ContextVar is None, `register_background_thread` should initialize it.
+    """
     # Ensure initial state is None
     _LOGGING_STATE["background_threads"].set(None)
 
@@ -262,8 +268,11 @@ def test_formatter_kwargs_applied():
     # Ensure formatter kwargs like `format` and `datefmt` are passed through
     user_config = {
         "handlers": {
-            "console": {"class": "logging.StreamHandler",
-                        "formatter": "standard", "level": "INFO"}
+            "console": {
+                "class": "logging.StreamHandler",
+                "formatter": "standard",
+                "level": "INFO",
+            }
         },
         "formatters": {
             "standard": {
@@ -276,8 +285,9 @@ def test_formatter_kwargs_applied():
     }
     handlers = build_handlers_from_config(user_config)
     assert any(
-        getattr(h, "formatter", None) and
-        getattr(h.formatter, "_fmt", None) == "FOO %(message)s" for h in handlers
+        getattr(h, "formatter", None)
+        and getattr(h.formatter, "_fmt", None) == "FOO %(message)s"
+        for h in handlers
     )
 
 
@@ -300,8 +310,8 @@ def test_handler_args_and_missing_formatter(tmp_path):
     handlers = build_handlers_from_config(user_config)
     # FileHandler should receive encoding arg
     assert any(
-        isinstance(h, logging.FileHandler) and
-        getattr(h, "encoding", None) == "utf-8" for h in handlers
+        isinstance(h, logging.FileHandler) and getattr(h, "encoding", None) == "utf-8"
+        for h in handlers
     )
     # Since formatter was set to None, handler.formatter should be absent
     assert any(getattr(h, "formatter", None) is None for h in handlers)
@@ -309,7 +319,8 @@ def test_handler_args_and_missing_formatter(tmp_path):
 
 def test_handler_level_numeric():
     """Test that passing a numeric level is accepted."""
-    user_config = {"handlers": {"console": {"class": "logging.StreamHandler",
-                                            "level": 10}}}
+    user_config = {
+        "handlers": {"console": {"class": "logging.StreamHandler", "level": 10}}
+    }
     handlers = build_handlers_from_config(user_config)
     assert any(getattr(h, "level", None) == 10 for h in handlers)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,28 +7,28 @@ def test_main_invokes_cli(monkeypatch):
     called = {}
 
     def fake_cli():
-        called['cli'] = True
+        called["cli"] = True
 
     # Patch sys.modules to inject fake cli
     import docbuild.__main__
 
-    monkeypatch.setattr(docbuild.__main__, 'cli', fake_cli)
-    monkeypatch.setitem(sys.modules, 'docbuild.__main__', docbuild.__main__)
+    monkeypatch.setattr(docbuild.__main__, "cli", fake_cli)
+    monkeypatch.setitem(sys.modules, "docbuild.__main__", docbuild.__main__)
 
     # Simulate running as __main__
-    docbuild.__main__.__name__ = '__main__'
+    docbuild.__main__.__name__ = "__main__"
     docbuild.__main__.cli()
-    assert called.get('cli') is True
+    assert called.get("cli") is True
 
 
 def test_main_entrypoint_runs_cli():
     env = os.environ.copy()
     # Subprocesses are not covered by default. This needs to be explicitly enabled.
-    env['COVERAGE_PROCESS_START'] = '.coveragerc'
-    env['PYTHONPATH'] = 'src'
+    env["COVERAGE_PROCESS_START"] = ".coveragerc"
+    env["PYTHONPATH"] = "src"
     # Run the module as a script
     result = subprocess.run(
-        [sys.executable, '-m', 'docbuild', '--help'],
+        [sys.executable, "-m", "docbuild", "--help"],
         capture_output=True,
         text=True,
         env=env,
@@ -36,4 +36,4 @@ def test_main_entrypoint_runs_cli():
     # The CLI may exit with code 0 or show help if no args
     assert result.returncode == 0 or result.returncode == 1
     # Optionally, check for expected output (e.g., help text)
-    assert 'Usage:' in result.stdout or 'usage:' in result.stdout.lower()
+    assert "Usage:" in result.stdout or "usage:" in result.stdout.lower()

--- a/tests/utils/test_contextmgr.py
+++ b/tests/utils/test_contextmgr.py
@@ -8,23 +8,27 @@ from unittest.mock import patch
 import pytest
 
 import docbuild.utils.contextmgr as contextmgr
-from docbuild.utils.contextmgr import PersistentOnErrorTemporaryDirectory, edit_json, make_timer
+from docbuild.utils.contextmgr import (
+    PersistentOnErrorTemporaryDirectory,
+    edit_json,
+    make_timer,
+)
 
 
 def test_timer_has_correct_attributes():
-    timer_name = 'test-timer'
+    timer_name = "test-timer"
     sleep_duration = 0.1
     time_func = make_timer(timer_name)
 
     with time_func() as timer_data:
         time.sleep(sleep_duration)
 
-    for key in ('name', 'start', 'end', 'elapsed'):
+    for key in ("name", "start", "end", "elapsed"):
         assert hasattr(timer_data, key), f"Expected key '{key}' not found in timer_data"
 
 
 def test_timer_as_context_manager_measures_time():
-    timer_name = 'test-timer'
+    timer_name = "test-timer"
     sleep_duration = 0.1
     timer = make_timer(timer_name)
 
@@ -37,8 +41,8 @@ def test_timer_as_context_manager_measures_time():
 
 
 def test_timer_factory_creates_independent_timers():
-    timer_name1 = 'test-timer-1'
-    timer_name2 = 'test-timer-2'
+    timer_name1 = "test-timer-1"
+    timer_name2 = "test-timer-2"
     sleep_duration = 0.1
 
     timer1 = make_timer(timer_name1)
@@ -60,7 +64,7 @@ def test_timer_factory_creates_independent_timers():
 
 
 def test_timer_for_nan_as_default():
-    timer_name = 'test-timer'
+    timer_name = "test-timer"
     timer = make_timer(timer_name)
     sleep_duration = 0.1
 
@@ -74,7 +78,7 @@ def test_timer_for_nan_as_default():
 # ----
 @pytest.fixture
 def fake_temp_path() -> str:
-    return '/mock/temp/dir'
+    return "/mock/temp/dir"
 
 
 def test_temp_dir_deleted_on_success(fake_temp_path: str) -> None:
@@ -82,10 +86,10 @@ def test_temp_dir_deleted_on_success(fake_temp_path: str) -> None:
     with (
         patch.object(
             contextmgr.tempfile,
-            'mkdtemp',
+            "mkdtemp",
             return_value=fake_temp_path,
         ),
-        patch.object(contextmgr.shutil, 'rmtree') as mock_rmtree,
+        patch.object(contextmgr.shutil, "rmtree") as mock_rmtree,
     ):
         with PersistentOnErrorTemporaryDirectory() as temp_path:
             assert temp_path == Path(fake_temp_path)
@@ -96,27 +100,27 @@ def test_temp_dir_deleted_on_success(fake_temp_path: str) -> None:
 def test_temp_dir_preserved_on_exception(fake_temp_path: str) -> None:
     """Ensure the directory is preserved if an exception occurs."""
     with (
-        patch.object(contextmgr.tempfile, 'mkdtemp', return_value=fake_temp_path),
-        patch.object(contextmgr.shutil, 'rmtree') as mock_rmtree,
+        patch.object(contextmgr.tempfile, "mkdtemp", return_value=fake_temp_path),
+        patch.object(contextmgr.shutil, "rmtree") as mock_rmtree,
     ):
         with pytest.raises(RuntimeError):
             with PersistentOnErrorTemporaryDirectory() as temp_path:
                 assert temp_path == Path(fake_temp_path)
-                raise RuntimeError('Simulated failure')
+                raise RuntimeError("Simulated failure")
 
         mock_rmtree.assert_not_called()
 
 
 def test_temp_dir_deletion_failure_is_logged(fake_temp_path: str) -> None:
     """Ensure that an OSError during directory deletion is logged."""
-    mock_error = OSError('Permission denied')
+    mock_error = OSError("Permission denied")
 
     with (
-        patch.object(contextmgr.tempfile, 'mkdtemp', return_value=fake_temp_path),
+        patch.object(contextmgr.tempfile, "mkdtemp", return_value=fake_temp_path),
         patch.object(
-            contextmgr.shutil, 'rmtree', side_effect=mock_error
+            contextmgr.shutil, "rmtree", side_effect=mock_error
         ) as mock_rmtree,
-        patch.object(contextmgr.log, 'exception') as mock_log_exception,
+        patch.object(contextmgr.log, "exception") as mock_log_exception,
     ):
         # The __exit__ method should catch the OSError and not re-raise it.
         with PersistentOnErrorTemporaryDirectory() as temp_path:
@@ -126,15 +130,15 @@ def test_temp_dir_deletion_failure_is_logged(fake_temp_path: str) -> None:
         mock_rmtree.assert_called_once_with(fake_temp_path)
         # Verify that the exception was logged with the correct message.
         mock_log_exception.assert_called_once_with(
-            'Failed to delete temp dir %s: %s', fake_temp_path, mock_error
+            "Failed to delete temp dir %s: %s", fake_temp_path, mock_error
         )
 
 
 async def test_async_temp_dir_deleted_on_success(fake_temp_path: str) -> None:
     """Ensure the directory is deleted if no exception occurs in an async context."""
     with (
-        patch.object(contextmgr.tempfile, 'mkdtemp', return_value=fake_temp_path),
-        patch.object(contextmgr.shutil, 'rmtree') as mock_rmtree,
+        patch.object(contextmgr.tempfile, "mkdtemp", return_value=fake_temp_path),
+        patch.object(contextmgr.shutil, "rmtree") as mock_rmtree,
     ):
         async with PersistentOnErrorTemporaryDirectory() as temp_path:
             assert temp_path == Path(fake_temp_path)
@@ -146,13 +150,13 @@ async def test_async_temp_dir_deleted_on_success(fake_temp_path: str) -> None:
 async def test_async_temp_dir_preserved_on_exception(fake_temp_path: str) -> None:
     """Ensure the directory is preserved if an exception occurs in an async context."""
     with (
-        patch.object(contextmgr.tempfile, 'mkdtemp', return_value=fake_temp_path),
-        patch.object(contextmgr.shutil, 'rmtree') as mock_rmtree,
+        patch.object(contextmgr.tempfile, "mkdtemp", return_value=fake_temp_path),
+        patch.object(contextmgr.shutil, "rmtree") as mock_rmtree,
     ):
         with pytest.raises(RuntimeError):
             async with PersistentOnErrorTemporaryDirectory() as temp_path:
                 assert temp_path == Path(fake_temp_path)
-                raise RuntimeError('Simulated failure')
+                raise RuntimeError("Simulated failure")
 
         await asyncio.sleep(0)
         mock_rmtree.assert_not_called()
@@ -160,13 +164,13 @@ async def test_async_temp_dir_preserved_on_exception(fake_temp_path: str) -> Non
 
 async def test_async_temp_dir_deletion_failure_is_logged(fake_temp_path: str) -> None:
     """Ensure that an OSError during async directory deletion is logged."""
-    mock_error = OSError('Permission denied')
+    mock_error = OSError("Permission denied")
     with (
-        patch.object(contextmgr.tempfile, 'mkdtemp', return_value=fake_temp_path),
+        patch.object(contextmgr.tempfile, "mkdtemp", return_value=fake_temp_path),
         patch.object(
-            contextmgr.shutil, 'rmtree', side_effect=mock_error
+            contextmgr.shutil, "rmtree", side_effect=mock_error
         ) as mock_rmtree,
-        patch.object(contextmgr.log, 'exception') as mock_log_exception,
+        patch.object(contextmgr.log, "exception") as mock_log_exception,
     ):
         async with PersistentOnErrorTemporaryDirectory() as temp_path:
             assert temp_path == Path(fake_temp_path)
@@ -174,88 +178,90 @@ async def test_async_temp_dir_deletion_failure_is_logged(fake_temp_path: str) ->
         await asyncio.sleep(0)
         mock_rmtree.assert_called_once_with(fake_temp_path)
         mock_log_exception.assert_called_once_with(
-            'Failed to delete temp dir %s: %s', fake_temp_path, mock_error
+            "Failed to delete temp dir %s: %s", fake_temp_path, mock_error
         )
 
+
 # ---
+
 
 def test_edit_json_modifies_file_correctly(tmp_path):
     """Happy path: reads, updates, and saves changes."""
     # Arrange
-    f = tmp_path / 'config.json'
-    f.write_text('{"value": 1}', encoding='utf-8')
+    f = tmp_path / "config.json"
+    f.write_text('{"value": 1}', encoding="utf-8")
 
     # Act
     with edit_json(f) as data:
-        data['value'] = 2
-        data['new'] = 'entry'
+        data["value"] = 2
+        data["new"] = "entry"
 
     # Assert
-    content = json.loads(f.read_text(encoding='utf-8'))
-    assert content == {'value': 2, 'new': 'entry'}
+    content = json.loads(f.read_text(encoding="utf-8"))
+    assert content == {"value": 2, "new": "entry"}
 
 
 def test_edit_json_aborts_write_on_user_exception(tmp_path):
     """If an error occurs inside the 'with' block, the file should not be touched."""
     # Arrange
-    f = tmp_path / 'config.json'
+    f = tmp_path / "config.json"
     original_content = '{"value": 1}'
-    f.write_text(original_content, encoding='utf-8')
+    f.write_text(original_content, encoding="utf-8")
 
     # Act
     with pytest.raises(ValueError):
         with edit_json(f) as data:
-            data['value'] = 999
-            raise ValueError('Something went wrong!')
+            data["value"] = 999
+            raise ValueError("Something went wrong!")
 
     # Assert
     # Verify the file content is exactly what it was before
-    assert f.read_text(encoding='utf-8') == original_content
+    assert f.read_text(encoding="utf-8") == original_content
 
 
 def test_edit_json_cleans_up_temp_file_on_dump_error(tmp_path, monkeypatch):
     """If the write phase fails (e.g. disk error), the temp file must be deleted."""
     # Arrange
-    f = tmp_path / 'config.json'
-    f.write_text('{"value": 1}', encoding='utf-8')
+    f = tmp_path / "config.json"
+    f.write_text('{"value": 1}', encoding="utf-8")
 
     # Simulate json.dump crashing
     def mock_dump(*args, **kwargs):
-        raise OSError('Disk full')
+        raise OSError("Disk full")
 
-    monkeypatch.setattr(json, 'dump', mock_dump)
+    monkeypatch.setattr(json, "dump", mock_dump)
 
     # Act
-    with pytest.raises(OSError, match='Disk full'):
+    with pytest.raises(OSError, match="Disk full"):
         with edit_json(f) as data:
-            data['value'] = 2
+            data["value"] = 2
 
     # Assert
     # 1. Original file is unchanged
-    assert json.loads(f.read_text()) == {'value': 1}
+    assert json.loads(f.read_text()) == {"value": 1}
 
     # 2. Verify NO temporary files were left behind
     # We look for any file starting with ".json_tmp_" in the directory
-    temp_files = list(tmp_path.glob('.json_tmp_*.tmp'))
-    assert temp_files == [], f'Found leftover temp files: {temp_files}'
+    temp_files = list(tmp_path.glob(".json_tmp_*.tmp"))
+    assert temp_files == [], f"Found leftover temp files: {temp_files}"
 
 
 def test_edit_json_raises_on_missing_file(tmp_path):
     """If the target JSON file does not exist, a FileNotFoundError is raised."""
-    f = tmp_path / 'missing.json'
+    f = tmp_path / "missing.json"
 
     with pytest.raises(FileNotFoundError, match=str(f)):
         with edit_json(f) as data:
-            data['x'] = 1
+            data["x"] = 1
 
 
 def test_edit_json_invalid_json_raises_with_path(tmp_path):
     """If the file contains invalid JSON, a JSONDecodeError with file path is raised."""
-    f = tmp_path / 'bad.json'
-    f.write_text('{ invalid json }', encoding='utf-8')
+    f = tmp_path / "bad.json"
+    f.write_text("{ invalid json }", encoding="utf-8")
 
     with pytest.raises(json.JSONDecodeError) as excinfo:
         with edit_json(f) as data:
-            data['x'] = 1
+            data["x"] = 1
 
     assert str(f) in str(excinfo.value)

--- a/tests/utils/test_convert.py
+++ b/tests/utils/test_convert.py
@@ -4,18 +4,18 @@ from docbuild.utils import convert
 
 
 @pytest.mark.parametrize(
-    'input_value,expected_output',
+    "input_value,expected_output",
     [
         (True, True),
-        ('yes', True),
-        ('true', True),
-        ('1', True),
-        ('on', True),
+        ("yes", True),
+        ("true", True),
+        ("1", True),
+        ("on", True),
         (False, False),
-        ('no', False),
-        ('false', False),
-        ('0', False),
-        ('off', False),
+        ("no", False),
+        ("false", False),
+        ("0", False),
+        ("off", False),
     ],
 )
 def test_convert2bool(input_value, expected_output):
@@ -25,5 +25,5 @@ def test_convert2bool(input_value, expected_output):
 
 def test_convert2bool_invalid():
     """Test the convert2bool function with invalid input."""
-    with pytest.raises(ValueError, match='Invalid boolean value: invalid'):
-        convert.convert2bool('invalid')
+    with pytest.raises(ValueError, match="Invalid boolean value: invalid"):
+        convert.convert2bool("invalid")

--- a/tests/utils/test_decorators.py
+++ b/tests/utils/test_decorators.py
@@ -1,4 +1,3 @@
-
 from lxml import etree
 import pytest
 
@@ -13,8 +12,8 @@ def test_register_check_registers_function():
     def foo(tree):
         return True
 
-    assert foo(etree.Element('root', nsmap=None, attrib=None)) is True
-    assert registry[0].__name__ == 'foo'
+    assert foo(etree.Element("root", nsmap=None, attrib=None)) is True
+    assert registry[0].__name__ == "foo"
 
 
 def test_register_check_type_error():
@@ -37,7 +36,7 @@ def test_multiple_functions_registered():
 
     assert len(registry) == 2
 
-    for func, name in zip(registry, ('foo', 'bar'), strict=False):
+    for func, name in zip(registry, ("foo", "bar"), strict=False):
         assert callable(func)
         assert func.__name__ == name
 
@@ -50,5 +49,5 @@ def test_wrapper_preserves_function_metadata():
         """Docstring for foo."""
         return True
 
-    assert foo.__name__ == 'foo'
-    assert foo.__doc__ == 'Docstring for foo.'
+    assert foo.__name__ == "foo"
+    assert foo.__doc__ == "Docstring for foo."

--- a/tests/utils/test_doc.py
+++ b/tests/utils/test_doc.py
@@ -1,20 +1,19 @@
-
 from docbuild.utils.doc import docstring
 
 
 def test_docstring_with_empty_func():
-    @docstring('Hello {name}, welcome to {place}', name='Alice')
+    @docstring("Hello {name}, welcome to {place}", name="Alice")
     def greet() -> str:
-        return 'Hello'
+        return "Hello"
 
-    assert greet() == 'Hello'
-    assert greet.__doc__ == 'Hello Alice, welcome to {place}'
+    assert greet() == "Hello"
+    assert greet.__doc__ == "Hello Alice, welcome to {place}"
 
 
 def test_docstring_with_existing_docstring():
-    @docstring(name='Alice')
+    @docstring(name="Alice")
     def greet():
         """Hello {name}, welcome to {place}."""
         pass
 
-    assert greet.__doc__ == 'Hello Alice, welcome to {place}.'
+    assert greet.__doc__ == "Hello Alice, welcome to {place}."

--- a/tests/utils/test_git.py
+++ b/tests/utils/test_git.py
@@ -3,7 +3,7 @@
 import asyncio
 from pathlib import Path
 from subprocess import CompletedProcess
-from unittest.mock import AsyncMock, Mock, call
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -16,10 +16,10 @@ from docbuild.utils.git import ManagedGitRepo
 def mock_subprocess_exec(monkeypatch) -> AsyncMock:
     """Fixture to mock asyncio.create_subprocess_exec."""
     process_mock = AsyncMock()
-    process_mock.communicate.return_value = (b'stdout success', b'stderr info')
+    process_mock.communicate.return_value = (b"stdout success", b"stderr info")
     process_mock.returncode = 0
     mock_create = AsyncMock(return_value=process_mock)
-    monkeypatch.setattr(asyncio, 'create_subprocess_exec', mock_create)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", mock_create)
     return mock_create
 
 
@@ -28,12 +28,12 @@ def mock_execute_git(monkeypatch) -> AsyncMock:
     """Fixture to mock execute_git_command."""
 
     async def side_effect(*args, **kwargs):
-        if args[0] == 'clone':
-            return CompletedProcess(args, 0, 'Cloning...', '')
-        return CompletedProcess(args, 0, 'stdout success', '')
+        if args[0] == "clone":
+            return CompletedProcess(args, 0, "Cloning...", "")
+        return CompletedProcess(args, 0, "stdout success", "")
 
     mock = AsyncMock(side_effect=side_effect)
-    monkeypatch.setattr(git_module, 'execute_git_command', mock)
+    monkeypatch.setattr(git_module, "execute_git_command", mock)
     return mock
 
 
@@ -47,18 +47,18 @@ async def test_managed_repo_clone_bare_new(
     tmp_path: Path, mock_execute_git: AsyncMock, monkeypatch
 ):
     """Test clone_bare when the repository does not exist yet."""
-    repo = ManagedGitRepo('http://a.b/c.git', tmp_path)
+    repo = ManagedGitRepo("http://a.b/c.git", tmp_path)
     # Simulate repo does not exist
-    monkeypatch.setattr(Path, 'exists', lambda self: False)
+    monkeypatch.setattr(Path, "exists", lambda self: False)
 
     result = await repo.clone_bare()
 
     assert result is True
     mock_execute_git.assert_awaited_once_with(
-        'clone',
-        '--bare',
-        '--progress',
-        'http://a.b/c.git',
+        "clone",
+        "--bare",
+        "--progress",
+        "http://a.b/c.git",
         str(repo.bare_repo_path),
         cwd=tmp_path,
         gitconfig=None,
@@ -69,9 +69,9 @@ async def test_managed_repo_clone_bare_exists(
     tmp_path: Path, mock_execute_git: AsyncMock, monkeypatch
 ):
     """Test clone_bare when the repository already exists."""
-    repo = ManagedGitRepo('http://a.b/c.git', tmp_path)
+    repo = ManagedGitRepo("http://a.b/c.git", tmp_path)
     # Simulate repo exists
-    monkeypatch.setattr(Path, 'exists', lambda self: True)
+    monkeypatch.setattr(Path, "exists", lambda self: True)
 
     await repo.clone_bare()
     mock_execute_git.assert_awaited_once()
@@ -81,10 +81,10 @@ async def test_managed_repo_clone_bare_failure(
     tmp_path: Path, mock_execute_git: AsyncMock, monkeypatch
 ):
     """Test clone_bare when the git command fails."""
-    repo = ManagedGitRepo('http://a.b/c.git', tmp_path)
+    repo = ManagedGitRepo("http://a.b/c.git", tmp_path)
     # Simulate repo does not exist
-    monkeypatch.setattr(Path, 'exists', lambda self: False)
-    mock_execute_git.side_effect = RuntimeError('Git clone failed')
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+    mock_execute_git.side_effect = RuntimeError("Git clone failed")
 
     result = await repo.clone_bare()
     assert result is False
@@ -94,18 +94,18 @@ async def test_managed_repo_create_worktree_success(
     tmp_path: Path, mock_execute_git: AsyncMock, monkeypatch
 ):
     """Test create_worktree successfully creates a worktree."""
-    repo = ManagedGitRepo('http://a.b/c.git', tmp_path)
+    repo = ManagedGitRepo("http://a.b/c.git", tmp_path)
     # Simulate bare repo exists
-    monkeypatch.setattr(Path, 'exists', lambda self: True)
-    target_dir = tmp_path / 'worktree'
+    monkeypatch.setattr(Path, "exists", lambda self: True)
+    target_dir = tmp_path / "worktree"
 
-    await repo.create_worktree(target_dir, 'main')
+    await repo.create_worktree(target_dir, "main")
 
     mock_execute_git.assert_awaited_once_with(
-        'clone',
-        '--local',
-        '--branch',
-        'main',
+        "clone",
+        "--local",
+        "--branch",
+        "main",
         str(repo.bare_repo_path),
         str(target_dir),
         cwd=target_dir.parent,
@@ -117,20 +117,20 @@ async def test_managed_repo_create_worktree_with_options(
     tmp_path: Path, mock_execute_git: AsyncMock, monkeypatch
 ):
     """Test create_worktree with additional clone options."""
-    repo = ManagedGitRepo('http://a.b/c.git', tmp_path)
+    repo = ManagedGitRepo("http://a.b/c.git", tmp_path)
     # Simulate bare repo exists
-    monkeypatch.setattr(Path, 'exists', lambda self: True)
-    target_dir = tmp_path / 'worktree'
+    monkeypatch.setattr(Path, "exists", lambda self: True)
+    target_dir = tmp_path / "worktree"
 
-    await repo.create_worktree(target_dir, 'develop', options=['--depth', '1'])
+    await repo.create_worktree(target_dir, "develop", options=["--depth", "1"])
 
     mock_execute_git.assert_awaited_once_with(
-        'clone',
-        '--local',
-        '--branch',
-        'develop',
-        '--depth',
-        '1',
+        "clone",
+        "--local",
+        "--branch",
+        "develop",
+        "--depth",
+        "1",
         str(repo.bare_repo_path),
         str(target_dir),
         cwd=target_dir.parent,
@@ -142,13 +142,13 @@ async def test_managed_repo_create_worktree_no_bare_repo(
     tmp_path: Path, mock_execute_git: AsyncMock, monkeypatch
 ):
     """Test create_worktree fails if the bare repository does not exist."""
-    repo = ManagedGitRepo('http://a.b/c.git', tmp_path)
+    repo = ManagedGitRepo("http://a.b/c.git", tmp_path)
     # Simulate bare repo does not exist
-    monkeypatch.setattr(Path, 'exists', lambda self: False)
-    target_dir = tmp_path / 'worktree'
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+    target_dir = tmp_path / "worktree"
 
-    with pytest.raises(FileNotFoundError, match='Bare repository does not exist'):
-        await repo.create_worktree(target_dir, 'main')
+    with pytest.raises(FileNotFoundError, match="Bare repository does not exist"):
+        await repo.create_worktree(target_dir, "main")
 
     mock_execute_git.assert_not_awaited()
 
@@ -157,18 +157,18 @@ async def test_managed_repo_create_worktree_not_local(
     tmp_path: Path, mock_execute_git: AsyncMock, monkeypatch
 ):
     """Test create_worktree without the --local flag."""
-    repo = ManagedGitRepo('http://a.b/c.git', tmp_path)
+    repo = ManagedGitRepo("http://a.b/c.git", tmp_path)
     # Simulate bare repo exists
-    monkeypatch.setattr(Path, 'exists', lambda self: True)
-    target_dir = tmp_path / 'worktree'
+    monkeypatch.setattr(Path, "exists", lambda self: True)
+    target_dir = tmp_path / "worktree"
 
     # Explicitly call with is_local=False
-    await repo.create_worktree(target_dir, 'main', is_local=False)
+    await repo.create_worktree(target_dir, "main", is_local=False)
 
     mock_execute_git.assert_awaited_once_with(
-        'clone',
-        '--branch',
-        'main',
+        "clone",
+        "--branch",
+        "main",
         str(repo.bare_repo_path),
         str(target_dir),
         cwd=target_dir.parent,
@@ -178,7 +178,7 @@ async def test_managed_repo_create_worktree_not_local(
 
 def test_managed_git_repo_repr(tmp_path: Path):
     """Test the __repr__ method of ManagedGitRepo."""
-    remote_url = 'https://github.com/test/repo.git'
+    remote_url = "https://github.com/test/repo.git"
     repo_model = Repo(remote_url)
     repo = ManagedGitRepo(remote_url, tmp_path)
     expected_repr = (
@@ -191,25 +191,25 @@ def test_managed_git_repo_repr(tmp_path: Path):
 def test_managed_git_repo_remote_url_property(tmp_path: Path):
     """Test the remote_url property of ManagedGitRepo."""
     # Use a short-form URL to ensure the underlying Repo model is used correctly
-    short_url = 'gh:/my-org/my-repo'
+    short_url = "gh:/my-org/my-repo"
     repo = ManagedGitRepo(short_url, tmp_path)
     # The property should return the full, canonical URL
-    assert repo.remote_url == 'https://github.com/my-org/my-repo.git'
+    assert repo.remote_url == "https://github.com/my-org/my-repo.git"
 
 
 def test_managed_git_repo_slug_property(tmp_path: Path):
     """Test the slug property of ManagedGitRepo."""
-    remote_url = 'https://github.com/my-org/my-repo.git'
+    remote_url = "https://github.com/my-org/my-repo.git"
     repo = ManagedGitRepo(remote_url, tmp_path)
     # The slug should be a filesystem-safe version of the canonical URL
-    expected_slug = 'https___github_com_my_org_my_repo_git'
+    expected_slug = "https___github_com_my_org_my_repo_git"
     assert repo.slug == expected_slug
 
 
 def test_managed_git_repo_permanent_root_property(tmp_path: Path):
     """Test the permanent_root property of ManagedGitRepo."""
-    remote_url = 'https://github.com/test/repo.git'
-    permanent_root = tmp_path / 'permanent_repos'
+    remote_url = "https://github.com/test/repo.git"
+    permanent_root = tmp_path / "permanent_repos"
     repo = ManagedGitRepo(remote_url, permanent_root)
     assert repo.permanent_root == permanent_root
 
@@ -218,9 +218,9 @@ async def test_fetch_updates_success(
     tmp_path: Path, mock_execute_git: AsyncMock, monkeypatch
 ):
     """Test fetch_updates successfully fetches updates."""
-    repo = ManagedGitRepo('http://a.b/c.git', tmp_path)
+    repo = ManagedGitRepo("http://a.b/c.git", tmp_path)
     # Simulate bare repo exists
-    monkeypatch.setattr(Path, 'exists', lambda self: True)
+    monkeypatch.setattr(Path, "exists", lambda self: True)
 
     result = await repo.fetch_updates()
 
@@ -232,9 +232,9 @@ async def test_fetch_updates_no_repo(
     tmp_path: Path, mock_execute_git: AsyncMock, monkeypatch
 ):
     """Test fetch_updates fails if the bare repository does not exist."""
-    repo = ManagedGitRepo('http://a.b/c.git', tmp_path)
+    repo = ManagedGitRepo("http://a.b/c.git", tmp_path)
     # Simulate bare repo does not exist
-    monkeypatch.setattr(Path, 'exists', lambda self: False)
+    monkeypatch.setattr(Path, "exists", lambda self: False)
 
     result = await repo.fetch_updates()
 
@@ -246,10 +246,10 @@ async def test_fetch_updates_failure(
     tmp_path: Path, mock_execute_git: AsyncMock, monkeypatch
 ):
     """Test fetch_updates when the git command fails."""
-    repo = ManagedGitRepo('http://a.b/c.git', tmp_path)
+    repo = ManagedGitRepo("http://a.b/c.git", tmp_path)
     # Simulate bare repo exists
-    monkeypatch.setattr(Path, 'exists', lambda self: True)
-    mock_execute_git.side_effect = RuntimeError('Git fetch failed')
+    monkeypatch.setattr(Path, "exists", lambda self: True)
+    mock_execute_git.side_effect = RuntimeError("Git fetch failed")
 
     result = await repo.fetch_updates()
 
@@ -260,19 +260,19 @@ async def test_managed_repo_clone_bare_already_processed(
     tmp_path: Path, mock_execute_git: AsyncMock, monkeypatch
 ):
     """Test clone_bare when the repository has been processed in this run."""
-    repo = ManagedGitRepo('http://a.b/c.git', tmp_path)
+    repo = ManagedGitRepo("http://a.b/c.git", tmp_path)
     # Simulate repo does not exist for the first call
-    monkeypatch.setattr(Path, 'exists', lambda self: False)
+    monkeypatch.setattr(Path, "exists", lambda self: False)
 
     # First call, should perform a clone
     result1 = await repo.clone_bare()
 
     assert result1 is True
     mock_execute_git.assert_awaited_once_with(
-        'clone',
-        '--bare',
-        '--progress',
-        'http://a.b/c.git',
+        "clone",
+        "--bare",
+        "--progress",
+        "http://a.b/c.git",
         str(repo.bare_repo_path),
         cwd=tmp_path,
         gitconfig=None,

--- a/tests/utils/test_merge.py
+++ b/tests/utils/test_merge.py
@@ -5,72 +5,72 @@ from docbuild.utils.merge import _dedup_doctypes, merge_doctypes
 
 
 def dt(s: str) -> Doctype:
-    """Helper function to create a Doctype instance from a string."""
+    """Create a Doctype instance from a string."""
     # The fix: call the classmethod from_str directly, or use a keyword argument.
     return Doctype.from_str(s)
 
 
 @pytest.mark.parametrize(
-    'inputs,expected',
+    "inputs,expected",
     [
         # Simple merge with wildcard
-        (['sles/1,2/en-us', 'sles/*/en-us'], ['sles/*/en-us']),
-        (['sles/1,2/*', 'sles/1/en-us'], ['sles/1,2/*']),
+        (["sles/1,2/en-us", "sles/*/en-us"], ["sles/*/en-us"]),
+        (["sles/1,2/*", "sles/1/en-us"], ["sles/1,2/*"]),
         # Non-overlapping products
-        (['sles/1,2/en-us', 'smart/1,2/en-us'], ['sles/1,2/en-us', 'smart/1,2/en-us']),
+        (["sles/1,2/en-us", "smart/1,2/en-us"], ["sles/1,2/en-us", "smart/1,2/en-us"]),
         # Wildcard in langs
-        (['sles/1/en-us', 'sles/2/*'], ['sles/1/en-us', 'sles/2/*']),
-        (['sles/1/en-us,de-de', 'sles/2/*'], ['sles/1/en-us,de-de', 'sles/2/*']),
+        (["sles/1/en-us", "sles/2/*"], ["sles/1/en-us", "sles/2/*"]),
+        (["sles/1/en-us,de-de", "sles/2/*"], ["sles/1/en-us,de-de", "sles/2/*"]),
         # Merging docsets and langs
-        (['sles/1/en-us', 'sles/2/en-us'], ['sles/1,2/en-us']),
-        (['sles/1/en-us', 'sles/1/de-de'], ['sles/1/de-de,en-us']),
-        (['sles/1/en-us', 'sles/1/en-us,de-de'], ['sles/1/de-de,en-us']),
+        (["sles/1/en-us", "sles/2/en-us"], ["sles/1,2/en-us"]),
+        (["sles/1/en-us", "sles/1/de-de"], ["sles/1/de-de,en-us"]),
+        (["sles/1/en-us", "sles/1/en-us,de-de"], ["sles/1/de-de,en-us"]),
         # Wildcard absorbs specific
-        (['sles/1/en-us', 'sles/1/*'], ['sles/1/*']),
-        (['sles/1/*', 'sles/1/en-us'], ['sles/1/*']),
+        (["sles/1/en-us", "sles/1/*"], ["sles/1/*"]),
+        (["sles/1/*", "sles/1/en-us"], ["sles/1/*"]),
         # No merge for different lifecycle
-        (['sles/1/en-us', 'sles/1@beta/en-us'], ['sles/1/en-us', 'sles/1@beta/en-us']),
+        (["sles/1/en-us", "sles/1@beta/en-us"], ["sles/1/en-us", "sles/1@beta/en-us"]),
         # No merge for different product
-        (['sles/1/en-us', 'smart/1/en-us'], ['sles/1/en-us', 'smart/1/en-us']),
+        (["sles/1/en-us", "smart/1/en-us"], ["sles/1/en-us", "smart/1/en-us"]),
         # Idempotent
-        (['sles/1/en-us'], ['sles/1/en-us']),
+        (["sles/1/en-us"], ["sles/1/en-us"]),
         # Two identical doctypes
-        (['sles/1/en-us', 'sles/1/en-us'], ['sles/1/en-us']),
+        (["sles/1/en-us", "sles/1/en-us"], ["sles/1/en-us"]),
         # Empty inputs
         ([], []),
         ## --- Some more realistic scenarios ---
         # 1
-        (['sles/15-SP6/en-us', 'sles/*/en-us'], ['sles/*/en-us']),
+        (["sles/15-SP6/en-us", "sles/*/en-us"], ["sles/*/en-us"]),
         # 2
         (
-            ['sles/15-SP5,15-SP4/*', 'sles/15-SP4/en-us'],
-            ['sles/15-SP4,15-SP5/*'],
+            ["sles/15-SP5,15-SP4/*", "sles/15-SP4/en-us"],
+            ["sles/15-SP4,15-SP5/*"],
         ),
         # 3
         (
             [
-                'sles/15-SP6,15-SP5/en-us,de-de',
-                'sles/*/en-us',
-                'smart/network,container/en-us',
+                "sles/15-SP6,15-SP5/en-us,de-de",
+                "sles/*/en-us",
+                "smart/network,container/en-us",
             ],
             [
-                'sles/*/en-us',
-                'sles/15-SP6,15-SP5/de-de',
-                'smart/container,network/en-us',
+                "sles/*/en-us",
+                "sles/15-SP6,15-SP5/de-de",
+                "smart/container,network/en-us",
             ],
         ),
         # 4
         (
             [
-                'sles/15-SP6,15-SP5/en-us,de-de',
-                'sles/15-SP4/zh-cn',
+                "sles/15-SP6,15-SP5/en-us,de-de",
+                "sles/15-SP4/zh-cn",
             ],
-            ['sles/15-SP5,15-SP6/de-de,en-us', 'sles/15-SP4/zh-cn'],
+            ["sles/15-SP5,15-SP6/de-de,en-us", "sles/15-SP4/zh-cn"],
         ),
         # 5
         (
-            ['sles/*/en-us', 'sles/*/de-de', 'sles/16-SP0/zh-cn'],
-            ['sles/*/de-de,en-us', 'sles/16-SP0/zh-cn'],
+            ["sles/*/en-us", "sles/*/de-de", "sles/16-SP0/zh-cn"],
+            ["sles/*/de-de,en-us", "sles/16-SP0/zh-cn"],
         ),
     ],
 )
@@ -86,38 +86,38 @@ def test_dedup_doctypes_empty():
 
 
 def test_dedup_doctypes_duplicates():
-    d = dt('sles/1/en-us')
+    d = dt("sles/1/en-us")
     result = _dedup_doctypes([d, d, d])
     assert result == [d]
     assert result != [d, d, d]
 
 
 def test_dedup_doctypes_single():
-    d = dt('sles/1/en-us')
+    d = dt("sles/1/en-us")
     result = _dedup_doctypes([d])
     assert result == [d]
 
 
 def test_dedup_doctypes_distinct():
-    dt1 = dt('sles/1/en-us')
-    dt2 = dt('sles/2/en-us')
+    dt1 = dt("sles/1/en-us")
+    dt2 = dt("sles/2/en-us")
     result = _dedup_doctypes([dt1, dt2])
     assert set(result) == {dt1, dt2}
 
 
 def test_dedup_doctypes_order_preserved():
     """Test that _dedup_doctypes preserves the order of first occurrence."""
-    dt1 = dt('sles/1/en-us')
-    dt2 = dt('sles/2/en-us')
-    dt3 = dt('sles/1/en-us')  # duplicate of dt1
+    dt1 = dt("sles/1/en-us")
+    dt2 = dt("sles/2/en-us")
+    dt3 = dt("sles/1/en-us")  # duplicate of dt1
     result = _dedup_doctypes([dt1, dt2, dt3])
     assert result == [dt1, dt2]
 
 
 def test_dedup_doctypes_multiple_distinct():
     """Test _dedup_doctypes with three distinct Doctype objects."""
-    dt1 = dt('sles/1/en-us')
-    dt2 = dt('sles/2/en-us')
-    dt3 = dt('sles/3/en-us')
+    dt1 = dt("sles/1/en-us")
+    dt2 = dt("sles/2/en-us")
+    dt3 = dt("sles/3/en-us")
     result = _dedup_doctypes([dt1, dt2, dt3])
     assert set(result) == {dt1, dt2, dt3}

--- a/tests/utils/test_paths.py
+++ b/tests/utils/test_paths.py
@@ -5,7 +5,7 @@ from docbuild.utils.paths import calc_max_len
 
 def test_calc_max_len():
     """Test the calc_max_len function."""
-    files = (Path('/path/to/file1.xml'), Path('/another/path/to/file2.xml'))
+    files = (Path("/path/to/file1.xml"), Path("/another/path/to/file2.xml"))
 
     # Test with default last_parts
     max_len_default = calc_max_len(files)
@@ -22,18 +22,18 @@ def test_calc_max_len():
 
 def test_calc_max_len_even_length():
     """Test that the maximum length returned is even."""
-    files = (Path('/path/to/file1.xml'), Path('/another/path/to/file2.xml'))
+    files = (Path("/path/to/file1.xml"), Path("/another/path/to/file2.xml"))
 
     max_len = calc_max_len(files)
-    assert max_len % 2 == 0, f'Expected even length, got {max_len}'
+    assert max_len % 2 == 0, f"Expected even length, got {max_len}"
 
 
 def test_calc_max_len_short_path():
     """Test calc_max_len with a path that has fewer parts than last_parts."""
-    files = (Path('/file.xml'), Path('/anotherfile.xml'))
+    files = (Path("/file.xml"), Path("/anotherfile.xml"))
 
     max_len = calc_max_len(files, last_parts=-3)
-    assert max_len > 0, 'Expected a positive maximum length.'
-    assert max_len == len('/anotherfile.xml'), (
-        'Expected the full path length for short paths.'
+    assert max_len > 0, "Expected a positive maximum length."
+    assert max_len == len("/anotherfile.xml"), (
+        "Expected the full path length for short paths."
     )

--- a/tests/utils/test_pidlock.py
+++ b/tests/utils/test_pidlock.py
@@ -1,18 +1,17 @@
 """Tests for the PidFileLock utility."""
 
+import builtins
 import errno
-import logging
 import multiprocessing as mp
 from multiprocessing import Event
-import os
 from pathlib import Path
 import platform
 import time
+from unittest.mock import Mock, patch
 
 import pytest
-from unittest.mock import patch, Mock
+
 import docbuild.utils.pidlock as pidlock_mod
-import builtins
 from docbuild.utils.pidlock import LockAcquisitionError, PidFileLock
 
 # Define a shared marker to skip the test if the OS is macOS (Darwin)
@@ -20,6 +19,7 @@ skip_macos = pytest.mark.skipif(
     platform.system() == "Darwin",
     reason="Skipped on macOS due to known multiprocessing/resource cleanup issues.",
 )
+
 
 @pytest.fixture
 def lock_setup(tmp_path):
@@ -32,8 +32,14 @@ def lock_setup(tmp_path):
 
 # --- Helper function for multiprocessing tests (Must be top-level/global) ---
 
-def _mp_lock_holder(resource_path: Path, lock_dir: Path, lock_path: Path, done_event: Event): # type: ignore
-    """Acquire and hold a lock in a separate process, waiting for an event to release."""
+
+def _mp_lock_holder(
+    resource_path: Path, lock_dir: Path, lock_path: Path, done_event: Event
+):  # type: ignore
+    """Acquire and hold a lock in a separate process.
+
+    Waiting for an event to release.
+    """
     lock = PidFileLock(resource_path, lock_dir)
     try:
         with lock:
@@ -47,6 +53,7 @@ def _mp_lock_holder(resource_path: Path, lock_dir: Path, lock_path: Path, done_e
 # -----------------------------------------------------------------------------
 # Core PidFileLock Tests
 # -----------------------------------------------------------------------------
+
 
 def test_acquire_and_release_creates_lock_file(lock_setup):
     """Test that the lock file is created on entry and removed on exit."""
@@ -76,7 +83,6 @@ def test_context_manager(lock_setup):
 @skip_macos
 def test_lock_prevents_concurrent_access_in_separate_process(lock_setup):
     """Test that two separate processes cannot acquire the same lock simultaneously."""
-
     resource_path, lock_dir = lock_setup
     lock_dir.mkdir()
     lock_path = PidFileLock(resource_path, lock_dir).lock_path
@@ -86,8 +92,7 @@ def test_lock_prevents_concurrent_access_in_separate_process(lock_setup):
 
     # Start a background process to hold the lock
     lock_holder = mp.Process(
-        target=_mp_lock_holder,
-        args=(resource_path, lock_dir, lock_path, done_event)
+        target=_mp_lock_holder, args=(resource_path, lock_dir, lock_path, done_event)
     )
     lock_holder.start()
 
@@ -95,7 +100,7 @@ def test_lock_prevents_concurrent_access_in_separate_process(lock_setup):
     timeout_start = time.time()
     while not lock_path.exists():
         if time.time() - timeout_start > 5:
-             raise TimeoutError("Child process failed to acquire lock in time.")
+            raise TimeoutError("Child process failed to acquire lock in time.")
         time.sleep(0.01)
 
     # Main thread tries to acquire the same lock (EXPECT FAILURE)
@@ -106,7 +111,7 @@ def test_lock_prevents_concurrent_access_in_separate_process(lock_setup):
 
     # Cleanup: Signal the child process to exit cleanly and wait for it
     done_event.set()
-    lock_holder.join(timeout=10) # Wait for clean exit (no need for terminate)
+    lock_holder.join(timeout=10)  # Wait for clean exit (no need for terminate)
 
     # Final check: Ensure the child exited successfully
     if lock_holder.is_alive():
@@ -119,9 +124,11 @@ def test_lock_prevents_concurrent_access_in_separate_process(lock_setup):
 
 
 def test_lock_is_reentrant_per_process(lock_setup):
-    """
-    Test that the per-path singleton behavior works and prevents double acquisition
-    using the new internal RuntimeError check.
+    """Test that the singleton pattern prevents re-entrant locking.
+
+    This test simulates a race condition where fcntl.flock raises EAGAIN. It
+    verifies that a LockAcquisitionError is raised and that the underlying file
+    handle is properly closed, ensuring resource c
     """
     resource_path, lock_dir = lock_setup
     lock_dir.mkdir()
@@ -129,11 +136,15 @@ def test_lock_is_reentrant_per_process(lock_setup):
     lock1 = PidFileLock(resource_path, lock_dir)
     lock2 = PidFileLock(resource_path, lock_dir)
 
-    assert lock1 is lock2 # Same instance
+    assert lock1 is lock2  # Same instance
 
     with lock1:
-        # Second attempt to enter the context should raise RuntimeError (internal API misuse)
-        with pytest.raises(RuntimeError, match="Lock already acquired by this PidFileLock instance."):
+        # Second attempt to enter the context should raise RuntimeError
+        # (internal API misuse)
+        with pytest.raises(
+            RuntimeError,
+            match="Lock already acquired by this PidFileLock instance."
+        ):
             with lock2:
                 pass
 
@@ -181,7 +192,8 @@ def test_acquire_critical_oserror(monkeypatch, tmp_path):
     def mocked_builtin_open(path, mode):
         # We now rely on monkeypatching os.open directly in pidlock.py,
         # but for this test, we mock builtins.open if os.open is not used directly.
-        # Since pidlock.py now uses open(self._lock_path, 'w+'), mocking builtins.open is correct
+        # Since pidlock.py now uses open(self._lock_path, 'w+'),
+        # mocking builtins.open is correct
         raise OSError(errno.EACCES, "Access denied")
 
     monkeypatch.setattr("builtins.open", mocked_builtin_open)
@@ -197,7 +209,7 @@ def test_acquire_critical_oserror(monkeypatch, tmp_path):
 
 
 def test_pidfilelock_singleton_per_lock_path(tmp_path):
-    """Constructing PidFileLock twice for the same resource should return the same instance."""
+    """Test that creating a PidFileLock for the same resource returns a singleton."""
     resource = tmp_path / "resource.txt"
     lock_dir = tmp_path / "locks"
 
@@ -210,10 +222,11 @@ def test_pidfilelock_singleton_per_lock_path(tmp_path):
 
 
 def test_flock_eagain_raises_lockacquisitionerror(tmp_path):
-    """If fcntl.flock raises EAGAIN/EWOULDBLOCK, a LockAcquisitionError is raised
-    and the module's cleanup path (closing the opened handle) is executed.
-    Use a real file handle (no patch of open) so the actual close() source line
-    in pidlock.py is executed and counted by coverage.
+    """Test that a flock EAGAIN error raises LockAcquisitionError and cleans up.
+
+    This test simulates a race condition where fcntl.flock raises EAGAIN. It
+    verifies that a LockAcquisitionError is raised and that the underlying file
+    handle is properly closed, ensuring resource cleanup.
     """
     resource = tmp_path / "resource.txt"
     lock_dir = tmp_path / "locks"
@@ -245,7 +258,7 @@ def test_open_eacces_raises_runtimeerror(tmp_path):
 
 
 def test_open_eacces_raises_runtimeerror_via_builtins(tmp_path):
-    """Ensure the EACCES/EPERM open failure branch raises RuntimeError (covers the raise RuntimeError line)."""
+    """Test that a permission error during open raises a RuntimeError."""
     resource = tmp_path / "resource.txt"
     lock_dir = tmp_path / "locks"
     lock_dir.mkdir()
@@ -255,7 +268,8 @@ def test_open_eacces_raises_runtimeerror_via_builtins(tmp_path):
     def fake_open(*args, **kwargs):
         raise OSError(errno.EACCES, "Permission denied (simulated)")
 
-    # Patch the actual builtins.open used by pidlock.open(...) to ensure the except branch is hit
+    # Patch the actual builtins.open used by pidlock.open(...)
+    # to ensure the except branch is hit
     with patch.object(builtins, "open", fake_open):
         with pytest.raises(RuntimeError, match="Cannot acquire lock"):
             with lock:
@@ -263,7 +277,7 @@ def test_open_eacces_raises_runtimeerror_via_builtins(tmp_path):
 
 
 def test_open_other_oserror_reraises_original_exception(tmp_path):
-    """If open() raises an OSError not handled by special branches, it should be re-raised."""
+    """Test that unhandled OSErrors from open() are re-raised."""
     resource = tmp_path / "resource.txt"
     lock_dir = tmp_path / "locks"
 
@@ -280,7 +294,7 @@ def test_open_other_oserror_reraises_original_exception(tmp_path):
 
 
 def test_enter_handles_flock_eagain_closes_handle(tmp_path):
-    """When flock raises EAGAIN after open succeeded, the opened handle is closed and LockAcquisitionError is raised."""
+    """Test that flock EAGAIN after open still closes the file handle."""
     resource = tmp_path / "resource.txt"
     lock_dir = tmp_path / "locks"
     # Create fake handle and ensure it has a close() we can assert
@@ -305,7 +319,7 @@ def test_enter_handles_flock_eagain_closes_handle(tmp_path):
 
 
 def test_enter_open_eacces_raises_runtimeerror(tmp_path):
-    """If module-level open raises EACCES, __enter__ raises a RuntimeError wrapping that OSError."""
+    """Test that a permission error on open raises a RuntimeError."""
     resource = tmp_path / "resource.txt"
     lock_dir = tmp_path / "locks"
 
@@ -319,7 +333,7 @@ def test_enter_open_eacces_raises_runtimeerror(tmp_path):
 
 
 def test_exit_flock_unlock_oserror_is_handled(tmp_path):
-    """If releasing the fcntl lock (second flock call) raises OSError, __exit__ should catch and log but not raise."""
+    """Test that an OSError during fcntl unlock is handled gracefully."""
     resource = tmp_path / "resource.txt"
     lock_dir = tmp_path / "locks"
     lock_dir.mkdir()
@@ -341,7 +355,7 @@ def test_exit_flock_unlock_oserror_is_handled(tmp_path):
 
 
 def test_exit_handle_close_raises_is_handled(tmp_path):
-    """If handle.close() raises OSError, __exit__ should catch and log and continue cleanup."""
+    """Test that an OSError during file handle close is handled."""
     resource = tmp_path / "resource.txt"
     lock_dir = tmp_path / "locks"
     lock_dir.mkdir()
@@ -350,14 +364,19 @@ def test_exit_handle_close_raises_is_handled(tmp_path):
     class BadHandle:
         def fileno(self):
             return 1
+
         def seek(self, *_):
             return None
+
         def truncate(self, *_):
             return None
+
         def write(self, *_):
             return None
+
         def flush(self):
             return None
+
         def close(self):
             raise OSError(errno.EIO, "close failed")
 
@@ -372,7 +391,7 @@ def test_exit_handle_close_raises_is_handled(tmp_path):
 
 
 def test_exit_unlink_raises_oserror_is_handled(tmp_path):
-    """If unlink() raises OSError during __exit__, it should be caught and logged without raising."""
+    """Test that an error during lock file removal is handled."""
     resource = tmp_path / "resource.txt"
     lock_dir = tmp_path / "locks"
     lock_dir.mkdir()
@@ -381,12 +400,14 @@ def test_exit_unlink_raises_oserror_is_handled(tmp_path):
     with patch.object(pidlock_mod.fcntl, "flock", lambda *a, **k: None):
         lock = PidFileLock(resource, lock_dir=lock_dir)
 
-        # Patch the Path.unlink implementation used by pidlock so unlink() raises OSError
+        # Patch the Path.unlink implementation used by pidlock so
+        # unlink() raises OSError
         def bad_unlink(self, missing_ok=True):
             raise OSError(errno.EIO, "unlink failed")
 
         with patch.object(pidlock_mod.Path, "unlink", bad_unlink):
-            # enter the context; when __exit__ calls unlink(), it will raise and be handled
+            # enter the context; when __exit__ calls unlink(),
+            # it will raise and be handled
             with lock:
                 pass
 
@@ -396,7 +417,7 @@ def test_exit_unlink_raises_oserror_is_handled(tmp_path):
 
 
 def test_enter_open_eacces_on_fresh_instance(tmp_path):
-    """Force the EACCES/EPERM branch on a fresh PidFileLock instance to cover the RuntimeError path."""
+    """Test that a permission error during file open raises RuntimeError."""
     resource = tmp_path / "resource_eacces.txt"
     lock_dir = tmp_path / "locks_eacces"
 
@@ -411,25 +432,21 @@ def test_enter_open_eacces_on_fresh_instance(tmp_path):
 
 
 def test_enter_flock_eagain_no_handle(tmp_path):
-    """
-    Simulate EAGAIN/EWOULDBLOCK being raised when 'handle' is None to hit the
-    'if handle: handle.close()' branch where 'handle' is None.
-    """
-
-    resource = tmp_path / 'resource.txt'
-    lock_dir = tmp_path / 'locks'
+    """Test that an EAGAIN error during file open is handled correctly."""
+    resource = tmp_path / "resource.txt"
+    lock_dir = tmp_path / "locks"
 
     # Mock open to return a handle
-    real_handle = open(tmp_path / 'lockfile.tmp', 'w+')
+    # real_handle = open(tmp_path / "lockfile.tmp", "w+")
 
     # Using two mocks: one for open to succeed, one for flock to fail.
     # Patch 'open' in a way that allows controlling the assignment of 'handle'.
 
     # Simulate open failing with EAGAIN directly, which also forces 'handle' to be None.
     def fake_open_with_eagain(*args, **kwargs):
-        raise OSError(errno.EAGAIN, 'Simulated open error matching flock failure')
+        raise OSError(errno.EAGAIN, "Simulated open error matching flock failure")
 
-    with patch.object(pidlock_mod, 'open', fake_open_with_eagain):
-        with pytest.raises(LockAcquisitionError, match='Resource is locked'):
+    with patch.object(pidlock_mod, "open", fake_open_with_eagain):
+        with pytest.raises(LockAcquisitionError, match="Resource is locked"):
             with PidFileLock(resource, lock_dir=lock_dir):
                 pass

--- a/tests/utils/test_shell.py
+++ b/tests/utils/test_shell.py
@@ -4,13 +4,13 @@ from pathlib import Path
 
 import pytest
 
-from docbuild.utils.shell import execute_git_command, CompletedProcess
+from docbuild.utils.shell import execute_git_command
 
 
 async def test_execute_git_command_with_gitconfig(tmp_path):
     """Verify that execute_git_command uses the config file.
 
-      This is provided in the`gitconfig` parameter to replace the user's configuration.
+    This is provided in the`gitconfig` parameter to replace the user's configuration.
     """
     # The tmp_path fixture provides a temporary directory as a Path object
     repo_path = tmp_path
@@ -53,11 +53,12 @@ async def test_execute_git_command_without_gitconfig(tmp_path):
 async def test_execute_git_command_with_nonexistent_cwd():
     with pytest.raises(FileNotFoundError):
         await execute_git_command(
-            'config', '--get', 'docbuild.name', cwd=Path("does-not-exist")
+            "config", "--get", "docbuild.name", cwd=Path("does-not-exist")
         )
+
 
 async def test_execute_git_command_with_failed_command():
     with pytest.raises(RuntimeError):
         await execute_git_command(
-            'foo',  # wrong git command
+            "foo",  # wrong git command
         )


### PR DESCRIPTION
Use `ruff format .`

Additionally:
* Remove unused imports with `ruff check --fix .`
* Fix docstrings manually, use imperative style
* Use double quotes in strings
* Remove unused variables

## TODOs

* The function `docbuild.cli.cmd_validate.process:process_file` is marked as "too complex (12 > 10). This will be covered in a different PR as it affects the logic, not the format.