### PR TITLE
docs: create common set of AI agent skills

### DIFF
--- a/.agents/skills/docbuild-alias/SKILL.md
+++ b/.agents/skills/docbuild-alias/SKILL.md
@@ -1,0 +1,21 @@
+# Skill - Running the docbuild tool via Custom Aliases
+
+## Context
+
+This repository provides custom shell aliases to make running tasks easier without needing to type long `uv run` commands constantly. 
+
+## Procedure
+
+1. Before attempting to run custom repository commands, you must source the alias script.
+2. Run: `source devel/activate-aliases.sh`
+3. Once sourced, you can use the custom aliases available in the environment (for example, `docbuild`, `upytest`, `makedocs`).
+4. To run the main CLI tool, simply use the `docbuild` alias followed by the relevant command (for example, `docbuild portal list`).
+
+## Checklist
+
+- [ ] Did you run `source devel/activate-aliases.sh` in the current terminal session?
+- [ ] Are you using the alias directly instead of invoking python/uv manually?
+
+## Validation
+
+Run `alias` or `type docbuild` in the terminal to verify the alias is active before attempting to build or test.

--- a/.agents/skills/docbuild-alias/SKILL.md
+++ b/.agents/skills/docbuild-alias/SKILL.md
@@ -9,8 +9,8 @@ This repository provides custom shell aliases to make running tasks easier witho
 1. Before attempting to run custom repository commands, you must source the alias script.
 2. Run: `source devel/activate-aliases.sh`
 3. Once sourced, you can use the custom aliases available in the environment (for example, `docbuild`, `upytest`, `makedocs`).
-4. **CRITICAL**: To run the main CLI tool, you must *always* use a dedicated development environment configuration to avoid conflicting with or polluting the developer's local host state. 
-5. Always run commands using the `--env-config` flag pointing to the development config (for example, `docbuild --env-config env.development.toml portal list`). Do not run `docbuild` without an isolated environment configuration.
+4. **CRITICAL**: To run the main CLI tool, you must *always* use the dedicated agent environment configuration to avoid conflicting with or polluting the human developer's local host state.
+5. Always run commands using the `--env-config` flag pointing to the agent config: `docbuild --env-config env.agent.toml <command>`. Do not run `docbuild` without this isolated environment configuration.
 
 ## Checklist
 

--- a/.agents/skills/docbuild-alias/SKILL.md
+++ b/.agents/skills/docbuild-alias/SKILL.md
@@ -9,7 +9,8 @@ This repository provides custom shell aliases to make running tasks easier witho
 1. Before attempting to run custom repository commands, you must source the alias script.
 2. Run: `source devel/activate-aliases.sh`
 3. Once sourced, you can use the custom aliases available in the environment (for example, `docbuild`, `upytest`, `makedocs`).
-4. To run the main CLI tool, simply use the `docbuild` alias followed by the relevant command (for example, `docbuild portal list`).
+4. **CRITICAL**: To run the main CLI tool, you must *always* use a dedicated development environment configuration to avoid conflicting with or polluting the developer's local host state. 
+5. Always run commands using the `--env-config` flag pointing to the development config (for example, `docbuild --env-config env.development.toml portal list`). Do not run `docbuild` without an isolated environment configuration.
 
 ## Checklist
 

--- a/.agents/skills/documentation/SKILL.md
+++ b/.agents/skills/documentation/SKILL.md
@@ -1,4 +1,4 @@
-# Skill -  Creating and Building Documentation
+# Skill - Creating and Building Documentation
 
 ## Context
 

--- a/.agents/skills/documentation/SKILL.md
+++ b/.agents/skills/documentation/SKILL.md
@@ -1,0 +1,25 @@
+# Skill -  Creating and Building Documentation
+
+## Context
+
+This project uses Sphinx for documentation. The source files are written in reStructuredText (.rst) and the configuration is handled via `conf.py`.
+
+## Procedure
+
+1. Locate the documentation source files in `docs/source/`.
+2. Edit or add `.rst` files as needed to document new features or CLI commands.
+3. If adding a new file, ensure it is referenced in the `toctree` of an existing index file.
+4. Ensure the custom aliases are active (`source devel/activate-aliases.sh`).
+5. Build the documentation by running the custom alias: `makedocs`.
+6. The HTML output is generated and placed in the appropriate build output directory (usually `docs/build/html/`).
+
+## Checklist
+
+- [ ] Are changes placed inside `docs/source/`?
+- [ ] Did you use standard Sphinx-style reStructuredText?
+- [ ] Did you build the docs using the `makedocs` alias?
+- [ ] Did the build complete without Sphinx warnings?
+
+## Validation
+
+Always run `makedocs` after modifying `.rst` files or docstrings. Do not consider a documentation task complete if the Sphinx build emits warnings or errors.

