### PR TITLE
chore: disable automatic assignee for Feature and Bug Request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: Report a reproducible bug or unexpected behavior.
-assignees: [tomschr]
 type: bug
 
 body:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,5 @@
 name: Feature Request
 description: Suggest an idea or request a new feature.
-assignees: [tomschr]
 type: feature
 
 body:


### PR DESCRIPTION
This PR removes the hardcoded `assignees` from the Feature Request issue template.

Changes
- Removed assignees: `[tomschr]` from `.github/ISSUE_TEMPLATE/feature-request.yml`.
- Removed assignees: `[tomschr]` from `.github/ISSUE_TEMPLATE/bug-report.yml`.