### PR TITLE
Use Pydantic for robust metadata processing

### DIFF
--- a/changelog.d/140.refactor.rst
+++ b/changelog.d/140.refactor.rst
@@ -1,0 +1,1 @@
+Refactor JSON structure for robust metadata handling in ``docserv.cli.cmd_metadata.metaprocess:store_productdocset_json``. Introduce Pydantic :class:`~docbuild.models.manifest.Manifest` model to encapsulate document metadata, enhancing validation and serialization.

--- a/devel/activate-aliases.sh
+++ b/devel/activate-aliases.sh
@@ -4,6 +4,9 @@
 # For testing:
 alias upytest="uv run --frozen pytest"
 
+# General Python command
+alias upython="uv run --frozen python"
+
 # For the interactive Python shell with the project's environment:
 alias uipython="uv run --frozen ipython --ipython-dir=.ipython"
 

--- a/src/docbuild/models/manifest.py
+++ b/src/docbuild/models/manifest.py
@@ -1,0 +1,197 @@
+"""Pydantic models for the metadata manifest structure."""
+
+from datetime import date
+from typing import Self
+
+from pydantic import (
+    BaseModel,
+    Field,
+    SerializationInfo,
+    field_serializer,
+    field_validator,
+)
+
+from ..models.language import LanguageCode
+from ..models.lifecycle import LifecycleFlag
+
+
+class Description(BaseModel):
+    """Represents a description for a product/docset."""
+
+    lang: LanguageCode
+    default: bool
+    description: str
+
+
+class CategoryTranslation(BaseModel):
+    """Represents a translation for a category title."""
+
+    lang: LanguageCode
+    default: bool
+    title: str
+
+
+class Category(BaseModel):
+    """Represents a category for a product/docset."""
+
+    id: str = Field(alias="categoryId")
+    translations: list[CategoryTranslation] = Field(default_factory=list)
+
+
+class Archive(BaseModel):
+    """Represents an archive (e.g., a ZIP file) for a product/docset."""
+
+    lang: LanguageCode
+    default: bool
+    zip: str
+
+
+class DocumentFormat(BaseModel):
+    """Represents the available formats for a document."""
+
+    html: str
+    pdf: str | None = Field(default=None, exclude_if=lambda v: v is None or v == "")
+    single_html: str | None = Field(
+        default=None, alias="single-html", exclude_if=lambda v: v is None or v == ""
+    )
+
+
+class SingleDocument(BaseModel):
+    """Represent a single document."""
+
+    lang: str | None = None
+    title: str
+    subtitle: str = Field(default="")
+    description: str
+    dcfile: str
+    rootid: str = Field(default="")
+    format: DocumentFormat
+    datemodified: date | None = Field(default=None, serialization_alias="dateModified")
+
+    @field_serializer("datemodified")
+    def serialize_date(self: Self, value: date | None, info: SerializationInfo) -> str:
+        """Serialize date to 'YYYY-MM-DD' or an empty string if None."""
+        if value is None:
+            return ""
+        return value.isoformat()
+
+
+class Product(BaseModel):
+    """Represents a single SUSE product."""
+
+    name: str
+    versions: list[str] = Field(default_factory=list)
+
+
+class Document(BaseModel):
+    """Represents a single document within the manifest."""
+
+    docs: list[SingleDocument] = Field(default_factory=list)
+    tasks: list[str] = Field(default_factory=list)
+    products: list[Product] = Field(default_factory=list)
+    doctypes: list[str] = Field(default_factory=list, alias="docTypes")
+    isgated: bool = Field(default=False, alias="isGated", serialization_alias="isGated")
+    rank: int | None = Field(default=None)
+
+    @field_validator("rank", mode="before")
+    @classmethod
+    def coerce_rank(cls: type[Self], value: str | int | None) -> int | None:
+        """Coerce rank from string to int, handling empty strings."""
+        if isinstance(value, str):
+            if not value.strip():
+                return None
+            return int(value)
+        return value
+
+    @field_serializer("rank")
+    def serialize_rank(
+        self: Self, value: int | str | None, info: SerializationInfo
+    ) -> str:
+        """Serialize rank to an empty string if None."""
+        if value is None:
+            return ""
+        return str(value)
+
+
+class Manifest(BaseModel):
+    """Represents the aggregated metadata manifest for a product/docset."""
+
+    productname: str
+    acronym: str
+    version: str
+    lifecycle: str | LifecycleFlag = Field(default=LifecycleFlag.unknown)
+    hide_productname: bool = Field(default=False, alias="hide-productname")
+    descriptions: list[Description] = Field(default_factory=list)
+    categories: list[Category] = Field(default_factory=list)
+    documents: list[Document] = Field(default_factory=list)
+    archives: list[Archive] = Field(default_factory=list)
+
+
+if __name__ == "__main__":  # pragma: nocover
+    from rich import print  # noqa: A004
+
+    # 1. Create a Python dictionary with example data
+    example_data = {
+        "productname": "SUSE Linux Enterprise Server",
+        "acronym": "sles",
+        "version": "15-SP6",
+        "lifecycle": "supported",
+        "hide_productname": False,
+        "descriptions": [
+            {
+                "lang": "en-us",
+                "default": True,
+                "description": "The English description for SLES 15-SP6.",
+            },
+            {
+                "lang": "de-de",
+                "default": False,
+                "description": "Die deutsche Beschreibung für SLES 15-SP6.",
+            },
+        ],
+        "categories": [
+            {
+                "categoryId": "getting-started",
+                "rank": 1,
+                "translations": [
+                    {"lang": "en-us", "default": True, "title": "Getting Started"}
+                ],
+            }
+        ],
+        "documents": [
+            {
+                "docs": [
+                    {
+                        "lang": "en",
+                        "default": True,
+                        "title": "Key Differences Between SUSE Linux Enterprise 15 and SUSE Linux 16",
+                        "subtitle": "Adopting SUSE Linux 16",
+                        "description": "Key differences between SLE 15 and SUSE Linux 16",
+                        "dcfile": "DC-SLE-comparison",
+                        "rootid": "comparison-sle16-sle15",
+                        "format": {
+                            "html": "/sles/16.0/html/SLE-comparison/",
+                            "pdf": "/sles/16.0/pdf/SLE-comparison_en.pdf",
+                        },
+                        "dateModified": "2025-11-04",
+                    }
+                ],
+                "tasks": ["About"],
+                # "products": [{"name": "SUSE Linux", "versions": ["16.0"]}],
+                "docTypes": [],
+                "isGated": False,
+                "rank": "",
+            }
+        ],
+        "archives": [
+            {"lang": "en-us", "default": True, "zip": "sles-15-SP6-en-us.zip"}
+        ],
+    }
+
+    # 2. Create a Manifest instance from the dictionary
+    manifest_instance = Manifest(**example_data)
+
+    # 3. Print the resulting object using rich for a nice visual representation
+    print(manifest_instance)
+    print("=" * 20)
+    print(manifest_instance.model_dump_json(indent=2))

