### PR TITLE
ci: dynamically build changelog for the latest documentation (#323)

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -55,7 +55,12 @@ jobs:
 
       - name: Build Changelog
         if: github.ref_type != 'tag'
-        run: uv run --frozen --no-sync towncrier build --yes --version "${{ env.DOC_VERSION }}"
+        run: |
+          if find changelog.d -maxdepth 1 -type f -name '*.rst' ! -name 'README.rst' ! -name '_template.rst' -print -quit | grep -q .; then
+            uv run --frozen --no-sync towncrier build --yes --version "${{ env.DOC_VERSION }}"
+          else
+            echo "No news fragments found; skipping Towncrier build."
+          fi
 
       - name: Build documentation
         env:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -57,7 +57,7 @@ jobs:
         if: github.ref_type != 'tag'
         run: |
           if find changelog.d -maxdepth 1 -type f -name '*.rst' ! -name 'README.rst' ! -name '_template.rst' -print -quit | grep -q .; then
-            uv run --frozen --no-sync towncrier build --yes --version "${{ env.DOC_VERSION }}"
+            uv run --frozen --no-sync towncrier build --yes --keep --version "${{ env.DOC_VERSION }}"
           else
             echo "No news fragments found; skipping Towncrier build."
           fi

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,6 +12,7 @@ on:
       - 'docs/**'
       - '.github/workflows/gh-pages.yml'
       - 'src/docbuild/__about__.py'
+      - 'changelog.d/**'
 
 permissions:
   contents: write

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -47,12 +47,13 @@ jobs:
           echo "Set Python version is ${{ steps.setup-uv.outputs.python-version }}"
 
       - name: Install dependencies
-        run: uv sync --frozen --group docs
+        run: uv sync --frozen --group docs --group changelog
 
       - name: Determine documentation version
         run: ${{ env.CI_BIN_DIR }}/determine-version.sh
 
       - name: Build Changelog
+        if: github.ref_type != 'tag'
         run: uv run --frozen --no-sync towncrier build --yes --version "${{ env.DOC_VERSION }}"
 
       - name: Build documentation

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Determine documentation version
         run: ${{ env.CI_BIN_DIR }}/determine-version.sh
 
+      - name: Build Changelog
+        run: uv run --frozen --no-sync towncrier build --yes --version "${{ env.DOC_VERSION }}"
+
       - name: Build documentation
         env:
           DOC_VERSION: ${{ env.DOC_VERSION }}

--- a/changelog.d/323.infra.rst
+++ b/changelog.d/323.infra.rst
@@ -1,0 +1,1 @@
+Added a step in the GitHub Pages CI workflow to dynamically build the changelog using Towncrier, ensuring the ``latest`` documentation page reflects the most recent unreleased entries.


### PR DESCRIPTION
Closes #323

### Changes Made

* Added a `Build Changelog` step to `.github/workflows/gh-pages.yml` using `towncrier`.
* This step runs right before `Build documentation` and dynamically compiles all unreleased fragments using the current `DOC_VERSION`.
* This ensures our `latest` documentation accurately reflects all current, unreleased work and provides early CI feedback if a fragment file is malformed.
* Added the corresponding news fragment file (`323.infra.rst`).

### Self-Review Checklist

**Conventions & Implementation**
- [x] Code is well-structured and easy to follow.
- [x] Implementation executes the exact Towncrier command necessary without disrupting the existing Sphinx build environment.
- [N/A] Ruff/Type Annotations (YAML CI infrastructure update).

**Documentation & CI**
- [x] Does the issue need a documentation update? (This *is* an infra update for the docs!)
- [x] Does the documentation build without errors? (The `towncrier build` step is placed properly to generate the file before `make html` runs).
- [x] Does the news fragment file exist?