### PR TITLE
Use uv.lock file to prevent attacks

### DIFF
--- a/changelog.d/305.infra.rst
+++ b/changelog.d/305.infra.rst
@@ -1,0 +1,1 @@
+Removed the default dependency cooldown from ``uv.toml`` so CI and Dependabot now rely on the committed ``uv.lock`` file, while cooldown-based updates remain available via ``UV_EXCLUDE_NEWER``.

--- a/uv.toml
+++ b/uv.toml
@@ -1,8 +1,10 @@
-# Allow package upgrades, ignoring pinned versions in any existing output file.
-upgrade = true
-
-# Allow upgrades for a specific package, ignoring pinned versions in any existing output file.
-upgrade-package = ["lxml"]
-
-# Security: Dependency cooldown
-exclude-newer = "10 days"
+# uv.toml — local/CI configuration for uv
+#
+# NOTE: `upgrade`, `upgrade-package`, and `exclude-newer` are intentionally
+# omitted here so that `uv sync --frozen` in CI uses the lockfile as-is.
+#
+# To update dependencies locally with a supply-chain cooldown window, run:
+#   UV_EXCLUDE_NEWER="10 days" uv lock --upgrade-package lxml
+#
+# The committed uv.lock (with SHA-256 hashes) is the primary supply-chain
+# protection. See: https://docs.astral.sh/uv/concepts/resolution/#exclude-newer


### PR DESCRIPTION
The dependency cooldown feature with `exclude-newer` seems to have some negative side effects for Dependabot. The workflow fails as uv can fullfil the dependencies anymore.

Removing all negative side effects from `uv.toml`. The committed `uv.lock` (with SHA-256 hashes) is the primary supply-chain protection. See: https://docs.astral.sh/uv/concepts/resolution/#exclude-newer


Related to PR #287.