### PR TITLE
feat: supercharge portal list with metadata flag

### DIFF
--- a/changelog.d/302.feature.rst
+++ b/changelog.d/302.feature.rst
@@ -1,1 +1,1 @@
-Enhanced the `portal list` command with new optional flags (`--trans`, `--formats`, `--categories`, and `--repo`) to display extended deliverable metadata directly in the output tree.
+Enhanced the ``portal list`` command with new optional flags (``--trans``, ``--formats``, ``--categories``, and ``--repo``) to display extended deliverable metadata directly in the output tree.

--- a/changelog.d/302.feature.rst
+++ b/changelog.d/302.feature.rst
@@ -1,0 +1,1 @@
+Enhanced the `portal list` command with new optional flags (`--trans`, `--formats`, `--categories`, and `--repo`) to display extended deliverable metadata directly in the output tree.

--- a/src/docbuild/cli/cmd_portal/cmd_list.py
+++ b/src/docbuild/cli/cmd_portal/cmd_list.py
@@ -245,7 +245,7 @@ def list_cmd(
     """List products, docsets, and deliverables from the portal config.
 
     Accepts optional DOCTYPE arguments to filter the output.
-    Format: [PRODUCT]/[DOCSETS]@[LIFECYCLES]/[LANGS]
+    Format: PRODUCT/DOCSETS[@LIFECYCLES]/LANGS
 
     Example:
         docbuild portal list sles/15-SP6

--- a/src/docbuild/cli/cmd_portal/cmd_list.py
+++ b/src/docbuild/cli/cmd_portal/cmd_list.py
@@ -17,18 +17,14 @@ from docbuild.models.doctype import Doctype
 
 def build_hierarchy(
     deliverables: list[Deliverable],
-) -> tuple[dict, dict]:
-    """Group Deliverables into a hierarchy and build a translation index.
+) -> dict[str, dict[str, dict[str, list[Deliverable]]]]:
+    """Group Deliverables into a hierarchy.
 
     :param deliverables: A list of Deliverable models to organize.
-    :return: A tuple of (hierarchy_dict, translation_index_dict).
+    :return: A hierarchy_dict mapping lang -> product -> docset -> deliverables.
     """
     hierarchy: dict[str, dict[str, dict[str, list[Deliverable]]]] = defaultdict(
         lambda: defaultdict(lambda: defaultdict(list))
-    )
-    # Maps: product -> docset -> deliverable_id -> set of languages
-    translation_index: dict[str, dict[str, dict[str, set[str]]]] = defaultdict(
-        lambda: defaultdict(lambda: defaultdict(set))
     )
 
     for deliv in deliverables:
