### PR TITLE
Doc: Use release instead of version on title page

### DIFF
--- a/changelog.d/306.doc.rst
+++ b/changelog.d/306.doc.rst
@@ -1,0 +1,1 @@
+The documentation index page now shows the current release (via ``setuptools-scm``) and build date on the title page.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,7 @@ import sys
 from typing import Self
 
 from docutils import nodes
+from setuptools_scm import get_version
 from sphinx.application import Sphinx
 from sphinx.errors import ExtensionError
 from sphinx.transforms import SphinxTransform
@@ -31,10 +32,11 @@ author = "Tom Schraitle, Sushant Gaurav"
 
 # Check, if we are using 'latest' (main) build
 if os.environ.get("DOC_VERSION") == "latest":
-    release = f"{__version__}-dev"
+    release: str = get_version(root="../..", relative_to=__file__)
 else:
     release = __version__
 
+version = __version__
 
 gh_user = "openSUSE"
 gh_repo_url = f"https://github.com/{gh_user}/{project}"
@@ -229,6 +231,8 @@ html_theme_options = {
 html_logo = "_static/logo.png"
 
 html_favicon = "_static/favicon.ico"
+
+html_title = f"{project.capitalize()} Documentation {release}"
 
 # -- Options for intersphinx extension ---------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,8 +3,11 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-|project| Documentation |release|
+|project| Documentation |version|
 =================================
+
+:Release: |release|
+:Built:   |today|
 
 This is the documentation for the |project| project, hosted at |gh_repo|.
 

--- a/docs/source/reference/_autoapi/docbuild/cli/cmd_portal/index.rst
+++ b/docs/source/reference/_autoapi/docbuild/cli/cmd_portal/index.rst
@@ -15,6 +15,7 @@ Submodules
 .. toctree::
    :maxdepth: 1
 
+   /reference/_autoapi/docbuild/cli/cmd_portal/cmd_list/index
    /reference/_autoapi/docbuild/cli/cmd_portal/cmd_validate/index
    /reference/_autoapi/docbuild/cli/cmd_portal/process/index
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ changelog = [
 docs = [
     "myst-parser>=5.1.0",
     "pydata-sphinx-theme>=0.17.1",
+    "setuptools-scm>=10.0.5",
     "sphinx>=9.1.0",
     "sphinx-autoapi>=3.8.0",
     "sphinx-autodoc-typehints>=3.10.2",
@@ -87,19 +88,19 @@ docs = [
 repl = [
     "ipython>=9.13.0",
 ]
-devel = [
-  {include-group = "typing"},
-  {include-group = "formatting"},
-  {include-group = "tests"},
-  {include-group = "changelog"},
-  {include-group = "docs"},
-  {include-group = "repl"},
-  # {include-group = "publish"},
-]
 github-action = [
   {include-group = "tests"},
   {include-group = "docs"},
 ]
+devel = [
+  {include-group = "typing"},
+  {include-group = "formatting"},
+  {include-group = "changelog"},
+  {include-group = "github-action"},
+  {include-group = "repl"},
+  # {include-group = "publish"},
+]
+
 
 [project.scripts]
 docbuild = "docbuild.__main__:cli"

--- a/uv.lock
+++ b/uv.lock
@@ -303,6 +303,7 @@ devel = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "setuptools-scm" },
     { name = "sphinx" },
     { name = "sphinx-autoapi" },
     { name = "sphinx-autodoc-typehints" },
@@ -315,6 +316,7 @@ devel = [
 docs = [
     { name = "myst-parser" },
     { name = "pydata-sphinx-theme" },
+    { name = "setuptools-scm" },
     { name = "sphinx" },
     { name = "sphinx-autoapi" },
     { name = "sphinx-autodoc-typehints" },
@@ -333,6 +335,7 @@ github-action = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "setuptools-scm" },
     { name = "sphinx" },
     { name = "sphinx-autoapi" },
     { name = "sphinx-autodoc-typehints" },
@@ -375,6 +378,7 @@ devel = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "ruff", specifier = ">=0.15.13" },
+    { name = "setuptools-scm", specifier = ">=10.0.5" },
     { name = "sphinx", specifier = ">=9.1.0" },
     { name = "sphinx-autoapi", specifier = ">=3.8.0" },
     { name = "sphinx-autodoc-typehints", specifier = ">=3.10.2" },
@@ -387,6 +391,7 @@ devel = [
 docs = [
     { name = "myst-parser", specifier = ">=5.1.0" },
     { name = "pydata-sphinx-theme", specifier = ">=0.17.1" },
+    { name = "setuptools-scm", specifier = ">=10.0.5" },
     { name = "sphinx", specifier = ">=9.1.0" },
     { name = "sphinx-autoapi", specifier = ">=3.8.0" },
     { name = "sphinx-autodoc-typehints", specifier = ">=3.10.2" },
@@ -405,6 +410,7 @@ github-action = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "setuptools-scm", specifier = ">=10.0.5" },
     { name = "sphinx", specifier = ">=9.1.0" },
     { name = "sphinx-autoapi", specifier = ">=3.8.0" },
     { name = "sphinx-autodoc-typehints", specifier = ">=3.10.2" },
@@ -1251,6 +1257,29 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "setuptools-scm"
+version = "10.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools" },
+    { name = "vcs-versioning" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/b1/2a6a8ecd6f9e263754036a0b573360bdbd6873b595725e49e11139722041/setuptools_scm-10.0.5.tar.gz", hash = "sha256:bbba8fe754516cdefd017f4456721775e6ef9662bd7887fb52ae26813d4838c3", size = 56748, upload-time = "2026-03-27T15:57:05.751Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e1/342c4434df56aa537f6ce7647eefee521d96fbb828b08acd709865767652/setuptools_scm-10.0.5-py3-none-any.whl", hash = "sha256:f611037d8aae618221503b8fa89319f073438252ae3420e01c9ceec249131a0a", size = 21695, upload-time = "2026-03-27T15:57:03.969Z" },
+]
+
+[[package]]
 name = "snowballstemmer"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1502,6 +1531,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "vcs-versioning"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/42/d97a7795055677961c63a1eef8e7b19d5968ed992ed3a70ab8eb012efad8/vcs_versioning-1.1.1.tar.gz", hash = "sha256:fabd75a3cab7dd8ac02fe24a3a9ba936bf258667b5a62ed468c9a1da0f5775bc", size = 97575, upload-time = "2026-03-27T20:42:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/60/73603fbcdbe5e803855bcce4414f94eaeed449083bd8183e67161af78188/vcs_versioning-1.1.1-py3-none-any.whl", hash = "sha256:b541e2ba79fc6aaa3850f8a7f88af43d97c1c80649c01142ee4146eddbc599e4", size = 79851, upload-time = "2026-03-27T20:42:40.45Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
* Use setuptools-scm to get the release similar to `git describe`
* Update `pyproject.toml` and `uv.lock`
* Update index page to present current release and built date