### PR TITLE
Allow metadata inside a pre-built deliverable

### DIFF
--- a/src/docbuild/config/xml/data/portal-config.rnc
+++ b/src/docbuild/config/xml/data/portal-config.rnc
@@ -1193,21 +1193,33 @@ div {
       ds.title,
       ds.subtitle?,
       ds.url+,
-      ds.descriptions
-      # ds.metadata  # TODO: We need to check what we need
+      ds.descriptions,
+      ds.metadata?
     }
 }
 
+[
+  db:refname [ "meta" ]
+  db:refpurpose [ "A single, separate metadata" ]
+]
+div {
+ds.meta =
+  ## A single named metadata entry
+  element meta {
+    attribute name { text },
+    text
+  }
+}
 
 [
   db:refname [ "metadata" ]
-  db:refpurpose [ "" ]
+  db:refpurpose [ "A collection of additional metadata" ]
 ]
 div {
 ds.metadata =
-  ##
+  ## A collection of additional metadata
   element metadata {
-    text  # TODO
+    ds.meta+
   }
 }
 


### PR DESCRIPTION
### Design decision
A pre-built deliverable allows holding this structure:

```xml
<metadata>
  <meta name="task">Entry 1</meta>
</metadata>
```

This allows adding whatever metadata we need. Downside is, we can't validate it.

### Questions

* Do we want to allow multiple `<metadata>` maybe with an additional `name` attribute?
  This would allow adding arrays of items which could make processing them a bit easier.