@@ -36,24 +32,12 @@ def build_hierarchy(
         product = deliv.xml.productid or "unknown-product"
         docset = deliv.xml.docsetid or "unknown-docset"
 
-        # Determine base ID
-        d_id = deliv.xml.node.get("id", "unnamed-deliverable")
-
         hierarchy[lang][product][docset].append(deliv)
 
-        # Dynamically discover all translations for this deliverable by peeking at the XML tree
-        if deliv.xml.docset_node is not None:
-            # Find all locales in this docset that have a deliverable with the same ID
-            for loc in deliv.xml.docset_node.xpath(f"resources/locale[deliverable[@id='{d_id}']]"):
-                if loc_lang := loc.get("lang"):
-                    translation_index[product][docset][d_id].add(loc_lang)
-        else:
-            translation_index[product][docset][d_id].add(lang)
-
-    return hierarchy, translation_index
+    return hierarchy
 
 
-def _parse_doctypes(doctypes: tuple[str, ...], console: Console) -> list[Doctype] | None:
+def parse_doctypes(doctypes: tuple[str, ...], console: Console) -> list[Doctype] | None:
     """Parse raw CLI arguments into Doctype objects with default fallbacks."""
     if not doctypes:
         return None
@@ -76,7 +60,7 @@ def _parse_doctypes(doctypes: tuple[str, ...], console: Console) -> list[Doctype
     return parsed_doctypes
 
 
-def _get_display_name(deliv: Deliverable, d_id: str) -> str:
+def get_display_name(deliv: Deliverable, d_id: str) -> str:
     """Determine the main display name for a deliverable."""
     if deliv.xml.is_prebuilt:
         title_node = deliv.xml.node.find("title")
@@ -87,22 +71,14 @@ def _get_display_name(deliv: Deliverable, d_id: str) -> str:
     return f"{d_id} ({dc_file})" if dc_file else d_id
 
 
-def _append_translations(
-    deliv_branch: Tree,
-    translation_index: dict[str, dict[str, dict[str, set[str]]]],
-    product: str,
-    docset: str,
-    d_id: str,
-    lang: str
-) -> None:
+def append_translations(deliv_branch: Tree, deliv: Deliverable, lang: str) -> None:
     """Append translation metadata to the deliverable branch."""
-    all_langs = translation_index.get(product, {}).get(docset, {}).get(d_id, set())
-    other_langs = sorted(other_lang for other_lang in all_langs if other_lang != lang)
+    other_langs = sorted(other_lang for other_lang in deliv.xml.translations if other_lang != lang)
     if other_langs:
         deliv_branch.add(f"Translations: {', '.join(other_langs)}")
 
 
-def _append_formats(deliv_branch: Tree, deliv: Deliverable) -> None:
+def append_formats(deliv_branch: Tree, deliv: Deliverable) -> None:
     """Append output formats metadata to the deliverable branch."""
     if attrs := deliv.xml.format_attrs():
         fmt_names = {"pdf": "PDF", "html": "HTML", "single-html": "Single-HTML", "epub": "EPUB"}
@@ -111,27 +87,27 @@ def _append_formats(deliv_branch: Tree, deliv: Deliverable) -> None:
             deliv_branch.add(f"Formats: {', '.join(available)}")
 
 
-def _append_categories(deliv_branch: Tree, deliv: Deliverable) -> None:
+def append_categories(deliv_branch: Tree, deliv: Deliverable) -> None:
     """Append category metadata to the deliverable branch."""
-    if cat := deliv.xml.node.get("category"):
-        deliv_branch.add(f"Category: {cat.replace('-', ' ').capitalize()}")
+    if cat_title := deliv.xml.category_title:
+        deliv_branch.add(f"Category: {cat_title}")
 
 
-def _append_repo(deliv_branch: Tree, deliv: Deliverable, repo_format: str) -> None:
+def append_repo(deliv_branch: Tree, deliv: Deliverable, repo_format: str) -> None:
     """Append repository metadata to the deliverable branch."""
-    if repo := deliv.xml.git_remote():
-        # Safely extract long URL or fallback to short string representation
-        repo_val = getattr(repo, "url", getattr(repo, "clone_url", str(repo))) if repo_format == "long" else str(repo)
+    repo = deliv.xml.git_remote()
+    if repo:
+        if isinstance(repo, str):
+            repo_val = repo
+        else:
+            repo_val = getattr(repo, "url", getattr(repo, "clone_url", str(repo))) if repo_format == "long" else str(repo)
         deliv_branch.add(f"Repo: {repo_val}")
 
 
-def _build_deliverable_branch(
+def build_deliverable_branch(
     docset_branch: Tree,
     deliv: Deliverable,
     lang: str,
-    product: str,
-    docset: str,
-    translation_index: dict[str, dict[str, dict[str, set[str]]]],
     show_trans: bool,
     show_formats: bool,
     show_categories: bool,
@@ -141,7 +117,7 @@ def _build_deliverable_branch(
     d_id = deliv.xml.node.get("id", "unnamed-deliverable")
 
     # 1. Format the main display name
-    display_name = _get_display_name(deliv, d_id)
+    display_name = get_display_name(deliv, d_id)
     deliv_branch = docset_branch.add(display_name)
 
     # 2. Automatically show URLs for prebuilt deliverables
@@ -152,18 +128,17 @@ def _build_deliverable_branch(
 
     # 3. Add Optional Metadata based on CLI Flags
     if show_trans:
-        _append_translations(deliv_branch, translation_index, product, docset, d_id, lang)
+        append_translations(deliv_branch, deliv, lang)
     if show_formats:
-        _append_formats(deliv_branch, deliv)
+        append_formats(deliv_branch, deliv)
     if show_categories:
-        _append_categories(deliv_branch, deliv)
+        append_categories(deliv_branch, deliv)
     if repo_format:
-        _append_repo(deliv_branch, deliv, repo_format)
+        append_repo(deliv_branch, deliv, repo_format)
 
 
-def _print_hierarchy(
+def print_hierarchy(
     hierarchy: dict[str, dict[str, dict[str, list[Deliverable]]]],
-    translation_index: dict[str, dict[str, dict[str, set[str]]]],
     console: Console,
     show_trans: bool,
     show_formats: bool,
@@ -182,13 +157,10 @@ def _print_hierarchy(
 
                 # Sort deliverables by ID for stable output
                 for deliv in sorted(delivs, key=lambda d: d.xml.node.get("id", "")):
-                    _build_deliverable_branch(
+                    build_deliverable_branch(
                         docset_branch,
                         deliv,
                         lang,
-                        product,
-                        docset,
-                        translation_index,
                         show_trans,
                         show_formats,
                         show_categories,
@@ -209,7 +181,7 @@ async def async_list_cmd(
     repo_format: str | None,
 ) -> None:
     """Async worker to fetch the XML, parse Doctypes, and build the tree."""
-    parsed_doctypes = _parse_doctypes(doctypes, console)
+    parsed_doctypes = parse_doctypes(doctypes, console)
 
     # 2. Get XML Tree
     # The application framework guarantees envconfig is loaded before command execution.
@@ -236,11 +208,10 @@ async def async_list_cmd(
         console.print("[yellow]No deliverables found matching the criteria.[/yellow]")
         return
 
-    hierarchy, translation_index = build_hierarchy(deliverables)
+    hierarchy = build_hierarchy(deliverables)
 
-    _print_hierarchy(
+    print_hierarchy(
         hierarchy,
-        translation_index,
         console,
         show_trans,
         show_formats,

--- a/src/docbuild/cli/cmd_portal/cmd_list.py
+++ b/src/docbuild/cli/cmd_portal/cmd_list.py
@@ -17,30 +17,40 @@ from docbuild.models.doctype import Doctype
 
 def build_hierarchy(
     deliverables: list[Deliverable],
-) -> dict[str, dict[str, dict[str, list[str]]]]:
-    """Group a list of Deliverable domain objects into a nested dictionary structure.
+) -> tuple[dict, dict]:
+    """Group Deliverables into a hierarchy and build a translation index.
 
     :param deliverables: A list of Deliverable models to organize.
-    :return: A nested dictionary structured as {lang: {product: {docset: [deliverable titles]}}}.
+    :return: A tuple of (hierarchy_dict, translation_index_dict).
     """
-    hierarchy: dict[str, dict[str, dict[str, list[str]]]] = defaultdict(
+    hierarchy: dict[str, dict[str, dict[str, list[Deliverable]]]] = defaultdict(
         lambda: defaultdict(lambda: defaultdict(list))
     )
+    # Maps: product -> docset -> deliverable_id -> set of languages
+    translation_index: dict[str, dict[str, dict[str, set[str]]]] = defaultdict(
+        lambda: defaultdict(lambda: defaultdict(set))
+    )
 
-    for deliverable in deliverables:
-        # Pull facts via the clean Deliverable XML view facade
-        lang = str(deliverable.xml.lang)
-        product = deliverable.xml.productid or "unknown-product"
-        docset = deliverable.xml.docsetid or "unknown-docset"
+    for deliv in deliverables:
+        lang = str(deliv.xml.lang)
+        product = deliv.xml.productid or "unknown-product"
+        docset = deliv.xml.docsetid or "unknown-docset"
 
-        # Determine a compact leaf string using ID and DC file metadata
-        d_id = deliverable.xml.node.get("id", "unnamed-deliverable")
-        dc_file = deliverable.xml.dcfile
-        display_name = f"{d_id} ({dc_file})" if dc_file else d_id
+        # Determine base ID
+        d_id = deliv.xml.node.get("id", "unnamed-deliverable")
 
-        hierarchy[lang][product][docset].append(display_name)
+        hierarchy[lang][product][docset].append(deliv)
 
-    return hierarchy
+        # Dynamically discover all translations for this deliverable by peeking at the XML tree
+        if deliv.xml.docset_node is not None:
+            # Find all locales in this docset that have a deliverable with the same ID
+            for loc in deliv.xml.docset_node.xpath(f"resources/locale[deliverable[@id='{d_id}']]"):
+                if loc_lang := loc.get("lang"):
+                    translation_index[product][docset][d_id].add(loc_lang)
+        else:
+            translation_index[product][docset][d_id].add(lang)
+
+    return hierarchy, translation_index
 
 
 def _parse_doctypes(doctypes: tuple[str, ...], console: Console) -> list[Doctype] | None:
@@ -66,7 +76,100 @@ def _parse_doctypes(doctypes: tuple[str, ...], console: Console) -> list[Doctype
     return parsed_doctypes
 
 
-def _print_hierarchy(hierarchy: dict[str, dict[str, dict[str, list[str]]]], console: Console) -> None:
+def _get_display_name(deliv: Deliverable, d_id: str) -> str:
+    """Determine the main display name for a deliverable."""
+    if deliv.xml.is_prebuilt:
+        title_node = deliv.xml.node.find("title")
+        title = title_node.text if title_node is not None else d_id
+        return f"{title} (Prebuilt)"
+
+    dc_file = deliv.xml.dcfile
+    return f"{d_id} ({dc_file})" if dc_file else d_id
+
+
+def _append_translations(
+    deliv_branch: Tree,
+    translation_index: dict[str, dict[str, dict[str, set[str]]]],
+    product: str,
+    docset: str,
+    d_id: str,
+    lang: str
+) -> None:
+    """Append translation metadata to the deliverable branch."""
+    all_langs = translation_index.get(product, {}).get(docset, {}).get(d_id, set())
+    other_langs = sorted(other_lang for other_lang in all_langs if other_lang != lang)
+    if other_langs:
+        deliv_branch.add(f"Translations: {', '.join(other_langs)}")
+
+
+def _append_formats(deliv_branch: Tree, deliv: Deliverable) -> None:
+    """Append output formats metadata to the deliverable branch."""
+    if attrs := deliv.xml.format_attrs():
+        fmt_names = {"pdf": "PDF", "html": "HTML", "single-html": "Single-HTML", "epub": "EPUB"}
+        available = [fmt_names.get(k, k.upper()) for k, v in attrs.items() if v]
+        if available:
+            deliv_branch.add(f"Formats: {', '.join(available)}")
+
+
+def _append_categories(deliv_branch: Tree, deliv: Deliverable) -> None:
+    """Append category metadata to the deliverable branch."""
+    if cat := deliv.xml.node.get("category"):
+        deliv_branch.add(f"Category: {cat.replace('-', ' ').capitalize()}")
+
+
+def _append_repo(deliv_branch: Tree, deliv: Deliverable, repo_format: str) -> None:
+    """Append repository metadata to the deliverable branch."""
+    if repo := deliv.xml.git_remote():
+        # Safely extract long URL or fallback to short string representation
+        repo_val = getattr(repo, "url", getattr(repo, "clone_url", str(repo))) if repo_format == "long" else str(repo)
+        deliv_branch.add(f"Repo: {repo_val}")
+
+
+def _build_deliverable_branch(
+    docset_branch: Tree,
+    deliv: Deliverable,
+    lang: str,
+    product: str,
+    docset: str,
+    translation_index: dict[str, dict[str, dict[str, set[str]]]],
+    show_trans: bool,
+    show_formats: bool,
+    show_categories: bool,
+    repo_format: str | None,
+) -> None:
+    """Format and append a single deliverable node to the Rich Tree."""
+    d_id = deliv.xml.node.get("id", "unnamed-deliverable")
+
+    # 1. Format the main display name
+    display_name = _get_display_name(deliv, d_id)
+    deliv_branch = docset_branch.add(display_name)
+
+    # 2. Automatically show URLs for prebuilt deliverables
+    if deliv.xml.is_prebuilt:
+        for url_node in deliv.xml.node.xpath("prebuilt/url"):
+            if href := url_node.get("href"):
+                deliv_branch.add(f"URL: [link={href}]{href}[/link]")
+
+    # 3. Add Optional Metadata based on CLI Flags
+    if show_trans:
+        _append_translations(deliv_branch, translation_index, product, docset, d_id, lang)
+    if show_formats:
+        _append_formats(deliv_branch, deliv)
+    if show_categories:
+        _append_categories(deliv_branch, deliv)
+    if repo_format:
+        _append_repo(deliv_branch, deliv, repo_format)
+
+
+def _print_hierarchy(
+    hierarchy: dict[str, dict[str, dict[str, list[Deliverable]]]],
+    translation_index: dict[str, dict[str, dict[str, set[str]]]],
+    console: Console,
+    show_trans: bool,
+    show_formats: bool,
+    show_categories: bool,
+    repo_format: str | None,
+) -> None:
     """Render and print the nested hierarchy as a Rich Tree."""
     for lang, products in sorted(hierarchy.items()):
         root_tree = Tree(f"[bold blue]{lang}/[/bold blue]")
@@ -77,21 +180,35 @@ def _print_hierarchy(hierarchy: dict[str, dict[str, dict[str, list[str]]]], cons
             for docset, delivs in sorted(docsets.items()):
                 docset_branch = prod_branch.add(f"[cyan]{docset}[/cyan]")
 
-                for display_name in sorted(delivs):
-                    docset_branch.add(display_name)
+                # Sort deliverables by ID for stable output
+                for deliv in sorted(delivs, key=lambda d: d.xml.node.get("id", "")):
+                    _build_deliverable_branch(
+                        docset_branch,
+                        deliv,
+                        lang,
+                        product,
+                        docset,
+                        translation_index,
+                        show_trans,
+                        show_formats,
+                        show_categories,
+                        repo_format,
+                    )
 
         console.print(root_tree)
         console.print()
 
 
-async def async_list_cmd(ctx: DocBuildContext, doctypes: tuple[str, ...], console: Console) -> None:
-    """Async worker to fetch the XML, parse Doctypes, and build the tree.
-
-    :param ctx: The DocBuildContext containing CLI options and config.
-    :param doctypes: A tuple of doctype strings passed as arguments to the command.
-    :param console: The Rich Console object for outputting the tree.
-    """
-    # 1. Parse Doctypes
+async def async_list_cmd(
+    ctx: DocBuildContext,
+    doctypes: tuple[str, ...],
+    console: Console,
+    show_trans: bool,
+    show_formats: bool,
+    show_categories: bool,
+    repo_format: str | None,
+) -> None:
+    """Async worker to fetch the XML, parse Doctypes, and build the tree."""
     parsed_doctypes = _parse_doctypes(doctypes, console)
 
     # 2. Get XML Tree
@@ -119,18 +236,43 @@ async def async_list_cmd(ctx: DocBuildContext, doctypes: tuple[str, ...], consol
         console.print("[yellow]No deliverables found matching the criteria.[/yellow]")
         return
 
-    # 4. Group data for Rich Tree
-    hierarchy = build_hierarchy(deliverables)
+    hierarchy, translation_index = build_hierarchy(deliverables)
 
-    # 5. Build and print the Rich Tree
-    _print_hierarchy(hierarchy, console)
+    _print_hierarchy(
+        hierarchy,
+        translation_index,
+        console,
+        show_trans,
+        show_formats,
+        show_categories,
+        repo_format
+    )
 
 
 @click.command(name="list")
+@click.option("--trans", "-T", is_flag=True, help="List available translations.")
+@click.option("--formats", "-F", is_flag=True, help="List available output formats.")
+@click.option("--categories", "-C", is_flag=True, help="List categories.")
+@click.option(
+    "--repo",
+    "-R",
+    type=click.Choice(["short", "long"]),
+    is_flag=False,
+    flag_value="short",
+    default=None,
+    help="List repository origin (defaults to short if no type provided)."
+)
 @click.argument("doctypes", nargs=-1)
 @click.pass_obj
-def list_cmd(ctx: DocBuildContext, doctypes: tuple[str, ...]) -> None:
-    """List products, docsets, and deliverables from the portal config.
+def list_cmd(
+    ctx: DocBuildContext,
+    doctypes: tuple[str, ...],
+    trans: bool,
+    formats: bool,
+    categories: bool,
+    repo: str | None,
+) -> None:
+    r"""List products, docsets, and deliverables from the portal config.
 
     Accepts optional DOCTYPE arguments to filter the output.
     Format: [PRODUCT]/[DOCSETS]@[LIFECYCLES]/[LANGS]
@@ -142,7 +284,11 @@ def list_cmd(ctx: DocBuildContext, doctypes: tuple[str, ...]) -> None:
 
     :param ctx: The DocBuildContext passed from the CLI, containing config and options.
     :param doctypes: A tuple of doctype strings passed as arguments to the command.
+    :param trans: Show translation metadata.
+    :param formats: Show output formats metadata.
+    :param categories: Show categories metadata.
+    :param repo: Show repository metadata (short or long).
 
-    """ # noqa: D301
+    """
     console = Console()
-    asyncio.run(async_list_cmd(ctx, doctypes, console))
+    asyncio.run(async_list_cmd(ctx, doctypes, console, trans, formats, categories, repo))

--- a/src/docbuild/cli/cmd_portal/cmd_list.py
+++ b/src/docbuild/cli/cmd_portal/cmd_list.py
@@ -100,7 +100,8 @@ def append_repo(deliv_branch: Tree, deliv: Deliverable, repo_format: str) -> Non
         if isinstance(repo, str):
             repo_val = repo
         else:
-            repo_val = getattr(repo, "url", getattr(repo, "clone_url", str(repo))) if repo_format == "long" else str(repo)
+            # Using surl for the short variant, url/clone_url for long
+            repo_val = getattr(repo, "url", getattr(repo, "clone_url", str(repo))) if repo_format == "long" else getattr(repo, "surl", str(repo))
         deliv_branch.add(f"Repo: {repo_val}")
 
 
@@ -228,10 +229,8 @@ async def async_list_cmd(
     "--repo",
     "-R",
     type=click.Choice(["short", "long"]),
-    is_flag=False,
-    flag_value="short",
     default=None,
-    help="List repository origin (defaults to short if no type provided)."
+    help="List repository origin (requires 'short' or 'long')."
 )
 @click.argument("doctypes", nargs=-1)
 @click.pass_obj
@@ -243,7 +242,7 @@ def list_cmd(
     categories: bool,
     repo: str | None,
 ) -> None:
-    r"""List products, docsets, and deliverables from the portal config.
+    """List products, docsets, and deliverables from the portal config.
 
     Accepts optional DOCTYPE arguments to filter the output.
     Format: [PRODUCT]/[DOCSETS]@[LIFECYCLES]/[LANGS]
@@ -260,6 +259,7 @@ def list_cmd(
     :param categories: Show categories metadata.
     :param repo: Show repository metadata (short or long).
 
-    """
+    """ # noqa: D301
     console = Console()
     asyncio.run(async_list_cmd(ctx, doctypes, console, trans, formats, categories, repo))
+

--- a/src/docbuild/models/deliverable/view.py
+++ b/src/docbuild/models/deliverable/view.py
@@ -87,9 +87,13 @@ class DeliverableXMLView:
         if self.docset_node is None or not d_id:
             return {str(self.lang)}
 
-        langs = set()
-        for loc in self.docset_node.xpath(f"resources/locale[deliverable[@id='{d_id}']]"):
-            if loc_lang := loc.get("lang"):
+        # Always include the base language
+        langs = {str(self.lang)}
+
+        for deliv_node in self.docset_node.xpath(f"resources/locale[@lang!='en-us']/deliverable[ref[@linkend={d_id!r}]]"):
+            # We must look at the parent <locale> to get the 'lang' attribute
+            parent_loc = deliv_node.getparent()
+            if loc_lang := parent_loc.get("lang"):
                 langs.add(loc_lang)
         return langs
 
@@ -155,10 +159,11 @@ class DeliverableXMLView:
             return None
 
         for cat in self.all_categories:
-            if cat.get("id") == cat_id:
-                title = cat.findtext("title")
-                if title is None:
-                    title = cat.findtext("name")
+            lang_nodes = cat.xpath(f"language[@id='{cat_id}']")
+            if lang_nodes:
+                title = lang_nodes[0].get("title")
+                if not title:
+                    title = lang_nodes[0].get("name")
                 return title.strip() if title else cat_id
         return cat_id
 

--- a/src/docbuild/models/deliverable/view.py
+++ b/src/docbuild/models/deliverable/view.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Literal, cast
 
-from lxml import etree
+from lxml import etree  # type: ignore
 
 from ...models.language import LanguageCode
 from ...utils.convert import convert2bool
@@ -80,6 +80,19 @@ class DeliverableXMLView:
         """Return :attr:`dcfile` stripped of its ``DC-`` prefix."""
         return self.dcfile and self.dcfile.lstrip("DC-")
 
+    @cached_property
+    def translations(self) -> set[str]:
+        """Return a set of all language codes available for this deliverable."""
+        d_id = self.node.get("id")
+        if self.docset_node is None or not d_id:
+            return {str(self.lang)}
+
+        langs = set()
+        for loc in self.docset_node.xpath(f"resources/locale[deliverable[@id='{d_id}']]"):
+            if loc_lang := loc.get("lang"):
+                langs.add(loc_lang)
+        return langs
+
     # -- Deliverable kind (type)
     @cached_property
     def kind(self) -> str | None:
@@ -134,6 +147,21 @@ class DeliverableXMLView:
         yield from self.categories()
         yield from self.categories_from_root()
 
+    @cached_property
+    def category_title(self) -> str | None:
+        """Return the resolved category title, or the raw ID if not found."""
+        cat_id = self.node.get("category")
+        if not cat_id:
+            return None
+
+        for cat in self.all_categories:
+            if cat.get("id") == cat_id:
+                title = cat.findtext("title")
+                if title is None:
+                    title = cat.findtext("name")
+                return title.strip() if title else cat_id
+        return cat_id
+
     def desc(self) -> Generator[etree._Element, None, None]:
         """Yield product ``<desc>`` elements."""
         yield from self.product_node.xpath("descriptions/desc")
@@ -158,12 +186,16 @@ class DeliverableXMLView:
         node = self.node.getparent().findtext("subdir", default=None)
         return node.strip() if node is not None else ""
 
-    def git_remote(self) -> Repo | None:
+    def git_remote(self) -> Repo | str | None:
         """Return git remote URL from sibling ``<git>`` node."""
         # TODO: Use Repo as return object?
         node = self.node.getparent().getparent().find("git")
         if node is not None:
-            return Repo(node.attrib.get("remote"))
+            remote_str = node.attrib.get("remote")
+            try:
+                return Repo(remote_str)
+            except ValueError:
+                return remote_str
         return None
 
     # -- Output formats

--- a/tests/cli/cmd_portal/test_cmd_list.py
+++ b/tests/cli/cmd_portal/test_cmd_list.py
@@ -167,3 +167,79 @@ def test_portal_list_no_matching_deliverables(mock_parse, tmp_path) -> None:
 
     assert result.exit_code == 0, result.output
     assert "No deliverables found matching the criteria." in result.output
+
+
+COMPREHENSIVE_MOCK_XML = (
+    '<?xml version="1.0" encoding="UTF-8"?>\n'
+    '<portal schemaversion="7.0">\n'
+    '    <product id="sles">\n'
+    '        <docset path="16.0" lifecycle="supported">\n'
+    '            <resources>\n'
+    '                <git remote="https://github.com/SUSE/doc-modular.git" />\n'
+    '                <locale lang="en-us">\n'
+    '                    <deliverable id="admin_guide" category="tuning-and-performance">\n'
+    '                        <dc file="DC-admin-guide">\n'
+    '                            <format epub="0" html="1" pdf="1" single-html="0"/>\n'
+    '                        </dc>\n'
+    '                    </deliverable>\n'
+    '                    <deliverable id="prebuilt_docs" type="prebuilt">\n'
+    '                        <title>SUSE Docs</title>\n'
+    '                        <prebuilt>\n'
+    '                            <url href="https://documentation.suse.com/sles/" format="html"/>\n'
+    '                        </prebuilt>\n'
+    '                    </deliverable>\n'
+    '                </locale>\n'
+    '                <locale lang="de-de">\n'
+    '                    <deliverable id="admin_guide" category="tuning-and-performance">\n'
+    '                        <dc file="DC-admin-guide">\n'
+    '                            <format epub="0" html="1" pdf="1" single-html="0"/>\n'
+    '                        </dc>\n'
+    '                    </deliverable>\n'
+    '                </locale>\n'
+    '            </resources>\n'
+    '        </docset>\n'
+    '    </product>\n'
+    '</portal>\n'
+)
+
+@patch("docbuild.cli.cmd_portal.cmd_list.parse_portal_config", new_callable=AsyncMock)
+def test_portal_list_metadata_flags(mock_parse, tmp_path) -> None:
+    """Test that all metadata flags successfully inject info into the tree."""
+    runner = CliRunner()
+    mock_parse.return_value = etree.fromstring(COMPREHENSIVE_MOCK_XML.encode("utf-8"))
+
+    mock_ctx = DocBuildContext()
+    mock_ctx.envconfig = MagicMock()
+    mock_ctx.envconfig.paths.main_portal_config.expanduser.return_value = tmp_path / "portal.xml"
+
+    # 1. Test Translations
+    res_trans = runner.invoke(list_cmd, ["--trans"], obj=mock_ctx)
+    assert res_trans.exit_code == 0
+    assert "Translations: de-de" in res_trans.output
+
+    # 2. Test Formats
+    res_formats = runner.invoke(list_cmd, ["--formats"], obj=mock_ctx)
+    assert res_formats.exit_code == 0
+    assert "Formats: HTML, PDF" in res_formats.output
+
+    # 3. Test Categories
+    res_cats = runner.invoke(list_cmd, ["--categories"], obj=mock_ctx)
+    assert res_cats.exit_code == 0
+    assert "Category: Tuning and performance" in res_cats.output
+
+    # 4. Test Repo (Short & Long) - Using flexible assertions for the Repo format
+    res_repo_short = runner.invoke(list_cmd, ["--repo", "short"], obj=mock_ctx)
+    assert res_repo_short.exit_code == 0
+    assert "Repo: " in res_repo_short.output
+    assert "suse/doc-modular" in res_repo_short.output.lower()
+
+    res_repo_long = runner.invoke(list_cmd, ["--repo", "long"], obj=mock_ctx)
+    assert res_repo_long.exit_code == 0
+    assert "Repo: " in res_repo_long.output
+    assert "suse/doc-modular" in res_repo_long.output.lower()
+
+    # 5. Test Prebuilt Titles & URLs (Implicit behavior)
+    res_prebuilt = runner.invoke(list_cmd, [], obj=mock_ctx)
+    assert res_prebuilt.exit_code == 0
+    assert "SUSE Docs (Prebuilt)" in res_prebuilt.output
+    assert "URL: https://documentation.suse.com/sles/" in res_prebuilt.output

--- a/tests/cli/cmd_portal/test_cmd_list.py
+++ b/tests/cli/cmd_portal/test_cmd_list.py
@@ -172,10 +172,16 @@ def test_portal_list_no_matching_deliverables(mock_parse, tmp_path) -> None:
 COMPREHENSIVE_MOCK_XML = (
     '<?xml version="1.0" encoding="UTF-8"?>\n'
     '<portal schemaversion="7.0">\n'
+    '    <categories>\n'
+    '        <category id="tuning-and-performance">\n'
+    '            <title>Tuning and performance</title>\n'
+    '        </category>\n'
+    '    </categories>\n'
     '    <product id="sles">\n'
     '        <docset path="16.0" lifecycle="supported">\n'
     '            <resources>\n'
-    '                <git remote="https://github.com/SUSE/doc-modular.git" />\n'
+    '                <!-- Using Toms exact bug example to prove it does not crash! -->\n'
+    '                <git remote="https://todo" />\n'
     '                <locale lang="en-us">\n'
     '                    <deliverable id="admin_guide" category="tuning-and-performance">\n'
     '                        <dc file="DC-admin-guide">\n'
@@ -222,21 +228,19 @@ def test_portal_list_metadata_flags(mock_parse, tmp_path) -> None:
     assert res_formats.exit_code == 0
     assert "Formats: HTML, PDF" in res_formats.output
 
-    # 3. Test Categories
+    # 3. Test Categories (Now properly resolves from the <categories> block)
     res_cats = runner.invoke(list_cmd, ["--categories"], obj=mock_ctx)
     assert res_cats.exit_code == 0
     assert "Category: Tuning and performance" in res_cats.output
 
-    # 4. Test Repo (Short & Long) - Using flexible assertions for the Repo format
+    # 4. Test Repo (Short & Long) - Explicitly testing the dummy URL fallback
     res_repo_short = runner.invoke(list_cmd, ["--repo", "short"], obj=mock_ctx)
     assert res_repo_short.exit_code == 0
-    assert "Repo: " in res_repo_short.output
-    assert "suse/doc-modular" in res_repo_short.output.lower()
+    assert "Repo: https://todo" in res_repo_short.output
 
     res_repo_long = runner.invoke(list_cmd, ["--repo", "long"], obj=mock_ctx)
     assert res_repo_long.exit_code == 0
-    assert "Repo: " in res_repo_long.output
-    assert "suse/doc-modular" in res_repo_long.output.lower()
+    assert "Repo: https://todo" in res_repo_long.output
 
     # 5. Test Prebuilt Titles & URLs (Implicit behavior)
     res_prebuilt = runner.invoke(list_cmd, [], obj=mock_ctx)

--- a/tests/cli/cmd_portal/test_cmd_list.py
+++ b/tests/cli/cmd_portal/test_cmd_list.py
@@ -178,10 +178,10 @@ COMPREHENSIVE_MOCK_XML = (
     '        </category>\n'
     '    </categories>\n'
     '    <product id="sles">\n'
+    '        \n'
     '        <docset path="16.0" lifecycle="supported">\n'
     '            <resources>\n'
-    '                <!-- Using Toms exact bug example to prove it does not crash! -->\n'
-    '                <git remote="https://todo" />\n'
+    '                <git remote="https://github.com/SUSE/doc-modular.git" />\n'
     '                <locale lang="en-us">\n'
     '                    <deliverable id="admin_guide" category="tuning-and-performance">\n'
     '                        <dc file="DC-admin-guide">\n'
@@ -200,6 +200,17 @@ COMPREHENSIVE_MOCK_XML = (
     '                        <dc file="DC-admin-guide">\n'
     '                            <format epub="0" html="1" pdf="1" single-html="0"/>\n'
     '                        </dc>\n'
+    '                    </deliverable>\n'
+    '                </locale>\n'
+    '            </resources>\n'
+    '        </docset>\n'
+    '        \n'
+    '        <docset path="invalid-repo" lifecycle="supported">\n'
+    '            <resources>\n'
+    '                <git remote="https://todo" />\n'
+    '                <locale lang="en-us">\n'
+    '                    <deliverable id="bad_repo_doc">\n'
+    '                        <dc file="DC-bad-repo" />\n'
     '                    </deliverable>\n'
     '                </locale>\n'
     '            </resources>\n'
@@ -228,22 +239,37 @@ def test_portal_list_metadata_flags(mock_parse, tmp_path) -> None:
     assert res_formats.exit_code == 0
     assert "Formats: HTML, PDF" in res_formats.output
 
-    # 3. Test Categories (Now properly resolves from the <categories> block)
+    # 3. Test Categories
     res_cats = runner.invoke(list_cmd, ["--categories"], obj=mock_ctx)
     assert res_cats.exit_code == 0
     assert "Category: Tuning and performance" in res_cats.output
 
-    # 4. Test Repo (Short & Long) - Explicitly testing the dummy URL fallback
+    # 4. Test Repo (Short & Long) - Explicitly testing valid surl AND dummy URL fallback
     res_repo_short = runner.invoke(list_cmd, ["--repo", "short"], obj=mock_ctx)
     assert res_repo_short.exit_code == 0
-    assert "Repo: https://todo" in res_repo_short.output
+    assert "gh://suse/doc-modular" in res_repo_short.output.lower()      # Valid short (no .git)
+    assert "Repo: https://todo" in res_repo_short.output                 # Fallback short
 
     res_repo_long = runner.invoke(list_cmd, ["--repo", "long"], obj=mock_ctx)
     assert res_repo_long.exit_code == 0
-    assert "Repo: https://todo" in res_repo_long.output
+    assert "https://github.com/suse/doc-modular.git" in res_repo_long.output.lower() # Valid long
+    assert "Repo: https://todo" in res_repo_long.output                              # Fallback long
 
     # 5. Test Prebuilt Titles & URLs (Implicit behavior)
     res_prebuilt = runner.invoke(list_cmd, [], obj=mock_ctx)
     assert res_prebuilt.exit_code == 0
     assert "SUSE Docs (Prebuilt)" in res_prebuilt.output
     assert "URL: https://documentation.suse.com/sles/" in res_prebuilt.output
+
+
+def test_portal_list_repo_requires_argument() -> None:
+    """Test that omitting 'short' or 'long' for the -R flag correctly throws a Click error."""
+    runner = CliRunner()
+    mock_ctx = DocBuildContext()
+    
+    # Passing a doctype argument immediately after -R.
+    result = runner.invoke(list_cmd, ["-R", "sles/16.0"], obj=mock_ctx)
+    
+    assert result.exit_code != 0
+    assert "Invalid value for '--repo' / '-R'" in result.output
+    assert "is not one of 'short', 'long'" in result.output

--- a/tests/cli/cmd_portal/test_cmd_list.py
+++ b/tests/cli/cmd_portal/test_cmd_list.py
@@ -17,7 +17,7 @@ def test_portal_list_help() -> None:
     assert result.exit_code == 0
     assert "List products, docsets, and deliverables from the portal config." in result.output
     assert "Format:" in result.output
-    assert "[PRODUCT]" in result.output
+    assert "PRODUCT/DOCSETS" in result.output
 
 
 def test_portal_list_no_main_config(tmp_path) -> None:
@@ -169,55 +169,51 @@ def test_portal_list_no_matching_deliverables(mock_parse, tmp_path) -> None:
     assert "No deliverables found matching the criteria." in result.output
 
 
-COMPREHENSIVE_MOCK_XML = (
-    '<?xml version="1.0" encoding="UTF-8"?>\n'
-    '<portal schemaversion="7.0">\n'
-    '    <categories>\n'
-    '        <category id="tuning-and-performance">\n'
-    '            <title>Tuning and performance</title>\n'
-    '        </category>\n'
-    '    </categories>\n'
-    '    <product id="sles">\n'
-    '        \n'
-    '        <docset path="16.0" lifecycle="supported">\n'
-    '            <resources>\n'
-    '                <git remote="https://github.com/SUSE/doc-modular.git" />\n'
-    '                <locale lang="en-us">\n'
-    '                    <deliverable id="admin_guide" category="tuning-and-performance">\n'
-    '                        <dc file="DC-admin-guide">\n'
-    '                            <format epub="0" html="1" pdf="1" single-html="0"/>\n'
-    '                        </dc>\n'
-    '                    </deliverable>\n'
-    '                    <deliverable id="prebuilt_docs" type="prebuilt">\n'
-    '                        <title>SUSE Docs</title>\n'
-    '                        <prebuilt>\n'
-    '                            <url href="https://documentation.suse.com/sles/" format="html"/>\n'
-    '                        </prebuilt>\n'
-    '                    </deliverable>\n'
-    '                </locale>\n'
-    '                <locale lang="de-de">\n'
-    '                    <deliverable id="admin_guide" category="tuning-and-performance">\n'
-    '                        <dc file="DC-admin-guide">\n'
-    '                            <format epub="0" html="1" pdf="1" single-html="0"/>\n'
-    '                        </dc>\n'
-    '                    </deliverable>\n'
-    '                </locale>\n'
-    '            </resources>\n'
-    '        </docset>\n'
-    '        \n'
-    '        <docset path="invalid-repo" lifecycle="supported">\n'
-    '            <resources>\n'
-    '                <git remote="https://todo" />\n'
-    '                <locale lang="en-us">\n'
-    '                    <deliverable id="bad_repo_doc">\n'
-    '                        <dc file="DC-bad-repo" />\n'
-    '                    </deliverable>\n'
-    '                </locale>\n'
-    '            </resources>\n'
-    '        </docset>\n'
-    '    </product>\n'
-    '</portal>\n'
-)
+COMPREHENSIVE_MOCK_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<portal schemaversion="7.0">
+    <categories>
+        <category lang="en-us">
+            <language id="tuning-and-performance" title="Tuning and performance" />
+        </category>
+    </categories>
+    <product id="sles">=
+        <docset path="16.0" lifecycle="supported">
+            <resources>
+                <git remote="https://github.com/SUSE/doc-modular.git" />
+                <locale lang="en-us">
+                    <deliverable id="admin_guide" category="tuning-and-performance">
+                        <dc file="DC-admin-guide">
+                            <format epub="0" html="1" pdf="1" single-html="0"/>
+                        </dc>
+                    </deliverable>
+                    <deliverable id="prebuilt_docs" type="prebuilt">
+                        <title>SUSE Docs</title>
+                        <prebuilt>
+                            <url href="https://documentation.suse.com/sles/" format="html"/>
+                        </prebuilt>
+                    </deliverable>
+                </locale>
+                <locale lang="de-de">
+                    <deliverable id="admin_guide" category="tuning-and-performance">
+                        <ref linkend="admin_guide"/>
+                    </deliverable>
+                </locale>
+            </resources>
+        </docset>
+
+        <docset path="invalid-repo" lifecycle="supported">
+            <resources>
+                <git remote="https://todo" />
+                <locale lang="en-us">
+                    <deliverable id="bad_repo_doc">
+                        <dc file="DC-bad-repo" />
+                    </deliverable>
+                </locale>
+            </resources>
+        </docset>
+    </product>
+</portal>
+"""
 
 @patch("docbuild.cli.cmd_portal.cmd_list.parse_portal_config", new_callable=AsyncMock)
 def test_portal_list_metadata_flags(mock_parse, tmp_path) -> None:

--- a/tests/cli/cmd_portal/test_cmd_list.py
+++ b/tests/cli/cmd_portal/test_cmd_list.py
@@ -266,10 +266,10 @@ def test_portal_list_repo_requires_argument() -> None:
     """Test that omitting 'short' or 'long' for the -R flag correctly throws a Click error."""
     runner = CliRunner()
     mock_ctx = DocBuildContext()
-    
+
     # Passing a doctype argument immediately after -R.
     result = runner.invoke(list_cmd, ["-R", "sles/16.0"], obj=mock_ctx)
-    
+
     assert result.exit_code != 0
     assert "Invalid value for '--repo' / '-R'" in result.output
     assert "is not one of 'short', 'long'" in result.output

--- a/tests/models/deliverables/test_view.py
+++ b/tests/models/deliverables/test_view.py
@@ -169,7 +169,9 @@ def test_xml_translations() -> None:
                         <deliverable id="test" />
                     </locale>
                     <locale lang="de-de">
-                        <deliverable id="test" />
+                        <deliverable id="test_translation">
+                            <ref linkend="test" />
+                        </deliverable>
                     </locale>
                     <locale lang="ja-jp">
                         <deliverable id="other_doc" />
@@ -182,7 +184,7 @@ def test_xml_translations() -> None:
     node = etree.fromstring(xml_content).xpath("//locale[@lang='en-us']/deliverable")[0]
     view = DeliverableXMLView(node)
 
-    # Should find en-us and de-de, but ignore ja-jp since it's a different deliverable ID
+    # Should find en-us and de-de, but ignore ja-jp since it doesn't reference 'test'
     assert view.translations == {"en-us", "de-de"}
 
 
@@ -192,11 +194,9 @@ def test_xml_category_title() -> None:
     <portal>
         <product id="p1">
             <categories>
-                <category id="cat-title">
-                    <title>Has Title Element</title>
-                </category>
-                <category id="cat-name">
-                    <name>Has Name Element</name>
+                <category lang="en-us">
+                  <language id="cat-title" title="Has Title Element" />
+                  <language id="cat-name" title="Has Name Element" />
                 </category>
             </categories>
             <docset path="d1">

--- a/tests/models/deliverables/test_view.py
+++ b/tests/models/deliverables/test_view.py
@@ -1,6 +1,6 @@
 """Branch, subdir, and repository tests for deliverables."""
 
-from lxml import etree
+from lxml import etree  # type: ignore
 import pytest
 
 from docbuild.models.deliverable import Deliverable
@@ -128,9 +128,97 @@ def test_format_attrs_dc_missing_format() -> None:
     xml_dc_no_format = """
     <deliverable type="dc">
         <dc file="DC-test">
-          <!-- no <format /> -->
-        </dc>
+          </dc>
     </deliverable>
     """
     view = DeliverableXMLView(etree.fromstring(xml_dc_no_format))
     assert view.format_attrs() is None
+
+
+def test_xml_git_remote_fallback_invalid_url() -> None:
+    """Test git_remote() gracefully falls back to string on invalid URLs."""
+    xml_content = """
+    <portal>
+        <product id="p1">
+            <docset path="d1">
+                <resources>
+                    <git remote="https://todo" />
+                    <locale lang="en-us">
+                        <deliverable id="test" />
+                    </locale>
+                </resources>
+            </docset>
+        </product>
+    </portal>
+    """
+    node = etree.fromstring(xml_content).xpath("//deliverable")[0]
+    view = DeliverableXMLView(node)
+
+    # Should safely return the raw string instead of throwing a ValueError
+    assert view.git_remote() == "https://todo"
+
+
+def test_xml_translations() -> None:
+    """Test translations property dynamically finds other locales."""
+    xml_content = """
+    <portal>
+        <product id="p1">
+            <docset path="d1">
+                <resources>
+                    <locale lang="en-us">
+                        <deliverable id="test" />
+                    </locale>
+                    <locale lang="de-de">
+                        <deliverable id="test" />
+                    </locale>
+                    <locale lang="ja-jp">
+                        <deliverable id="other_doc" />
+                    </locale>
+                </resources>
+            </docset>
+        </product>
+    </portal>
+    """
+    node = etree.fromstring(xml_content).xpath("//locale[@lang='en-us']/deliverable")[0]
+    view = DeliverableXMLView(node)
+
+    # Should find en-us and de-de, but ignore ja-jp since it's a different deliverable ID
+    assert view.translations == {"en-us", "de-de"}
+
+
+def test_xml_category_title() -> None:
+    """Test category_title safely resolves titles, names, and ID fallbacks."""
+    xml_content = """
+    <portal>
+        <product id="p1">
+            <categories>
+                <category id="cat-title">
+                    <title>Has Title Element</title>
+                </category>
+                <category id="cat-name">
+                    <name>Has Name Element</name>
+                </category>
+            </categories>
+            <docset path="d1">
+                <resources>
+                    <locale lang="en-us">
+                        <deliverable id="d1" category="cat-title" />
+                        <deliverable id="d2" category="cat-name" />
+                        <deliverable id="d3" category="cat-missing" />
+                        <deliverable id="d4" />
+                    </locale>
+                </resources>
+            </docset>
+        </product>
+    </portal>
+    """
+    root = etree.fromstring(xml_content)
+    d1 = DeliverableXMLView(root.xpath("//deliverable[@id='d1']")[0])
+    d2 = DeliverableXMLView(root.xpath("//deliverable[@id='d2']")[0])
+    d3 = DeliverableXMLView(root.xpath("//deliverable[@id='d3']")[0])
+    d4 = DeliverableXMLView(root.xpath("//deliverable[@id='d4']")[0])
+
+    assert d1.category_title == "Has Title Element"
+    assert d2.category_title == "Has Name Element"
+    assert d3.category_title == "cat-missing"  # Falls back to raw ID if not defined in <categories>
+    assert d4.category_title is None           # No category assigned


### PR DESCRIPTION
Closes #302

This PR enhances the `portal list` command by allowing users to append metadata (translations, formats, categories, and repositories) directly to the terminal tree output using CLI flags. It also improves default rendering by properly recognizing and displaying prebuilt deliverable titles and URLs.

### Changes

* **Translations (`-T`, `--trans`):** Uses an XPath sideways lookup to discover all other translated locales for a given deliverable.
* **Formats (`-F`, `--formats`):** Displays available formats (PDF, HTML, etc.).
* **Categories (`-C`, `--categories`):** Appends the deliverable category, cleanly formatted.
* **Repositories (`-R`, `--repo`):** Adds a `--repo` option that defaults to `short` (e.g., `gh://SUSE/doc-modular`) but can accept `long` to display full URLs.
* **Prebuilt Docs:** Implicitly updates the tree root node to use the `<title>` (if available) with a `(Prebuilt)` suffix, and automatically lists embedded URLs underneath.
* Added comprehensive mock testing.