### PR TITLE
Switch order in GH issue template (bug report)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -57,17 +57,6 @@ body:
       required: true
 
   - type: textarea
-    id: expected_behavior
-    attributes:
-      label: Expected Behavior
-      description: What did you expect to happen?
-      placeholder: |
-        I expected the command to return this output...
-        Or, I expected the application to behave like this...
-    validations:
-      required: false
-
-  - type: textarea
     id: actual_behavior
     attributes:
       label: Actual Behavior
@@ -75,6 +64,17 @@ body:
       placeholder: |
         Instead, I got this output...
         Or, the application crashed with this error...
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: |
+        I expected the command to return this output...
+        Or, I expected the application to behave like this...
     validations:
       required: false
 

--- a/changelog.d/260.infra.rst
+++ b/changelog.d/260.infra.rst
@@ -1,0 +1,1 @@
+Switch order in GH issue template (bug report)


### PR DESCRIPTION
In the bug report template, you have now this order:

1. Project Version
2. Python Version
3. Operating System
4. Steps to Reproduce
5. Actual Behavior
6. Expected Behavior
7. Additional Information

Before, steps 5 and 6 were switched. With the fixed order, I think this is more logical.