--- a/tests/models/test_manifest.py
+++ b/tests/models/test_manifest.py
@@ -1,0 +1,121 @@
+from datetime import date
+
+import pytest
+
+from docbuild.models.manifest import (
+    Document,
+    DocumentFormat,
+    SingleDocument,
+)
+
+
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        # 1: Full data
+        (
+            {
+                "html": "/html-path",
+                "pdf": "/pdf-path",
+                "single-html": "/single-html-path",
+            },
+            #
+            {
+                "html": "/html-path",
+                "pdf": "/pdf-path",
+                "single-html": "/single-html-path",
+            },
+        ),
+        # 2: Only required field
+        (
+            {
+                "html": "/html-path",
+            },
+            #
+            {
+                "html": "/html-path",
+            },
+        ),
+        # 3: Optional pdf field is empty string
+        (
+            {
+                "html": "/html-path",
+                "pdf": "",
+            },
+            #
+            {
+                "html": "/html-path",
+            },
+        ),
+        # 4: Optional single-html field is empty string
+        (
+            {
+                "html": "/html-path",
+                "single-html": "",
+            },
+            #
+            {
+                "html": "/html-path",
+            },
+        ),
+        # 5: Optional pdf field is None
+        (
+            {
+                "html": "/html-path",
+                "pdf": None,
+            },
+            #
+            {
+                "html": "/html-path",
+            },
+        ),
+    ],
+)
+def test_manifest_documentformat(data, expected):
+    """Test DocumentFormat model serialization and deserialization."""
+
+    doc = DocumentFormat.model_validate(data)
+    serialized = doc.model_dump(by_alias=True)
+    assert serialized == expected
+
+
+def test_single_document_serialize_date_non_none() -> None:
+    """Serialize datemodified with a non-None date value."""
+
+    serialized = SingleDocument(
+        lang="en",
+        title="Example title",
+        description="Example description",
+        dcfile="DC-EXAMPLE",
+        format=DocumentFormat(html="/example-html"),
+        datemodified=date(2025, 1, 2),
+    ).model_dump(by_alias=True)
+    assert serialized["dateModified"] == "2025-01-02"
+
+
+@pytest.mark.parametrize(
+    "input_rank, expected_internal, expected_serialized",
+    [
+        ("", None, ""),  # empty string → None → ""
+        ("  ", None, ""),  # whitespace-only → None → ""
+        (None, None, ""),  # explicit None → None → ""
+        ("5", 5, "5"),  # string number → int → "5"
+        (5, 5, "5"),  # int stays int → "5"
+    ],
+)
+def test_document_rank_coercion_and_serialization(
+    input_rank: str | int | None,
+    expected_internal: int | None,
+    expected_serialized: str,
+) -> None:
+    """Coerce rank values and serialize using the custom validator/serializer."""
+
+    doc = Document(rank=input_rank)
+
+    # internal Python representation after validation
+    assert doc.rank == expected_internal
+
+    # serialized representation used in manifests
+    serialized = doc.model_dump(by_alias=True)
+    # rank has no alias, so its key is "rank"
+    assert serialized["rank"] == expected_serialized


