### PR TITLE
Add convenience wrapper script for Portal

### DIFF
--- a/changelog.d/256.feature.rst
+++ b/changelog.d/256.feature.rst
@@ -1,0 +1,1 @@
+Add convenience wrapper scripts for Portal validation and migration from old Docserv config.

--- a/src/docbuild/config/xml/data/migrate.sh
+++ b/src/docbuild/config/xml/data/migrate.sh
@@ -17,6 +17,13 @@ XSLT="$SCRIPT_DIR/convert-v6-to-v7.xsl"
 INPUT="docserv-stitch-2026-04-27.xml"
 USE_XINCLUDE=false
 
+
+if ! command -v xsltproc >/dev/null 2>&1; then
+    echo "Error: 'xsltproc' is required but not installed." >&2
+    exit 1
+fi
+
+
 # --- Help Function ---
 usage() {
     # Using shell parameter expansion ${0##*/} instead of basename $0
@@ -80,7 +87,7 @@ if [ "$USE_XINCLUDE" = true ]; then
     # --stringparam use.xincludes 1 passes the parameter to your XSLT logic
     # Note: You may also need to add the physical --xinclude flag here if xsltproc
     # needs to resolve the tags before passing them to the XSLT.
-    XINCLUDE_FLAGS="--stringparam use.xincludes 1"
+    XINCLUDE_FLAGS="--xinclude --stringparam use.xincludes 1"
 fi
 
 # --- Execution ---

--- a/src/docbuild/config/xml/data/migrate.sh
+++ b/src/docbuild/config/xml/data/migrate.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+# --- Default Values ---
+SCHEMAFILE="portal-config.rnc"
+OUTPUT="portal-test.xml"
+OUTDIR="./"
+
+# Get the directory where the script is located using shell built-ins
+# If $0 contains a slash, SCRIPT_DIR is the part before the last slash.
+# Otherwise, we assume the current directory (.).
+case "$0" in
+    */*) SCRIPT_DIR="${0%/*}" ;;
+    *)   SCRIPT_DIR="." ;;
+esac
+
+XSLT="$SCRIPT_DIR/convert-v6-to-v7.xsl"
+INPUT="docserv-stitch-2026-04-27.xml"
+USE_XINCLUDE=false
+
+# --- Help Function ---
+usage() {
+    # Using shell parameter expansion ${0##*/} instead of basename $0
+    SCRIPT_NAME=${0##*/}
+    cat << EOF
+Usage: $SCRIPT_NAME [OPTIONS] [INPUT_FILE]
+
+Options:
+  -s, --schema FILE      Path to schema file (Default: $SCHEMAFILE)
+  -o, --output FILE      Name of the output file (Default: $OUTPUT)
+  -d, --dir DIR          Output directory (Default: $OUTDIR)
+  -x, --xinclude         Enable xinclude processing
+  -h, --help             Show this help message
+
+Arguments:
+  INPUT_FILE             The Docserv stitch file
+
+Example:
+  $SCRIPT_NAME -x --schema custom.rnc docserv-stitch.xml
+EOF
+    exit 0
+}
+
+# --- Manual Argument Parsing ---
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -s|--schema)
+            SCHEMAFILE="$2"
+            shift 2
+            ;;
+        -o|--output)
+            OUTPUT="$2"
+            shift 2
+            ;;
+        -d|--dir)
+            OUTDIR="$2"
+            shift 2
+            ;;
+        -x|--xinclude)
+            USE_XINCLUDE=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        -*)
+            echo "Error: Unknown option $1"
+            usage
+            ;;
+        *)
+            # This is assumed to be the input file
+            INPUT="$1"
+            shift
+            ;;
+    esac
+done
+
+# --- Prepare xsltproc Arguments ---
+XINCLUDE_FLAGS=""
+if [ "$USE_XINCLUDE" = true ]; then
+    # --stringparam use.xincludes 1 passes the parameter to your XSLT logic
+    # Note: You may also need to add the physical --xinclude flag here if xsltproc
+    # needs to resolve the tags before passing them to the XSLT.
+    XINCLUDE_FLAGS="--stringparam use.xincludes 1"
+fi
+
+# --- Execution ---
+# Note: Administrative privileges (sudo) may be required if writing to system-protected directories.
+xsltproc $XINCLUDE_FLAGS \
+         --stringparam schemafile "$SCHEMAFILE" \
+         --stringparam outputfile "$OUTPUT" \
+         --stringparam outputdir "$OUTDIR" \
+         "$XSLT" "$INPUT"

--- a/src/docbuild/config/xml/data/validate.sh
+++ b/src/docbuild/config/xml/data/validate.sh
@@ -95,9 +95,10 @@ fi
 echo "Validating $INPUT against $SCHEMAFILE..."
 
 if [ "$USE_XINCLUDE" = true ]; then
