### PR TITLE
Use `--no-sync` for custom alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Docbuild builds documentation from DocBook 5/ASCIIDoc, manages XML configs, clon
 ## Setup
 
 1. Create a virtual environment with `uv venv`
-2. Install dependencies: `uv sync --frozen --group devel`
+2. Install dependencies: `uv sync --frozen --no-sync --group devel`
 
 ## Testing with `uv`
 

--- a/changelog.d/301.infra.rst
+++ b/changelog.d/301.infra.rst
@@ -1,0 +1,1 @@
+Use ``--no-sync`` for custom alias.

--- a/devel/activate-aliases.sh
+++ b/devel/activate-aliases.sh
@@ -1,20 +1,29 @@
 #!/bin/bash
 # If you change this file, update the README.rst file accordingly.
+#
+# The options that are used in the aliases are:
+# --frozen:  Prevents uv from updating the uv.lock file
+# --no-sync: Prevents uv from automatically updating or installing
+#            anything into the .venv.
+#
+# Source: https://docs.astral.sh/uv/reference/cli/
+#
+# This file belongs to the repository https://github.com/openSUSE/docbuild
 
 # For testing:
-alias upytest="uv run --frozen pytest"
+alias upytest="uv run --frozen --no-sync pytest"
 
 # General Python command
-alias upython="uv run --frozen python"
+alias upython="uv run --frozen --no-sync python"
 
 # For the interactive Python shell with the project's environment:
-alias uipython="uv run --frozen ipython --ipython-dir=.ipython"
+alias uipython="uv run --frozen --no-sync ipython --ipython-dir=.ipython"
 
 # For executing the project's script:
-alias docbuild="uv run --frozen docbuild"
+alias docbuild="uv run --frozen --no-sync docbuild"
 
 # For managing changelog and news files:
-alias towncrier="uv run --frozen towncrier"
+alias towncrier="uv run --frozen --no-sync towncrier"
 
 # For creating docs:
-alias makedocs="uv run --frozen make -C docs html"
+alias makedocs="uv run --frozen --no-sync make -C docs html"

--- a/docs/source/developer/build-docs.rst
+++ b/docs/source/developer/build-docs.rst
@@ -19,7 +19,7 @@ To build the documentation for this project, use the following steps:
    .. code-block:: shell-session
       :name: sphinx-build
 
-      uv run --frozen make -C docs html
+      uv run --frozen --no-sync make -C docs html
 
 #. Watch for warnings and errors during the build process.
    If you encounter any issues, review the output and fix them accordingly.

--- a/docs/source/developer/run-testsuite.rst
+++ b/docs/source/developer/run-testsuite.rst
@@ -15,7 +15,7 @@ To run the full test suite, use the following command:
    :caption: Running pytest directly with |uv|
    :name: running-pytest-with-uv
 
-   uv run --frozen pytest
+   uv run --frozen --no-sync pytest
 
 or use the alias (see :ref:`devel-helpers` for more information):
 


### PR DESCRIPTION
The option `--no-sync` prevents uv from automatically updating or installing anything into the VENV. This is usually what we want: uv shouldn't update the VENV unless we told them.

Update custom alias and documentation.