### PR TITLE
Fix permission issue in forks for coverage comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,12 +159,19 @@ jobs:
           echo "\`\`\`" >> coverage_comment.txt
           echo "</details>" >> coverage_comment.txt
 
-      - name: Post Coverage Comment
+      - name: Save PR Number
         if: success() && github.event_name == 'pull_request' && matrix.python-version == '3.12'
-        uses: marocchino/sticky-pull-request-comment@v2
+        run: echo ${{ github.event.number }} > pr_number.txt
+
+      - name: Upload Coverage Artifact
+        if: success() && github.event_name == 'pull_request' && matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
         with:
-          path: coverage_comment.txt
-          header: coverage
+          name: coverage-artifact
+          path: |
+            coverage_comment.txt
+            pr_number.txt
+
 
   test-macos:
     name: macos-python-${{ matrix.python-version }}

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,36 @@
+name: Post Coverage Comment
+
+on:
+  workflow_run:
+    # Must match the 'name' key in ci.yml exactly
+    workflows: ["CI/Test"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download Coverage Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR Number
+        id: pr
+        run: echo "number=$(cat pr_number.txt)" >> $GITHUB_OUTPUT
+
+      - name: Post Coverage Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.pr.outputs.number }}
+          path: coverage_comment.txt
+          header: coverage

--- a/changelog.d/148.infra.rst
+++ b/changelog.d/148.infra.rst
@@ -1,0 +1,1 @@
+Fix permission issue in forks for coverage comment.


### PR DESCRIPTION
  ## Problem
When working with forks, the "Post Coverage Comment" fails due to the following error:

    Error: Resource not accessible by integration

## Diagnosis
When a Pull Request is opened from a fork (which is common in open source), GitHub generates a `GITHUB_TOKEN` with read-only permissions for the target repository. This is a security measure to prevent malicious code in a fork from modifying your repository or stealing secrets.

Even though we specified `permissions: pull-requests: write` in our YAML, GitHub ignores this elevation request for forks. Consequently, the action `marocchino/sticky-pull-request-comment` fails because it cannot write to the PR.

## Solution
To fix this securely, the workflow must be split into two separate workflows:

* The test workflow (the current `ci.yml`)
* The comment workflow (new)

The latter runs automatically *after* the test workflow finishes. Because this runs in your repo's context (not the fork's), it has write permissions and can download the artifact to post the comment.