### PR TITLE
Fix #286: Introduce dependency cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       - "tomschr"
     cooldown:
       # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
-      default-days: 5
+      default-days: 7
     labels:
       - "area:dependencies"
 

--- a/changelog.d/286.feature.rst
+++ b/changelog.d/286.feature.rst
@@ -1,0 +1,1 @@
+Introduce a dependency cooldown  to mitigate supply-chain attacks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ changelog = [
     "towncrier>=25.8.0",
 ]
 docs = [
-    "myst-parser>=5.1.0",
+    "myst-parser>=5.0.0",
     "pydata-sphinx-theme>=0.17.1",
     "sphinx>=9.1.0",
     "sphinx-autoapi>=3.8.0",

--- a/uv.toml
+++ b/uv.toml
@@ -3,3 +3,6 @@ upgrade = true
 
 # Allow upgrades for a specific package, ignoring pinned versions in any existing output file.
 upgrade-package = ["lxml"]
+
+# Security: Dependency cooldown
+exclude-newer = "10 days"


### PR DESCRIPTION
A dependency cooldown doesn't install anything that is too new. This mitigates some supply-chain attacks (but keep in mind, it's NOT a panacea.)

### Additional changes

Had to lower the version of `myst-parser` to >=5.0.0 to avoid a failure on MacOS.