### PR TITLE
feat: auto-complete partial language codes in LanguageCode

### DIFF
--- a/changelog.d/259.bugfix.rst
+++ b/changelog.d/259.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a validation bug in `LanguageCode` by automatically stripping leading and trailing whitespaces from input strings.

--- a/changelog.d/309.feature.rst
+++ b/changelog.d/309.feature.rst
@@ -1,0 +1,1 @@
+Refactored `LanguageCode` to automatically strip leading and trailing whitespaces and auto-complete partial language codes (for example, resolving `en` to `en-us`).

--- a/src/docbuild/models/language.py
+++ b/src/docbuild/models/language.py
@@ -125,9 +125,17 @@ class LanguageCode(BaseModel):
     @field_validator("language", mode="before")
     @classmethod
     def _normalize_language_separator(cls, value: str) -> str:
-        """Strip whitespaces and normalize separator from ``_`` to ``-``."""
+        """Strip whitespaces, normalize separator, and auto-complete partial languages."""
         if isinstance(value, str):
-            return value.strip().replace("_", "-")
+            val = value.strip().replace("_", "-")
+
+            # Auto-complete partial languages (e.g. "en" -> "en-us")
+            if val != "*" and "-" not in val:
+                for allowed_lang in cls.ALLOWED_LANGS:
+                    if allowed_lang != "*" and allowed_lang.startswith(f"{val}-"):
+                        return allowed_lang
+
+            return val
         return value
 
     @field_validator("language")

--- a/tests/models/test_language.py
+++ b/tests/models/test_language.py
@@ -163,3 +163,29 @@ def test_convert_str_to_dict_accepts_string() -> None:
     # ensure computed properties work as expected
     assert lc.lang == "en"
     assert lc.country == "us"
+
+
+def test_language_code_strips_whitespaces():
+    """Test that leading and trailing whitespaces are cleanly stripped."""
+    assert LanguageCode(language=" en-us").language == "en-us"
+    assert LanguageCode(language="en-us ").language == "en-us"
+    assert LanguageCode(language="  en-us  ").language == "en-us"
+
+
+def test_language_code_autocompletes_partial_language():
+    """Test that partial languages are expanded to their full valid codes."""
+    assert LanguageCode(language="en").language == "en-us"
+    assert LanguageCode(language=" de ").language == "de-de"
+
+
+def test_language_code_rejects_unknown_partial():
+    """Test that passing an invalid partial language still raises a ValidationError."""
+    with pytest.raises(ValidationError, match="Invalid language code"):
+        LanguageCode(language="zz")
+
+
+def test_language_matches_with_whitespaces():
+    """Test that the matches method handles dirty string comparisons safely."""
+    lang = LanguageCode(language="de-de")
+    assert lang.matches(" de-de ")
+    assert lang.matches(" * ")


### PR DESCRIPTION
Closes #309 

### Changes

* Updated the `_normalize_language_separator` pre-validator in `LanguageCode` to detect partial languages (strings without a hyphen).
* If a partial language is detected, it searches `ALLOWED_LANGUAGES` and auto-completes to the full `LANGUAGE-COUNTRY` format.
* Retains standard `ValidationError` behavior for completely invalid inputs (e.g., `"fr"`).