### PR TITLE
Implement Multi-Version Doc Switcher

### DIFF
--- a/.github/bin/determine-version.sh
+++ b/.github/bin/determine-version.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Parses the GitHub environment to set the DOC_VERSION and
+# TARGET_DIR variables, ensuring release tags get a clean "v"
+# prefix and test branches are safely sanitized.
+
+set -euo pipefail
+
+if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+    echo "DOC_VERSION=latest" >> "$GITHUB_ENV"
+    echo "TARGET_DIR=latest" >> "$GITHUB_ENV"
+
+elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+    RAW_VERSION=${GITHUB_REF#refs/tags/}
+
+    # Ensure the version strictly starts with 'v'
+    # (This safely strips 'v' if it somehow already exists, then prepends it)
+    VERSION="v${RAW_VERSION#v}"
+    echo "DOC_VERSION=${VERSION}" >> "$GITHUB_ENV"
+    echo "TARGET_DIR=${VERSION}" >> "$GITHUB_ENV"
+
+else
+    # Fallback for testing branches (e.g., refs/heads/test-feature)
+    BRANCH_NAME=${GITHUB_REF#refs/heads/}
+    # Sanitize branch name to be URL safe
+    SAFE_BRANCH=$(echo "${BRANCH_NAME}" | tr -cd 'a-zA-Z0-9-')
+
+    echo "DOC_VERSION=${SAFE_BRANCH}" >> "$GITHUB_ENV"
+    echo "TARGET_DIR=${SAFE_BRANCH}" >> "$GITHUB_ENV"
+fi

--- a/.github/bin/generate-versions.py
+++ b/.github/bin/generate-versions.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Generate version switcher JSON.
+
+Scans the assembled deploy directory to dynamically
+build the versions.json file, populating the version-switcher
+dropdown menu for your end users.
+"""
+
+import argparse
+from collections.abc import Iterable
+import json
+import os
+from pathlib import Path
+import re
+
+#
+BASE = (
+    f"https://{os.environ.get('GITHUB_REPOSITORY_OWNER', '')}"
+    f".github.io/"
+    f"{os.environ.get('GITHUB_REPOSITORY', '').split('/')[-1]}"
+)
+
+
+def parsecli(cli: Iterable[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Generate version switcher JSON.")
+    parser.add_argument(
+        "-i",
+        "--input",
+        default=".versions.json",
+        help="Input JSON file in the repository root (default: .versions.json)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="versions.json",
+        help="Output JSON filename inside the deploy directory (default: versions.json)",
+    )
+    parser.add_argument(
+        "-k",
+        "--keep",
+        type=int,
+        default=3,
+        help="Number of semantic version tags to keep in the dropdown (default: 3)",
+    )
+    parser.add_argument(
+        "-d",
+        "--dry-run",
+        action="store_true",
+        help="Print the generated JSON to the console without writing to the file",
+    )
+    parser.add_argument(
+        "--input-dir",
+        default="deploy",
+        type=Path,
+        help="The input direcotry (default '%(default)s')",
+    )
+    args = parser.parse_args(cli)
+    return args
+
+
+def main() -> None:
+    """Generate version switcher JSON."""
+    args = parsecli()
+
+    input_path = Path(args.input)
+    deploy = Path(args.input_dir)
+    output_path = deploy / args.output
+
+    # 1. Read base versions from the input file if it exists
+    versions = []
+    if input_path.exists():
+        try:
+            versions = json.loads(input_path.read_text())
+            print(f"Loaded base versions from {args.input}")
+        except Exception as e:
+            print(f"Warning: Could not parse {args.input}: {e}")
+
+    # Track existing versions to prevent duplicating them
+    existing_versions = {v.get("version") for v in versions if isinstance(v, dict)}
+
+    # 2. Add Development/Stable if they exist and aren't in the input file
+    if "latest" not in existing_versions and (deploy / "latest").exists():
+        versions.append(
+            {
+                "name": "Development",
+                "version": "latest",
+                "url": f"{BASE}/latest/",
+            }
+        )
+
+    if "stable" not in existing_versions and (deploy / "stable").exists():
+        versions.append(
+            {
+                "name": "Stable",
+                "version": "stable",
+                "url": f"{BASE}/stable/",
+            }
+        )
+
+    # 3. Find and sort strictly formatted semver tags (e.g. 1.0.0 or v0.18.0)
+    tags = sorted(
+        [
+            p.name
+            for p in deploy.iterdir()
+            # Strict SemVer match: optional 'v' followed by exactly X.Y.Z
+            if p.is_dir() and re.match(r"^v?\d+\.\d+\.\d+$", p.name)
+        ],
+        key=lambda s: [int(u) for u in re.findall(r"\d+", s)],
+        reverse=True,
+    )
+
+    # 4. Append the top N semantic tags based on the --keep argument
+    for tag in tags[: args.keep]:
+        if tag not in existing_versions:
+            versions.append(
+                {
+                    "name": tag,
+                    "version": tag,
+                    "url": f"{BASE}/{tag}/",
+                }
+            )
+
+    # Ensure output directory exists and write final JSON
+    if args.dry_run:
+        print("--- DRY RUN ---")
+        print(f"Would write the following {len(versions)} entries to {output_path}:")
+        print(json.dumps(versions, indent=2))
+    else:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(versions, indent=2))
+        print(f"Generated {output_path} containing {len(versions)} version entries.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/bin/prepare-deploy.sh
+++ b/.github/bin/prepare-deploy.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Assembles the deploy/ staging area by merging the newly built
+# documentation with the existing historical docs, while also
+# managing the stable symlink and root index.html redirect.
+
+set -euo pipefail
+
+mkdir -p deploy
+
+echo "Cloning existing gh-pages branch..."
+
+git clone \
+    --depth 1 \
+    --branch gh-pages \
+    "https://github.com/${GITHUB_REPOSITORY}.git" \
+    old-gh-pages || true
+
+if [[ -d old-gh-pages ]]; then
+    echo "Preserving existing documentation versions..."
+    cp -r old-gh-pages/* deploy/ || true
+fi
+
+echo "Replacing current version: ${TARGET_DIR}"
+
+rm -rf "deploy/${TARGET_DIR}"
+mkdir -p "deploy/${TARGET_DIR}"
+
+cp -r docs/build/html/* "deploy/${TARGET_DIR}/"
+
+# stable -> latest tagged release
+if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+    echo "Updating stable alias..."
+
+    # TARGET_DIR already contains the correctly formatted 'vX.Y.Z' string
+    mkdir -p deploy && rm -rf deploy/stable && ln -s "${TARGET_DIR}" deploy/stable
+fi
+
+echo "Creating root redirect..."
+
+cat > deploy/index.html <<EOF
+<meta http-equiv="refresh" content="0; url=latest/">
+EOF

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,9 +5,19 @@ on:
   push:
     branches:
       - main
+      - 'test-docs?-**'
+    tags:
+      - '[0-9]*.[0-9]*.[0-9]*'
     paths:
       - 'docs/**'
       - '.github/workflows/gh-pages.yml'
+      - 'src/docbuild/__about__.py'
+
+permissions:
+  contents: write
+
+env:
+  CI_BIN_DIR: .github/bin
 
 jobs:
   build-and-deploy:
@@ -16,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install Graphviz
         run: sudo apt-get update && sudo apt-get install -y graphviz
@@ -37,16 +49,29 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --group docs
 
+      - name: Determine documentation version
+        run: ${{ env.CI_BIN_DIR }}/determine-version.sh
+
       - name: Build documentation
+        env:
+          DOC_VERSION: ${{ env.DOC_VERSION }}
         run: |
+          # The DOC_VERSION is handled inside conf.py using os.environ
           uv run make -C docs html
+
+      - name: Prepare deployment
+        run: ${{ env.CI_BIN_DIR }}/prepare-deploy.sh
+
+      - name: Generate versions.json
+        run: ${{ env.CI_BIN_DIR }}/generate-versions.py --output versions.json
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/build/html
-    
+          publish_dir: deploy
+
       - name: Print documentation URL
         run: |
-            echo "Your documentation will be available at: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
+            echo "Documentation URL: "
+            echo "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          # A Personal Access Token (PAT) is REQUIRED here to trigger gh-pages.yml
+          # The default GITHUB_TOKEN intentionally prevents triggered events from starting new workflows.
+          token: ${{ secrets.PAT_TOKEN_FOR_TAGS }}
 
       - name: Check Version Consistency
         id: version_check

--- a/.versions.json
+++ b/.versions.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "latest",
+    "version": "latest",
+    "url": "https://opensuse.github.io/docbuild/latest/"
+  },
+  {
+    "name": "stable",
+    "version": "stable",
+    "url": "https://opensuse.github.io/docbuild/stable/"
+  },
+  {
+    "name": "v0.18.0",
+    "version": "v0.18.0",
+    "url": "https://opensuse.github.io/docbuild/v0.18.0/"
+  }
+]

--- a/changelog.d/282.infra.rst
+++ b/changelog.d/282.infra.rst
@@ -1,0 +1,1 @@
+Implement multi-version doc switcher

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,6 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 from datetime import datetime
+import os
 from pathlib import Path
 import sys
 from typing import Self
@@ -212,6 +213,11 @@ html_theme_options = {
         # "image_light": "_static/logo-light.png",
         # "image_dark": "_static/logo-dark.png",
     },
+    "switcher": {
+        "json_url": "https://opensuse.github.io/docbuild/versions.json",
+        "version_match": os.environ.get("DOC_VERSION", "latest"),
+    },
+    "navbar_end": ["theme-switcher", "version-switcher"],
 }
 
 html_logo = "_static/logo.png"


### PR DESCRIPTION
Fixes #281

* Add a `.versions.json` as required by Pydata Sphinx theme
* Configure Sphinx to use the version switcher
* Use the PAT in `actions/checkout` to trigger `gh-pages.yml`
* Adjust `gh-pages.yml`:
  * Trigger for tags in Semver format (`MAJOR.MINOR.PATCH`)
  * Detect changes in `src/docbuild/__about__.py`
  * Trigger for branches with matches `tests-docs?-*`. Useful for testing
  * Introduce three new steps which call scripts in `.github/bin/`:
    * Determine documentation version
    * Prepare deployment
    * Generate `versions.json`
   
NOTE: The tags are MAJOR.MINOR.PATCH, but the directory on the GitHub `gh-pages` branch contains a "v" prefix.