### PR DESCRIPTION
This commit introduces a small refactoring of the metadata generation process, leveraging Pydantic models to create a more robust, clear, and maintainable data pipeline.

## Problem

The function `docserv.cli.cmd_metadata.metaprocess:store_productdocset_json` creates a dictionary structure. However, this is a low-level task. This is not the task of this function. This function should only _collect_ the JSON data, not actually create them. 


## Key changes

- **Introduced `Manifest` Pydantic Model:** The dictionary-based `structure` in `metaprocess.py` has been replaced with a comprehensive `Manifest` Pydantic model. This provides automatic data validation, type safety, and a single source of truth for the metadata schema. Sub-models for `Description`, `Category`, `Archive`, and `Document` were also created.

- **Centralized XPath Logic:** The responsibility for generating XPath segments for products and docsets has been moved from the `store_productdocset_json` function into the `Doctype` model. This improves separation of concerns, making the processing logic cleaner and the `Doctype` model more self-contained.

- **Enhanced `LifecycleFlag` Enum:** The `LifecycleFlag` enum now intelligently handles string-to-enum conversion by implementing the `_missing_` method. This removes the need for repetitive `@field_validator` decorators in consumer models (`Manifest`, `Doctype`), centralizes the conversion logic, and makes the enum more Pythonic and reusable.

- **Aligned and Fixed Unit Tests:** The test suite for metadata processing has been updated to align with the new, stricter validation rules. Mock data now conforms to the Pydantic models, and assertions have been corrected to check for `log.warning/error` calls instead of `console_err.print`.

