### PR TITLE
docs: differentiate shell commands from their output using '$'

### DIFF
--- a/changelog.d/349.doc.rst
+++ b/changelog.d/349.doc.rst
@@ -1,0 +1,1 @@
+Differentiate shell commands from their output across all shell code-blocks.

--- a/docs/source/developer/build-changelog.rst
+++ b/docs/source/developer/build-changelog.rst
@@ -16,7 +16,7 @@ To build the changelog, make sure you have:
    .. code-block:: shell-session
       :caption: Build a combined changelog from news fragments
 
-      towncrier build [--yes]
+      $ towncrier build [--yes]
 
    After this command, the :file:`CHANGELOG.rst` file in the root directory is updated and all news fragments are removed from the directory :file:`changelog.d/`.
 

--- a/docs/source/developer/build-docs.rst
+++ b/docs/source/developer/build-docs.rst
@@ -12,14 +12,14 @@ To build the documentation for this project, use the following steps:
    .. code-block:: shell-session
       :name: makedocs
 
-      makedocs
+      $ makedocs
 
    If you want to have a bit more control, use this command:
 
    .. code-block:: shell-session
       :name: sphinx-build
 
-      uv run --frozen --no-sync make -C docs html
+      $ uv run --frozen --no-sync make -C docs html
 
 #. Watch for warnings and errors during the build process.
    If you encounter any issues, review the output and fix them accordingly.

--- a/docs/source/developer/bump-version.rst
+++ b/docs/source/developer/bump-version.rst
@@ -10,7 +10,7 @@ This project follows :term:`Semantic Versioning <SemVer>`. To bump the version, 
    :caption: Bumping the minor part
    :name: sh-bump-version
 
-   ./devel/bump-version.sh minor
+   $ ./devel/bump-version.sh minor
 
 This script automates the versioning process with the following actions:
 

--- a/docs/source/developer/prepare-environment.rst
+++ b/docs/source/developer/prepare-environment.rst
@@ -72,10 +72,10 @@ The following steps are recommended to set up your development environment:
       :caption: Creating a virtual environment with |uv|
       :name: uv-venv
 
-      uv venv --prompt venv313 --python 3.13 .venv
+      $ uv venv --prompt venv313 --python 3.13 .venv
 
    Keep in mind that the Python version used in the virtual environment should match the version specified in the :file:`pyproject.toml` file.
-   
+
    The example above uses Python 3.13, but you can adjust it according to your needs as long as it is compatible with the project.
    See file :file:`pyproject.toml` in ``project.requires-python`` for the exact version.
 
@@ -85,7 +85,7 @@ The following steps are recommended to set up your development environment:
       :caption: Synchronizing the virtual environment with the development dependencies
       :name: uv-sync-devel
 
-      uv sync --frozen --group devel
+      $ uv sync --frozen --group devel
 
    The option ``--frozen`` ensures that the dependencies are installed exactly as specified in the lock file, preventing any unexpected changes.
 
@@ -95,7 +95,7 @@ The following steps are recommended to set up your development environment:
       :caption: Activating the shell aliases for development
       :name: activate-aliases
 
-      source devel/activate-aliases.sh
+      $ source devel/activate-aliases.sh
 
 
 After completing these steps, your development environment is ready to go.
