### PR TITLE
ci: fix build-and-deploy failure

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -57,7 +57,7 @@ jobs:
         if: github.ref_type != 'tag'
         run: |
           if find changelog.d -maxdepth 1 -type f -name '*.rst' ! -name 'README.rst' ! -name '_template.rst' -print -quit | grep -q .; then
-            uv run --frozen --no-sync towncrier build --yes --keep --version "${{ env.DOC_VERSION }}"
+            uv run --frozen --no-sync towncrier build --keep --version "${{ env.DOC_VERSION }}"
           else
             echo "No news fragments found; skipping Towncrier build."
           fi

--- a/changelog.d/367.infra.rst
+++ b/changelog.d/367.infra.rst
@@ -1,0 +1,1 @@
+Fixed failures of the Towncrier step in the GitHub Pages CI.


### PR DESCRIPTION
towncrier failed because the options '--yes' and '--keep' were selected at the same time.