--- a/.agents/skills/documentation/SKILL.md
+++ b/.agents/skills/documentation/SKILL.md
@@ -2,7 +2,9 @@
 
 ## Context
 
-This project uses Sphinx for documentation. The source files are written in reStructuredText (.rst) and the configuration is handled via `conf.py`.
+This project uses Sphinx for documentation. The source files are written in reStructuredText (.rst) and the configuration is handled via `conf.py`. 
+
+**Note on Structure**: The documentation is separated into different guides (for example, user, developer, etc.). When reading or updating documentation, always ensure you are navigating and modifying the correct guide for the target audience.
 
 ## Procedure
 

--- a/.agents/skills/documentation/SKILL.md
+++ b/.agents/skills/documentation/SKILL.md
@@ -20,7 +20,7 @@ This project uses Sphinx for documentation. The source files are written in reSt
 - [ ] Are changes placed inside `docs/source/`?
 - [ ] Did you use standard Sphinx-style reStructuredText?
 - [ ] Did you build the docs using the `makedocs` alias?
-- [ ] Did the build complete without Sphinx warnings?
+- [ ] Did the build complete without Sphinx errors? (**Note**: It is safe to ignore pre-existing warnings).
 
 ## Validation
 

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -1,0 +1,22 @@
+# Skill - Running and Interpreting Tests
+
+## Context
+
+This repository uses `pytest` for testing, wrapped in a custom alias script to ensure the environment is correctly configured before tests run. 
+
+## Procedure
+
+1. Before running tests, ensure the development aliases are active in your session.
+2. Run the test suite using the project-specific alias `upytest` (instead of standard `pytest`).
+3. If running a specific test file, append the path: `upytest tests/path/to/test.py`.
+4. Analyze the output. If tests fail, read the traceback carefully, specifically looking for assertion errors, missing mocks, or formatting mismatches (like unexpected newline characters).
+
+## Checklist
+
+- [ ] Did you use `upytest` instead of standard `pytest`?
+- [ ] If tests failed, did you trace the failure back to the exact line in the test file or source code?
+- [ ] Did you strip or handle terminal formatting or newlines in string assertions if testing rich CLI output?
+
+## Validation
+
+Always execute the test command after making a code change. Do not assume the code works. If tests fail, automatically attempt a fix based on the traceback before asking the user for help. A task is not complete until `upytest` returns a 0 exit code.

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -8,14 +8,15 @@ This repository uses `pytest` for testing, wrapped in a custom alias script to e
 
 1. Before running tests, ensure the development aliases are active in your session.
 2. Run the test suite using the project-specific alias `upytest` (instead of standard `pytest`).
-3. If running a specific test file, append the path: `upytest tests/path/to/test.py`.
-4. Analyze the output. If tests fail, read the traceback carefully, specifically looking for assertion errors, missing mocks, or formatting mismatches (like unexpected newline characters).
+3. If running a specific test file, append the path and **always use the verbose flag (`-v`)** to get elaborate output and full string diffs: `upytest -v tests/path/to/test.py`.
+4. Analyze the output. If tests fail, read the traceback carefully, specifically looking for assertion errors, missing mocks, or formatting mismatches (like unexpected newline characters in rich console outputs).
 
 ## Checklist
 
 - [ ] Did you use `upytest` instead of standard `pytest`?
 - [ ] If tests failed, did you trace the failure back to the exact line in the test file or source code?
 - [ ] Did you strip or handle terminal formatting or newlines in string assertions if testing rich CLI output?
+- [ ] **CRITICAL**: If you ran `upytest` on a *specific* test file, did you ignore the inevitable coverage threshold failure (< 90%)? (This is normal behavior for targeted runs and is not an actual test error).
 
 ## Validation
 

--- a/.agents/skills/towncrier/SKILL.md
+++ b/.agents/skills/towncrier/SKILL.md
@@ -7,7 +7,7 @@ This repository uses `towncrier` to generate the changelog. Every pull request t
 ## Procedure
 
 1. Identify the issue number associated with your current task.