@@ -113,7 +113,7 @@ To get started, clone this repository to your local machine (you need VPN access
 
 .. code-block:: shell-session
 
-   git clone https://gitlab.suse.de/susedoc/docserv-config.git
+   $ git clone https://gitlab.suse.de/susedoc/docserv-config.git
 
 You will later need to point ``docbuild`` to the location of this cloned
 repository in your configuration.

--- a/docs/source/developer/run-ipython.rst
+++ b/docs/source/developer/run-ipython.rst
@@ -14,7 +14,7 @@ This is useful for experimenting with the project's code and for debugging.
 .. code-block:: shell-session
    :caption: Running IPython using |uv| with alias :ref:`uipython <devel-helpers>`
 
-   uipython
+   $ uipython
 
 
 After the IPython shell is loaded, you can use the normal import without changing the import path:

--- a/docs/source/developer/run-testsuite.rst
+++ b/docs/source/developer/run-testsuite.rst
@@ -15,7 +15,7 @@ To run the full test suite, use the following command:
    :caption: Running pytest directly with |uv|
    :name: running-pytest-with-uv
 
-   uv run --frozen --no-sync pytest
+   $ uv run --frozen --no-sync pytest
 
 or use the alias (see :ref:`devel-helpers` for more information):
 
@@ -23,7 +23,7 @@ or use the alias (see :ref:`devel-helpers` for more information):
    :caption: Running pytest using |uv| with alias :ref:`upytest <devel-helpers>`
    :name: running-upytest
 
-   upytest
+   $ upytest
 
 This command will execute all the tests defined in the project. The test suite is designed to ensure that all components of the project are functioning correctly and to catch any regressions.
 
@@ -36,8 +36,8 @@ In case you want to run a specific test or a subset of tests, specify the path t
    :caption: Running specific tests
    :name: running-specific-tests
 
-   upytest tests/test_module.py
-   upytest tests/test_module.py::test_function_name
+   $ upytest tests/test_module.py
+   $ upytest tests/test_module.py::test_function_name
 
 In the first example, all tests in `test_module.py` will be executed, while in the second example, only the specific test function `test_function_name` will be run.
 
@@ -50,7 +50,7 @@ If one of the test fails and you want to repeat the test run after you have fixe
    :caption: Running only the last failed tests
    :name: running-last-failed-tests
 
-   upytest --lf
+   $ upytest --lf
 
 
 .. _interprete-coverage:

--- a/docs/source/developer/update-package.rst
+++ b/docs/source/developer/update-package.rst
@@ -8,5 +8,4 @@ time keep the development group dependencies intact, use the following command:
 
 .. code-block:: shell-session
 
-   uv sync --group devel --upgrade-package pydantic-core
-
+   $ uv sync --group devel --upgrade-package pydantic-core

--- a/docs/source/developer/update-project.rst
+++ b/docs/source/developer/update-project.rst
@@ -13,5 +13,4 @@ In some cases, it may be helpful to manually update the project.
    :caption: Updating the project
    :name: uv-pip-update-project
 
-   uv pip install --upgrade -e .
-
+   $ uv pip install --upgrade -e .

--- a/docs/source/user/check-env.rst
+++ b/docs/source/user/check-env.rst
@@ -19,7 +19,7 @@ To check all DC files in all repositories, use the following command:
 .. code-block:: shell-session
    :caption: Checking DC files in all repositories
 
-   docbuild --env-config ENV_CONFIG_FILE check dc-files
+   $ docbuild --env-config ENV_CONFIG_FILE check dc-files
 
 To check DC files only for a specific product and docset, use the doctype
 syntax:
@@ -27,7 +27,7 @@ syntax:
 .. code-block:: shell-session
    :caption: Checking DC files for SLES 16.0 in English only
 
-   docbuild --env-config ENV_CONFIG_FILE check dc-files 'sles/16.0/en-us'
+   $ docbuild --env-config ENV_CONFIG_FILE check dc-files 'sles/16.0/en-us'
 
 If a DC file is missing, the tool will report it, allowing you to take
 corrective action.

--- a/docs/source/user/config.rst
+++ b/docs/source/user/config.rst
@@ -62,14 +62,14 @@ The validation checks for different aspects of the configuration, such as:
 Detailed Validation Feedback
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If the configuration is invalid, the application provides a structured, 
-color-coded error report to help you identify and fix the issues. Each error 
+If the configuration is invalid, the application provides a structured,
+color-coded error report to help you identify and fix the issues. Each error
 includes:
 
 * **Location**: The exact path in the TOML file (e.g., ``server.host``).
 * **Field Info**: A human-readable title and description of the field's purpose.
 * **Error Detail**: A specific message explaining why the value failed validation.
-* **Documentation Link**: A direct URL to a reference page with more details 
+* **Documentation Link**: A direct URL to a reference page with more details
   on how to resolve that specific error type.
 
 Example error output:
@@ -90,11 +90,11 @@ Fixing Common Issues
 If you encounter validation errors, check the following common causes:
 
 * **Missing Keys**: Ensure all mandatory fields (like ``paths.root_config_dir``) are defined.
-* **Typing Errors**: Ensure booleans (``true``/``false``) and integers are not enclosed 
+* **Typing Errors**: Ensure booleans (``true``/``false``) and integers are not enclosed
   in quotes.
-* **Permission Issues**: If a path error occurs, verify that the user running 
+* **Permission Issues**: If a path error occurs, verify that the user running
   ``docbuild`` has the necessary read/write permissions for the specified directory.
-* **Circular Placeholders**: Ensure that your static placeholders do not point 
+* **Circular Placeholders**: Ensure that your static placeholders do not point
   to each other in a loop (e.g., Key A referencing Key B, which references Key A).
 
 
@@ -172,7 +172,7 @@ static placeholders have been correctly resolved into absolute paths.
 .. code-block:: shell-session
    :caption: Displaying the resolved environment configuration
 
-   docbuild --env-config=YOUR_TOML_CONFIG config env
+   $ docbuild --env-config=YOUR_TOML_CONFIG config env
 
 If the configuration contains errors—such as missing mandatory keys or invalid data types—the command will output a validation error detailing what needs to be fixed.
 
@@ -190,6 +190,6 @@ between configurations without needing to remember the exact command syntax.
    :caption: Example aliases for different configuration files
    :name: docbuild-aliases
 
-   alias docbuild-prod='docbuild --env-config env.production.toml'
-   alias docbuild-test='docbuild --env-config env.testing.toml'
-   alias docbuild-dev='docbuild --env-config env.devel.toml'
+   $ alias docbuild-prod='docbuild --env-config env.production.toml'
+   $ alias docbuild-test='docbuild --env-config env.testing.toml'
+   $ alias docbuild-dev='docbuild --env-config env.devel.toml'

--- a/docs/source/user/install.rst
+++ b/docs/source/user/install.rst
@@ -29,7 +29,7 @@ There are different methods to install the :command:`uv` package manager
 
    .. code-block:: shell-session
 
-      curl -sSfL https://astral.sh/uv/install.sh | sh
+      $ curl -sSfL https://astral.sh/uv/install.sh | sh
 
 
    This will install two commands :command:`uv` and :command:`uvx` in :file:`~/.local/bin/`. Make sure this directory is in your :envvar:`PATH` environment variable.
@@ -40,9 +40,9 @@ There are different methods to install the :command:`uv` package manager
 
    .. code-block:: shell-session
 
-      type uv
+      $ type uv
       uv is hashed (/home/tux/.local/bin/uv)
-      uv --version
+      $ uv --version
       ...
 
    You should see the version of :command:`uv` printed in the terminal.
@@ -53,7 +53,7 @@ There are different methods to install the :command:`uv` package manager
 
    .. code-block:: shell-session
 
-      uv python install 3.13
+      $ uv python install 3.13
 
    The previous command downloads Python 3.13 and install it in the directory :file:`~/.local/share/uv/python/<VERSION>`.
 
@@ -63,7 +63,7 @@ There are different methods to install the :command:`uv` package manager
 
    .. code-block:: shell-session
 
-      uv python list
+      $ uv python list
       cpython-3.14.0b1-linux-x86_64-gnu                 <download available>
       cpython-3.14.0b1+freethreaded-linux-x86_64-gnu    <download available>
       cpython-3.13.4-linux-x86_64-gnu                   /home/tux/.local/share/uv/python/cpython-3.13.4-linux-x86_64-gnu/bin/python3.13
@@ -83,8 +83,8 @@ Installing the tool
 
    .. code-block:: shell-session
 
-      git clone https://github.com/openSUSE/docbuild.git
-      cd docbuild
+      $ git clone https://github.com/openSUSE/docbuild.git
+      $ cd docbuild
 
 2. **Create a virtual environment**
 
@@ -93,7 +93,7 @@ Installing the tool
 
    .. code-block:: shell-session
 
-      uv venv --prompt "venv313" .venv
+      $ uv venv --prompt "venv313" .venv
 
    This will create a virtual environment in the directory `.venv`.
 
@@ -103,7 +103,7 @@ Installing the tool
 
    .. code-block:: shell-session
 
-      uv sync --frozen
+      $ uv sync --frozen
       Resolved 29 packages in 586ms
       Built docbuild @ file:///.../docbuild
       Installed 15 packages in 2.11s

--- a/docs/source/user/metadata.rst
+++ b/docs/source/user/metadata.rst
@@ -1,13 +1,13 @@
 Creating Metadata
 =================
 
-The :command:`docbuild metadata` subcommand is used to create metadata from a :command:`daps metadata` call. 
+The :command:`docbuild metadata` subcommand is used to create metadata from a :command:`daps metadata` call.
 
 
 .. code-block:: shell
    :caption: Synopsis of :command:`docbuild metadata`
 
-   docbuild metadata [OPTIONS] [DOCTYPES]...
+   $ docbuild metadata [OPTIONS] [DOCTYPES]...
 
 The process does this:
 

--- a/docs/source/user/portal-config/create-product.rst
+++ b/docs/source/user/portal-config/create-product.rst
@@ -8,19 +8,19 @@ a new product, proceed as follows:
 
 #. Determine the product ID.
 
-   This unique ID is used in several places in the configuration. 
+   This unique ID is used in several places in the configuration.
    The product ID should be short and descriptive.
    In this example, we assume we were asked to create a new product about
    NAS functionality.
-   A good product ID would be ``nas``. 
+   A good product ID would be ``nas``.
 
 #. In your configuration directory :file:`config.d/`, create a new
    directory and the configuration file for the product:
 
    .. code-block:: shell
 
-        mkdir -p config.d/nas
-        touch config.d/nas/nas.xml
+        $ mkdir -p config.d/nas
+        $ touch config.d/nas/nas.xml
 
 #. Edit the product configuration file and add the following content:
 

--- a/docs/source/user/portal-config/validate-portal.rst
+++ b/docs/source/user/portal-config/validate-portal.rst
@@ -10,7 +10,7 @@ Portal schema.
 .. code-block:: shell
    :caption: Synopsis of :command:`docbuild portal validate`
 
-   docbuild portal validate [OPTIONS]
+   $ docbuild portal validate [OPTIONS]
 
 
 Calling it with just the ENV configuration will validate it according to the

--- a/docs/source/user/run-docbuild.rst
+++ b/docs/source/user/run-docbuild.rst
@@ -6,10 +6,10 @@ If you have installed the docbuild tool from the source code, run it using
 
 .. code-block:: shell-session
 
-   uv run docbuild --help
+   $ uv run docbuild --help
 
 In case you have installed different Python versions using :command:`uv python install` (see :ref:`prepare-installation`), specify the Python version to use with the ``-P``/``--python <VERSION>`` option:
 
 .. code-block:: shell-session
 
-   uv run --python 3.14 docbuild --help
+   $ uv run --python 3.14 docbuild --help

--- a/docs/source/user/validate.rst
+++ b/docs/source/user/validate.rst
@@ -6,7 +6,7 @@ The :command:`docbuild config validate` subcommand is used to verify that your T
 .. code-block:: shell
    :caption: Synopsis of :command:`docbuild config validate`
 
-   docbuild config validate [OPTIONS]
+   $ docbuild config validate [OPTIONS]
 
 The tool validates:
 


### PR DESCRIPTION
in order to mitigate potential reader confusion.
This has already been done in other doc files e.g. `user/portal-config/validate-portal.rst`.
These changes unify the practice across all shell code blocks.