### PR TITLE
Add skip-changelog label for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,4 @@ updates:
       - "tomschr"
     labels:
       - "area:dependencies"
+      - "skip-changelog"

--- a/changelog.d/344.infra.rst
+++ b/changelog.d/344.infra.rst
@@ -1,0 +1,3 @@
+When Dependabot creates a PR, the ``check-changelog`` workflow checks for a newsfragment file.
+As Dependabot never creates one, we need to skip this check with adding the ``skip-changelog``.
+


### PR DESCRIPTION
When Dependabot creates a PR, the check-changelog workflow checks for a newsfragment file. As Dependabot never creates one, we need to skip this check with adding the `skip-changelog`.
