### PR TITLE
GHA: Provide jing custom wrapper for MacOS

### DIFF
--- a/.github/workflows/MacOS/bin/jing
+++ b/.github/workflows/MacOS/bin/jing
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# -----------------------------------------------------------------------------
+# Jing Wrapper Script (macOS/Linux Parity)
+#
+# This script ensures a consistent execution environment across macOS and Linux.
+# It addresses a functional gap in the standard Homebrew (jing-trang) formula, 
+# which excludes the Xerces JARs necessary for XInclude resolution.
+#
+# Configuration:
+#   - Explicitly includes Xerces and XML-APIs in the classpath.
+#   - Supports XInclude resolution via the ADDITIONAL_FLAGS environment variable
+#     (see DEFAULT_FLAGS for the required parser configuration).
+#   - DEBUG or VERBOSE: Set to "1" to print the Java VM path, classpath,
+#     main class, active flags, and arguments to stderr.
+#
+# Features:
+#   - Explicitly includes Xerces and XML-APIs in the classpath if found.
+#   - Supports XInclude resolution via ADDITIONAL_FLAGS (see DEFAULT_FLAGS below).
+# -----------------------------------------------------------------------------
+#
+# Author: Tom Schraitle 2026
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# -----------------------------------------------------------------------------
+# JAR locations
+# -----------------------------------------------------------------------------
+# Path logic:
+# $SCRIPT_DIR              -> .github/workflows/MacOS/bin
+# $SCRIPT_DIR/..           -> .github/workflows/MacOS
+# $SCRIPT_DIR/../..        -> .github/workflows
+# $SCRIPT_DIR/../../..     -> (Repository Root)
+# $SCRIPT_DIR/../../../MacOS/lib -> Target JAR folder
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+# Resolve symlinks (macOS/Linux compatible version)
+while [ -L "$SCRIPT_PATH" ]; do
+  DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ $SCRIPT_PATH != /* ]] && SCRIPT_PATH="$DIR/$SCRIPT_PATH"
+done
+
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+JAR_ROOT="$(realpath $SCRIPT_DIR/../lib)"
+
+JING_JAR="${JING_JAR:-$JAR_ROOT/jing.jar}"
+RELAXNG_DATATYPE_JAR="${RELAXNG_DATATYPE_JAR:-$JAR_ROOT/relaxngDatatype.jar}"
+XERCES_JAR="${XERCES_JAR:-$JAR_ROOT/xercesImpl.jar}" 
+XML_APIS_JAR="${XML_APIS_JAR:-$JAR_ROOT/xml-apis.jar}"
+
+# -----------------------------------------------------------------------------
+# Default JVM flags
+# -----------------------------------------------------------------------------
+
+DEFAULT_FLAGS=(
+# Java property to enable the XInclude resolution. It is not set
+# here to be consistent with the Linux version. If you need it, set the
+# ADDITIONAL_FLAGS environment variable to the following value:
+#  "-Dorg.apache.xerces.xni.parser.XMLParserConfiguration=org.apache.xerces.parsers.XIncludeParserConfiguration"
+)
+
+# -----------------------------------------------------------------------------
+# Jing's main class
+# -----------------------------------------------------------------------------
+
+MAIN_CLASS="com.thaiopensource.relaxng.util.Driver"
+
+# -----------------------------------------------------------------------------
+# Classpath
+# -----------------------------------------------------------------------------
+
+CLASSPATH=(
+  "$JING_JAR"
+  "$RELAXNG_DATATYPE_JAR"
+)
+
+[[ -f "$XERCES_JAR" ]] && CLASSPATH+=("$XERCES_JAR")
+[[ -f "$XML_APIS_JAR" ]] && CLASSPATH+=("$XML_APIS_JAR")
+
+CP=$(IFS=:; printf '%s' "${CLASSPATH[*]}")
+
+# -----------------------------------------------------------------------------
+# Build Java command
+# -----------------------------------------------------------------------------
+
+JAVA_CMD=(java)
+
+# Internal default flags. Use parameter transformation to fix expansion of
+# zero-indexed arrays
+JAVA_CMD+=(${DEFAULT_FLAGS[@]+"${DEFAULT_FLAGS[@]}"})
+
+# User-provided ADDITIONAL_FLAGS
+if [[ -n "${ADDITIONAL_FLAGS:-}" ]]; then
+  # shellcheck disable=SC2206
+  EXTRA_FLAGS_ARRAY=(${ADDITIONAL_FLAGS})
+  JAVA_CMD+=("${EXTRA_FLAGS_ARRAY[@]}")
+fi
+
+
+# -----------------------------------------------------------------------------
+# Debug output
+# -----------------------------------------------------------------------------
+
+if [[ "${DEBUG:-0}" == "1" || "${VERBOSE:-0}" == "1" ]]; then
+  {
+    echo "Java virtual machine used: $(command -v java)"
+    echo "classpath used: $CP"
+    echo "main class used: ${MAIN_CLASS}"
+    echo "flags used: ${JAVA_CMD[*]:1}"
+    echo "arguments used: $*"
+  } >&2
+fi
+
+# -----------------------------------------------------------------------------
+# Execute Jing
+# -----------------------------------------------------------------------------
+
+exec "${JAVA_CMD[@]}" \
+  -cp "$CP" \
+  ${MAIN_CLASS} \
+  "$@"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       JING_VERSION:
         description: "Jing version to use"
         required: false
-        default: "20091111"  # Default value
+        default: ""  # Leave empty to use the general default
   pull_request:
   push:
     branches:
@@ -13,6 +13,8 @@ on:
     paths:
       - 'src/**'
       - 'tests/**'
+      - '.github/workflows/ci.yml'
+      - 'pyproject.toml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,6 +33,8 @@ env:
   PYTHONSTARTMETHOD: spawn
   # The group to use for installing/testing dependencies, see pyproject.toml
   PYPROJECT_GROUP: github-action
+  # The default version of Jing
+  DEFAULT_JING_VERSION: "20241231"
 
 jobs:
   test-ubuntu:
@@ -205,31 +209,46 @@ jobs:
       # Install macOS-specific external tools (such as XML parsers and Java)
       - name: Install external tools (macOS)
         run: |
-          brew install libxml2 libxslt openjdk
+          brew install libxml2 libxslt
 
-          # Define the version and URL for jing.jar, using the input version from workflow_dispatch
-          JING_VERSION="${{ github.event.inputs.JING_VERSION || '20091111' }}"
-          JING_URL="https://repo1.maven.org/maven2/com/thaiopensource/jing/${JING_VERSION}/jing-${JING_VERSION}.jar"
+      - name: Setup Jing
+        run: |
+          set -euo pipefail
 
-          # Download jing.jar file for XML validation
-          curl -sL -f $JING_URL -o jing.jar
+          JING_VERSION="${{ github.event.inputs.JING_VERSION || env.DEFAULT_JING_VERSION }}"
+          JING_URL="https://github.com/relaxng/jing-trang/releases/download/V${JING_VERSION}/jing-${JING_VERSION}.zip"
+          LIB_DIR="${GITHUB_WORKSPACE}/.github/workflows/MacOS/lib"
+          BIN_DIR="${GITHUB_WORKSPACE}/.github/workflows/MacOS/bin"
+          mkdir -p "$LIB_DIR"
 
-          # Ensures the jar file is successfully downloaded, else exit with error
-          if [ ! -f jing.jar ]; then
-              echo "::error file=$JING_URL:: Failed to download jing.jar"
-              exit 1
-          fi
+          echo "${BIN_DIR}" >> "$GITHUB_PATH"
+          hash -r
+          echo "Downloading: $JING_URL"
+          curl -fSL --progress-bar "$JING_URL" -o jing.zip
+          unzip -j jing.zip "jing-*/bin/*.jar" -d "$LIB_DIR"
+          rm jing.zip
+          echo "Installed JARs:"
+          ls -la "$LIB_DIR"
 
-          # Create a bash script to run jing.jar easily from the command line
-          echo '#!/bin/bash' > jing
-          echo 'java -jar jing.jar "$@"' >> jing
-          chmod +x jing
+      - name: Echo PATH env
+        run: echo "PATH=$PATH"
 
-          # Add paths of installed tools to GitHub Actions environment for easy access
-          echo "$(pwd)" >> $GITHUB_PATH
-          echo "/opt/homebrew/opt/openjdk/bin" >> $GITHUB_PATH
-          echo "/opt/homebrew/opt/libxml2/bin" >> $GITHUB_PATH
-          echo "/opt/homebrew/opt/libxslt/bin" >> $GITHUB_PATH
+      - name: Inspect jing script
+        run: |
+          # 1. Show the first line with invisible characters
+          head -n 1 "${GITHUB_WORKSPACE}/.github/workflows/MacOS/bin/jing" | cat -e
+          
+          # 2. Check file type and line endings
+          file "${GITHUB_WORKSPACE}/.github/workflows/MacOS/bin/jing"
+          
+          # 3. Try running it explicitly with bash to bypass the shebang
+          bash "${GITHUB_WORKSPACE}/.github/workflows/MacOS/bin/jing" || true 
+
+      - name: Verify Jing wrapper
+        env:
+           DEBUG: 1
+        run: |
+          jing || true
 
       # Run the tests using pytest inside the created virtual environment
       - name: Run tests

--- a/changelog.d/278.infra.rst
+++ b/changelog.d/278.infra.rst
@@ -1,0 +1,1 @@
+GHA: Provide :command:`jing` custom wrapper for MacOS to resolve XInclude elements


### PR DESCRIPTION
## Changes in this PR
* Provide a custom wrapper script under `.github/workflows/MacOS/bin`
* Wrapper script contains also the Xerces JAR that allows XInclude resolution (important for resolve `xi:include` elements inside Portal config)
* Use `ADDITIONAL_FLAGS` to set the XML parser for XInclude resolution (like the openSUSE version)
* Use `DEBUG` or `VERBOSE` to to print the Java VM path, classpath, main class, active flags, and arguments to stderr.
* Clean up the GitHub Action steps to download a Jing version from GitHub directly. Default version is "20241231"
* Add some debug steps for MacOS

---

## Reason 
It addresses a functional gap in the standard Homebrew (jing-trang) formula, which excludes the Xerces JARs necessary for XInclude resolution.