### PR TITLE
Add newsfragment for Portal Schema refactoring

### DIFF
--- a/changelog.d/187.refactor.rst
+++ b/changelog.d/187.refactor.rst
@@ -1,0 +1,28 @@
+Refactor product schema (:pr:`197`)
+
+These changes reflect broad architectural shifts and naming conventions
+throughout the entire configuration system.
+
+* **Rebranding**: The naming convention has shifted from Docserv to Portal.
+  This is reflected in namespace changes and element renaming
+  (e.g., ``<product>`` is now part of a portal root).
+
+* **Documentation-First Design**: The schema now heavily utilizes ``db:refname``
+  and ``db:refpurpose`` annotations for almost every element and attribute.
+  This allows for automated generation of human-readable documentation directly
+  from the RNC file.
+
+* **Enhanced Modularity**: The schema now explicitly supports splitting large
+  configuration files into smaller, more manageable parts. By utilizing
+  inclusion mechanisms, you can maintain different sections of the portal
+  (like ``<categories>`` or specific products) in separate files, leading to
+  a cleaner and more maintainable structure.
+
+* **Implicit Language Logic**: Master/source language identification
+  has shifted from a boolean attribute (``@default``) to a value-based system.
+  The schema now assumes ``en-us`` is the source locale for products and deliverables.
+
+* **Migration Tooling**: To facilitate the transition, an XSLT migration
+  stylesheet is available. This tool automates the conversion of version
+  6.0 configuration files to the 7.0 format, handling the renaming of
+  elements, restructuring of attributes, and the removal of deprecated metadata.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -133,6 +133,8 @@ extlinks = {
     "gh_tree": (f"{gh_repo_url}/tree/main/%s", "%s"),
     # Linking to the GH issue tracker:
     "gh": (f"{gh_repo_url}/issues/%s", "GH #%s"),
+    # Linking to a GH pull request:
+    "pr": (f"{gh_repo_url}/pull/%s", "PR #%s"),
 }
 
 


### PR DESCRIPTION
* Add missing newsfragment file
* Add new macro `:pr:` in doc config to link to GitHub pull requests
* Related to PR #197, issue #187