### PR TITLE
Activate custom aliases in VSCode automatically

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,4 +15,10 @@
     },
     "python.analysis.diagnosticsSource": "Pyright",
     "python.analysis.typeCheckingMode": "standard",
+    "terminal.integrated.env.linux": {
+        "PROMPT_COMMAND": "if [ -f \"${workspaceFolder}/devel/activate-aliases.sh\" ]; then source \"${workspaceFolder}/devel/activate-aliases.sh\"; unset PROMPT_COMMAND; fi"
+    },
+    "terminal.integrated.env.osx": {
+        "PROMPT_COMMAND": "if [ -f \"${workspaceFolder}/devel/activate-aliases.sh\" ]; then source \"${workspaceFolder}/devel/activate-aliases.sh\"; unset PROMPT_COMMAND; fi"
+    }
 }


### PR DESCRIPTION
## Situation
When opening a new terminal under VSCode, it sources `.venv/bin/activate` and activates the virtual Python environment. However, we need to manually source our own aliases. This is a bit inconvenient as you don't have access to these aliases (and neither your AI bot has that).

## Proposed solution

This fix activates our own custom aliases in `devel/activate-aliases.sh`. It works for Linux and MacOS.

## Alternatives

An alternative way would be to create a `docbuild.code-workspace` file and add the additions under a `settings` key. That may be even the more portable solution. 