### PR TITLE
Add GH Action for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,22 @@
 
 version: 2
 updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    open-pull-requests-limit: 5
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "tomschr"
+    cooldown:
+      # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
+      default-days: 5
+    labels:
+      - "area:dependencies"
+
   - package-ecosystem: "pip"
-    directory: "/" # Location of your pyproject.toml
+    directory: "/"
     schedule:
       interval: "weekly"
     allow:

--- a/changelog.d/144.infra.rst
+++ b/changelog.d/144.infra.rst
@@ -1,0 +1,1 @@
+Enable GitHub Action for Dependabot config validation.


### PR DESCRIPTION
## Change
Dependabot checks for updates in our Python packages. However, it wasn't configured to check for GitHub Actions too. This PR adds that.

## Benefits
With Dependabot, we are informed when a new version of a GitHub Action is released. The bot creates a new PR and allows us to use the new version or reject it.