-    # We set both JAVA_OPTS (openSUSE/Fedora) and JAVA_ARGS (Debian/Ubuntu)
-    # to ensure the XInclude parser configuration is picked up regardless of the wrapper.
-    ADDITIONAL_FLAGS="$XINCLUDE_PROP" jing $JING_FLAGS "$SCHEMAFILE" "$INPUT"
+    # We set ADDITIONAL_FLAGS (openSUSE), JAVA_OPTS (Fedora)
+    # and JAVA_ARGS (Debian/Ubuntu) to ensure the XInclude parser
+    # configuration is picked up regardless of the wrapper.
+    ADDITIONAL_FLAGS="$XINCLUDE_PROP" JAVA_OPTS="$XINCLUDE_PROP" JAVA_ARGS="$XINCLUDE_PROP" jing $JING_FLAGS "$SCHEMAFILE" "$INPUT"
 else
     jing $JING_FLAGS "$SCHEMAFILE" "$INPUT"
 fi

--- a/src/docbuild/config/xml/data/validate.sh
+++ b/src/docbuild/config/xml/data/validate.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+
+# Get the directory where the script is located using shell built-ins
+case "$0" in
+    */*) SCRIPT_DIR="${0%/*}" ;;
+    *)   SCRIPT_DIR="." ;;
+esac
+
+# --- Default Values ---
+SCHEMAFILE="$SCRIPT_DIR/portal-config.rnc"
+USE_XINCLUDE=false
+DISABLE_ID_CHECK=false
+INPUT=""
+
+# --- Help Function ---
+usage() {
+    SCRIPT_NAME=${0##*/}
+    cat << EOF
+Usage: $SCRIPT_NAME [OPTIONS] <INPUT_FILE>
+
+Options:
+  -s, --schema FILE      Path to RNC/RNG schema file (Default: $SCHEMAFILE)
+  -x, --xinclude         Enable XInclude processing
+  -i, --id               Disable checking of ID/IDREF/IDREFS
+  -h, --help             Show this help message
+
+Arguments:
+  INPUT_FILE             The main Portal XML file to validate
+
+
+Example:
+  $SCRIPT_NAME -x --id config.d/portal.xml
+EOF
+    exit 0
+}
+
+# --- Manual Argument Parsing ---
+if [ $# -eq 0 ]; then usage; fi
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -s|--schema)
+            SCHEMAFILE="$2"
+            shift 2
+            ;;
+        -x|--xinclude)
+            USE_XINCLUDE=true
+            shift
+            ;;
+        -i|--id)
+            DISABLE_ID_CHECK=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        -*)
+            echo "Error: Unknown option $1"
+            usage
+            ;;
+        *)
+            INPUT="$1"
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$INPUT" ]; then
+    echo "Error: No input XML file specified."
+    usage
+fi
+
+# --- Prepare Jing Arguments ---
+JING_FLAGS=""
+XINCLUDE_PROP="-Dorg.apache.xerces.xni.parser.XMLParserConfiguration=org.apache.xerces.parsers.XIncludeParserConfiguration"
+
+# Detect if the schema is in compact syntax (.rnc)
+case "$SCHEMAFILE" in
+    *.rnc)
+        JING_FLAGS+="-c "
+        ;;
+esac
+
+if [ "$DISABLE_ID_CHECK" = true ]; then
+    JING_FLAGS+="-i "
+fi
+
+# --- Execution ---
+echo "Validating $INPUT against $SCHEMAFILE..."
+
+if [ "$USE_XINCLUDE" = true ]; then
+    # We set both JAVA_OPTS (openSUSE/Fedora) and JAVA_ARGS (Debian/Ubuntu)
+    # to ensure the XInclude parser configuration is picked up regardless of the wrapper.
+    ADDITIONAL_FLAGS="$XINCLUDE_PROP" jing $JING_FLAGS "$SCHEMAFILE" "$INPUT"
+else
+    jing $JING_FLAGS "$SCHEMAFILE" "$INPUT"
+fi
+
+# Check the exit status of jing
+if [ $? -eq 0 ]; then
+    echo "Validation successful."
+else
+    echo "Validation failed."
+    exit 1
+fi

--- a/src/docbuild/config/xml/data/validate.sh
+++ b/src/docbuild/config/xml/data/validate.sh
@@ -12,6 +12,11 @@ USE_XINCLUDE=false
 DISABLE_ID_CHECK=false
 INPUT=""
 
+if ! command -v jing >/dev/null 2>&1; then
+    echo "Error: 'jing' is required but not installed." >&2
+    exit 1
+fi
+
 # --- Help Function ---
 usage() {
     SCRIPT_NAME=${0##*/}
@@ -77,13 +82,14 @@ XINCLUDE_PROP="-Dorg.apache.xerces.xni.parser.XMLParserConfiguration=org.apache.
 # Detect if the schema is in compact syntax (.rnc)
 case "$SCHEMAFILE" in
     *.rnc)
-        JING_FLAGS+="-c "
+        JING_FLAGS="$JING_FLAGS -c"
         ;;
 esac
 
 if [ "$DISABLE_ID_CHECK" = true ]; then
-    JING_FLAGS+="-i "
+    JING_FLAGS="$JING_FLAGS -i"
 fi
+
 
 # --- Execution ---
 echo "Validating $INPUT against $SCHEMAFILE..."


### PR DESCRIPTION
Add two convenience wrapper scripts:

* `migrate.sh`
  Converts an old docserv-stitchfile.xml into the new Portal config.
* `validate.sh`
  Validates the new Portal file (and everything that was included).