### PR TITLE
RNG: Correct content model of `<dc>`

### DIFF
--- a/changelog.d/267.infra.rst
+++ b/changelog.d/267.infra.rst
@@ -1,1 +1,1 @@
-RNC: Correct ``<git>`` tag inside ``<dc>``
+Portal Config: Correct ``<git>`` tag inside ``<dc>``

--- a/changelog.d/269.infra.rst
+++ b/changelog.d/269.infra.rst
@@ -1,0 +1,3 @@
+Portal Config: Correct content model of ``<dc>``.
+The previous content model enforced a ``<git>`` element.
+A "lonely" ``<subdir>`` wasn't possible. This is fixed now.

--- a/src/docbuild/config/xml/data/portal-config.rnc
+++ b/src/docbuild/config/xml/data/portal-config.rnc
@@ -1225,7 +1225,7 @@ ds.dc =
     ds.dc.file.attr,
     #
     (
-      ds.git,
+      ds.git?,
       (
         ds.branch? &
         ds.subdir?


### PR DESCRIPTION
The previous content model enforced a `<git>` element. A "lonely" `<subdir>` wasn't possible.
This is fixed now.