### PR TITLE
RNC: Correct `<git>` inside `<dc>`

### DIFF
--- a/changelog.d/267.infra.rst
+++ b/changelog.d/267.infra.rst
@@ -1,0 +1,1 @@
+RNC: Correct ``<git>`` tag inside ``<dc>``

--- a/src/docbuild/config/xml/data/portal-config.rnc
+++ b/src/docbuild/config/xml/data/portal-config.rnc
@@ -1147,10 +1147,6 @@ ds.deliverable_en_us_dc =
     ),
     #
     ds.dc
-    #ds.git?,
-    #ds.subdir?,
-    #ds.format,
-    #ds.partners*
   }
 }
 
@@ -1228,8 +1224,13 @@ ds.dc =
   element dc {
     ds.dc.file.attr,
     #
-    ds.git?,
-    ds.subdir?,
+    (
+      ds.git,
+      (
+        ds.branch? &
+        ds.subdir?
+      )
+    )?,
     ds.format,
     ds.subdeliverable*,
     ds.partners*


### PR DESCRIPTION
* Allow `<git>`, `<branch>`, and `<subdir>` inside `<dc>`
* Enforce order, at least start with `<git>`
* Remove unused comment