-2. Determine the correct fragment type. Allowed types are: `breaking`, `bugfix`, `deprecation`, `doc`, `feature`, `refactor`, `removal`, `infra`, `security`.
+2. Determine the correct fragment type. **To find the current list of allowed types, you must read the `towncrier.toml` file** in the repository root, which is the ultimate source of truth.
 3. Create a new file in the `changelog.d/` directory.
 4. The file name must follow the format: `<issue>.<type>.rst` where `<issue>` is the GitHub pull request or issue number (for example, `303.bugfix.rst`). If there is no issue/PR number, start the file name with `+` and a short slug (for example, `+add-json.feature.rst`).
 5. Write a concise, user-facing sentence inside the file explaining the change. Use reStructuredText format.

--- a/.agents/skills/towncrier/SKILL.md
+++ b/.agents/skills/towncrier/SKILL.md
@@ -1,0 +1,24 @@
+# Skill - Managing News Fragments (Towncrier)
+
+## Context
+
+This repository uses `towncrier` to generate the changelog. Every pull request that introduces a user-facing change, bugfix or significant internal change must include a news fragment.
+
+## Procedure
+
+1. Identify the issue number associated with your current task.
+2. Determine the correct fragment type. Allowed types generally include: `bugfix`, `feature`, `doc`, `removal`, `misc`.
+3. Create a new file in the `changelog.d/` directory.
+4. The file name must follow the format: `<issue_number>.<type>.rst` (for example, `303.bugfix.rst`).
+5. Write a concise, user-facing sentence inside the file explaining the change. Use reStructuredText format.
+
+## Checklist
+
+- [ ] Is the file placed inside the `changelog.d/` directory?
+- [ ] Does the file name strictly follow the `<issue_number>.<type>.rst` convention?
+- [ ] Is the content written in standard `.rst` format?
+- [ ] Is the message clear and focused on user or developer impact?
+
+## Validation
+
+Before concluding the task, run `ls changelog.d/` to verify your file exists and is named correctly. If you have access to the CLI, run a dry-run of towncrier (if available) to ensure the fragment is picked up.

--- a/.agents/skills/towncrier/SKILL.md
+++ b/.agents/skills/towncrier/SKILL.md
@@ -7,18 +7,18 @@ This repository uses `towncrier` to generate the changelog. Every pull request t
 ## Procedure
 
 1. Identify the issue number associated with your current task.
-2. Determine the correct fragment type. Allowed types generally include: `bugfix`, `feature`, `doc`, `removal`, `misc`.
+2. Determine the correct fragment type. Allowed types are: `breaking`, `bugfix`, `deprecation`, `doc`, `feature`, `refactor`, `removal`, `infra`, `security`.
 3. Create a new file in the `changelog.d/` directory.
-4. The file name must follow the format: `<issue_number>.<type>.rst` (for example, `303.bugfix.rst`).
+4. The file name must follow the format: `<issue>.<type>.rst` where `<issue>` is the GitHub pull request or issue number (for example, `303.bugfix.rst`). If there is no issue/PR number, start the file name with `+` and a short slug (for example, `+add-json.feature.rst`).
 5. Write a concise, user-facing sentence inside the file explaining the change. Use reStructuredText format.
 
 ## Checklist
 
 - [ ] Is the file placed inside the `changelog.d/` directory?
-- [ ] Does the file name strictly follow the `<issue_number>.<type>.rst` convention?
+- [ ] Does the file name strictly follow the `<issue>.<type>.rst` convention?
 - [ ] Is the content written in standard `.rst` format?
 - [ ] Is the message clear and focused on user or developer impact?
 
 ## Validation
 
-Before concluding the task, run `ls changelog.d/` to verify your file exists and is named correctly. If you have access to the CLI, run a dry-run of towncrier (if available) to ensure the fragment is picked up.
+Before concluding the task, run `towncrier check` to ensure the fragment is valid and will be picked up. Optionally run `towncrier build --draft` to preview the generated changelog output.

--- a/.github/agents/docbuild.agent.md
+++ b/.github/agents/docbuild.agent.md
@@ -3,6 +3,7 @@ name: docbuild
 description: 'Help me with design, tests, documentation, and improving code.'
 tools: [execute/killTerminal, execute/runInTerminal, read/terminalSelection, read/terminalLastCommand, read/getTaskOutput, read/getNotebookSummary, read/problems, read/readFile, read/viewImage, edit/editFiles, search/changes, search/codebase, search/fileSearch, search/listDirectory, search/searchResults, search/textSearch, search/usages, web/githubRepo, todo, ms-python.python/getPythonEnvironmentInfo, ms-python.python/getPythonExecutableCommand]
 ---
+
 You are a professional senior Python developer and technical writer focused on this repository.
 Your role is to assist me with designing maintainable software features, writing tests, creating documentation, and improving the existing codebases.
 
@@ -22,13 +23,11 @@ Docbuild builds documentation from DocBook 5/ASCIIDoc, manages XML configs, clon
 * Custom shell aliases: `devel/activate-aliases.sh`
 * Sphinx docs: `docs/` (built with `makedocs` from our custom shell alias), source: `docs/source/`, config: `docs/source/conf.py`.
 
-
 ## Primary goals
 
 * Make minimal, surgical changes.
 * Improve tests, documentation, and code clarity.
 * Ensure CI passes and tests are runnable locally.
-
 
 ## How to run locally
 
@@ -37,12 +36,10 @@ Run tests:
 * Run the complete test suite with `uv run --frozen pytest`.
 * Single tests with `uv run --frozen pytest tests/path/to/test_file.py::test_function_name`.
 
-
 ## Constraints & Safety
 
 * Keep changes minimal and focused; avoid broad refactors.
 * Never commit secrets or credentials.
-
 
 ## Coding Standards
 
@@ -61,16 +58,19 @@ Ensure the generated code conforms to these points:
 3. Ask concise clarifying questions if the requested change scope is ambiguous.
 4. Declare intent before running any environment or repo-affecting actions (when tools are available).
 
-
 ## Deliverables Format
 
 * Provide minimal explanations.
 * When returning code, include file path and only the changed code block(s).
 * Show how to run tests that verify the change.
 
-
 ## Documentation
 
 * For code changes, update or add docstrings in the affected functions/classes.
 * For user-facing features, update the Sphinx docs in `docs/source/` and ensure they build correctly with `makedocs`.
 * For any new CLI commands, add usage examples in the CLI help and update the relevant documentation sections.
+
+## AI Agent Skills
+
+* Detailed procedural skills (Testing, Towncrier, Documentation, Aliases) are located in `.agents/skills/`.
+* Always consult the `SKILL.md` file in the relevant skill directory before executing complex workflows.

--- a/.github/skills
+++ b/.github/skills
@@ -1,0 +1,1 @@
+../.agents/skills/

--- a/changelog.d/266.feature.rst
+++ b/changelog.d/266.feature.rst
@@ -1,0 +1,1 @@
+Added foundational AI agent skill files under ``.agents/skills/`` (with a symlink at ``.github/skills/``) and updated the primary agent instructions to standardize AI interactions with repository workflows.

--- a/env.agent.toml
+++ b/env.agent.toml
@@ -1,2 +1,7 @@
 # Dedicated environment configuration for AI agents.
 # This file ensures agent actions do not pollute local developer environments.
+
+server.name = "ai-agent"
+server.role = "devel"
+root_config_dir = "~/.config/docbuild/"
+paths.base_cache_dir = "~/.local/state/docbuild"

--- a/env.agent.toml
+++ b/env.agent.toml
@@ -1,0 +1,2 @@
+# Dedicated environment configuration for AI agents.
+# This file ensures agent actions do not pollute local developer environments.


### PR DESCRIPTION
Closes #266

Created a standardized set of AI agent "skill" files to help AI assistants interact with the repository's workflows more effectively and reliably.

### Changes Made

* Created `.agents/skills/` directory with detailed `SKILL.md` guides for:
  * **Towncrier**: Managing news fragments.
  * **Testing**: Running tests via `upytest` and analyzing failures.
  * **Docbuild Alias**: Activating and using the `devel/activate-aliases.sh` script.
  * **Documentation**: Building Sphinx docs via `makedocs`.
* Added a symlink at `.github/skills` pointing to `.agents/skills/` for broader tool compatibility.
* Updated `.github/agents/docbuild.agent.md` to instruct the AI to consult these skill files.
* Added news fragment `266.feature.rst`.

### Self-Review Checklist

**Conventions & Implementation**:

- [x] Skill files are concise, procedural, and include checklists/validation steps.
- [x] Symlink created successfully.

**Documentation & CI**:

- [x] Does the news fragment file exist?