### PR TITLE
Reorg XDG directory setup and defaults

### DIFF
--- a/changelog.d/369.refactor.rst
+++ b/changelog.d/369.refactor.rst
@@ -1,0 +1,1 @@
+The project's directory structure was refactored to align with XDG standards using ``platformdirs``, centralizing path definitions and introducing new, more flexible configuration options for cache, runtime, and lock directories.

--- a/docs/source/reference/_autoapi/docbuild/cli/cmd_portal/cmd_list/index.rst
+++ b/docs/source/reference/_autoapi/docbuild/cli/cmd_portal/cmd_list/index.rst
@@ -15,6 +15,14 @@ Functions
 .. autoapisummary::
 
    docbuild.cli.cmd_portal.cmd_list.build_hierarchy
+   docbuild.cli.cmd_portal.cmd_list.parse_doctypes
+   docbuild.cli.cmd_portal.cmd_list.get_display_name
+   docbuild.cli.cmd_portal.cmd_list.append_translations
+   docbuild.cli.cmd_portal.cmd_list.append_formats
+   docbuild.cli.cmd_portal.cmd_list.append_categories
+   docbuild.cli.cmd_portal.cmd_list.append_repo
+   docbuild.cli.cmd_portal.cmd_list.build_deliverable_branch
+   docbuild.cli.cmd_portal.cmd_list.print_hierarchy
    docbuild.cli.cmd_portal.cmd_list.async_list_cmd
    docbuild.cli.cmd_portal.cmd_list.list_cmd
 
@@ -22,31 +30,67 @@ Functions
 Module Contents
 ---------------
 
-.. py:function:: build_hierarchy(deliverables: list[docbuild.models.deliverable.Deliverable]) -> dict[str, dict[str, dict[str, list[str]]]]
+.. py:function:: build_hierarchy(deliverables: list[docbuild.models.deliverable.Deliverable]) -> dict[str, dict[str, dict[str, list[docbuild.models.deliverable.Deliverable]]]]
 
-   Group a list of Deliverable domain objects into a nested dictionary structure.
+   Group Deliverables into a hierarchy.
 
    :param deliverables: A list of Deliverable models to organize.
-   :return: A nested dictionary structured as {lang: {product: {docset: [deliverable titles]}}}.
+   :return: A hierarchy_dict mapping lang -> product -> docset -> deliverables.
 
 
-.. py:function:: async_list_cmd(ctx: docbuild.cli.context.DocBuildContext, doctypes: tuple[str, Ellipsis], console: rich.console.Console) -> None
+.. py:function:: parse_doctypes(doctypes: tuple[str, Ellipsis], console: rich.console.Console) -> list[docbuild.models.doctype.Doctype] | None
+
+   Parse raw CLI arguments into Doctype objects with default fallbacks.
+
+
+.. py:function:: get_display_name(deliv: docbuild.models.deliverable.Deliverable, d_id: str) -> str
+
+   Determine the main display name for a deliverable.
+
+
+.. py:function:: append_translations(deliv_branch: rich.tree.Tree, deliv: docbuild.models.deliverable.Deliverable, lang: str) -> None
+
+   Append translation metadata to the deliverable branch.
+
+
+.. py:function:: append_formats(deliv_branch: rich.tree.Tree, deliv: docbuild.models.deliverable.Deliverable) -> None
+
+   Append output formats metadata to the deliverable branch.
+
+
+.. py:function:: append_categories(deliv_branch: rich.tree.Tree, deliv: docbuild.models.deliverable.Deliverable) -> None
+
+   Append category metadata to the deliverable branch.
+
+
+.. py:function:: append_repo(deliv_branch: rich.tree.Tree, deliv: docbuild.models.deliverable.Deliverable, repo_format: str) -> None
+
+   Append repository metadata to the deliverable branch.
+
+
+.. py:function:: build_deliverable_branch(docset_branch: rich.tree.Tree, deliv: docbuild.models.deliverable.Deliverable, lang: str, show_trans: bool, show_formats: bool, show_categories: bool, repo_format: str | None) -> None
+
+   Format and append a single deliverable node to the Rich Tree.
+
+
+.. py:function:: print_hierarchy(hierarchy: dict[str, dict[str, dict[str, list[docbuild.models.deliverable.Deliverable]]]], console: rich.console.Console, show_trans: bool, show_formats: bool, show_categories: bool, repo_format: str | None) -> None
+
+   Render and print the nested hierarchy as a Rich Tree.
+
+
+.. py:function:: async_list_cmd(ctx: docbuild.cli.context.DocBuildContext, doctypes: tuple[str, Ellipsis], console: rich.console.Console, show_trans: bool, show_formats: bool, show_categories: bool, repo_format: str | None) -> None
    :async:
 
 
    Async worker to fetch the XML, parse Doctypes, and build the tree.
 
-   :param ctx: The DocBuildContext containing CLI options and config.
-   :param doctypes: A tuple of doctype strings passed as arguments to the command.
-   :param console: The Rich Console object for outputting the tree.
 
-
-.. py:function:: list_cmd(ctx: docbuild.cli.context.DocBuildContext, doctypes: tuple[str, Ellipsis]) -> None
+.. py:function:: list_cmd(ctx: docbuild.cli.context.DocBuildContext, doctypes: tuple[str, Ellipsis], trans: bool, formats: bool, categories: bool, repo: str | None) -> None
 
    List products, docsets, and deliverables from the portal config.
 
    Accepts optional DOCTYPE arguments to filter the output.
-   Format: [PRODUCT]/[DOCSETS]@[LIFECYCLES]/[LANGS]
+   Format: PRODUCT/DOCSETS[@LIFECYCLES]/LANGS
 
    Example:
        docbuild portal list sles/15-SP6
@@ -56,6 +100,10 @@ Module Contents
 
    :param ctx: The DocBuildContext passed from the CLI, containing config and options.
    :param doctypes: A tuple of doctype strings passed as arguments to the command.
+   :param trans: Show translation metadata.
+   :param formats: Show output formats metadata.
+   :param categories: Show categories metadata.
+   :param repo: Show repository metadata (short or long).
 
 
 

--- a/docs/source/reference/_autoapi/docbuild/config/load/index.rst
+++ b/docs/source/reference/_autoapi/docbuild/config/load/index.rst
@@ -15,7 +15,6 @@ Functions
 .. autoapisummary::
 
    docbuild.config.load.load_single_config
-   docbuild.config.load.load_and_merge_configs
    docbuild.config.load.handle_config
 
 
@@ -33,27 +32,14 @@ Module Contents
        or cannot be decoded.
 
 
-.. py:function:: load_and_merge_configs(defaults: collections.abc.Sequence[str | pathlib.Path], *paths: str | pathlib.Path) -> tuple[tuple[str | pathlib.Path, Ellipsis], dict[str, Any]]
-
-   Load config files and merge all content regardless of the nesting level.
-
-   The order of defaults and paths is important. The paths are in the order of
-   system path, user path, and current working directory.
-   The defaults are in the order of common config file names followed by more
-   specific ones. The later ones will override data from the earlier ones.
-
-   :param defaults: a sequence of base filenames (without path!) to look for
-                    in the paths
-   :param paths: the paths to look for config files (without the filename!)
-   :return: the found config files and the merged dictionary (raw dict)
-
-
 .. py:function:: handle_config(user_path: pathlib.Path | str | None, search_dirs: collections.abc.Iterable[str | pathlib.Path], basenames: collections.abc.Iterable[str] | None, default_filename: str | None = None, default_config: object | None = None) -> tuple[tuple[pathlib.Path, Ellipsis] | None, object | dict, bool]
 
    Return (config_files, config, from_defaults) for config file handling.
 
    Note: The returned configuration is the **raw loaded dictionary**. No
    placeholder replacement or validation has been performed on it.
+   Configurations are collected across all search directories and deeply merged
+   on top of the default configuration to allow partial user configs.
 
    :param user_path: Path to the user-defined config file, if any.
    :param search_dirs: Iterable of directories to search for config files.
@@ -64,8 +50,6 @@ Module Contents
 
        * A tuple of found config file paths or None if no config file is found.
        * The loaded configuration as a dictionary or the default configuration.
-       * A boolean indicating if the default configuration was used.
-   :raises ValueError: If no config file is found and no default
-       configuration is provided.
+       * A boolean indicating if the default configuration was used exclusively.
 
 

--- a/docs/source/reference/_autoapi/docbuild/constants/index.rst
+++ b/docs/source/reference/_autoapi/docbuild/constants/index.rst
@@ -15,6 +15,7 @@ Attributes
 .. autoapisummary::
 
    docbuild.constants.APP_NAME
+   docbuild.constants.DEFAULT_SERVER_NAME
    docbuild.constants.DEFAULT_LANGS
    docbuild.constants.ALLOWED_LANGUAGES
    docbuild.constants.DEFAULT_DELIVERABLES
@@ -31,16 +32,21 @@ Attributes
    docbuild.constants.USER_CONFIG_DIR
    docbuild.constants.SYSTEM_CONFIG_DIR
    docbuild.constants.CONFIG_PATHS
+   docbuild.constants.STATE_HOME
+   docbuild.constants.CONFIG_HOME
+   docbuild.constants.DATA_HOME
+   docbuild.constants.CACHE_HOME
+   docbuild.constants.RUNTIME_DIR
    docbuild.constants.APP_CONFIG_BASENAMES
    docbuild.constants.PROJECT_LEVEL_APP_CONFIG_FILENAMES
    docbuild.constants.APP_CONFIG_FILENAME
    docbuild.constants.ENV_CONFIG_FILENAME
    docbuild.constants.DEFAULT_ENV_CONFIG_FILENAME
    docbuild.constants.GIT_CONFIG_FILENAME
+   docbuild.constants.BASE_LOG_DIR
    docbuild.constants.BASE_STATE_DIR
    docbuild.constants.GITLOGGER_NAME
    docbuild.constants.PORTALLOGGER_NAME
-   docbuild.constants.BASE_LOG_DIR
    docbuild.constants.BASE_LOCK_DIR
    docbuild.constants.XMLDATADIR
    docbuild.constants.DEFAULT_ERROR_LIMIT
@@ -59,6 +65,13 @@ Module Contents
 
 
    The name of the application, used in paths and config files.
+
+
+.. py:data:: DEFAULT_SERVER_NAME
+   :value: 'default-env'
+
+
+   The default server name used in the application configuration.
 
 
 .. py:data:: DEFAULT_LANGS
@@ -84,13 +97,13 @@ Module Contents
 
 
 .. py:data:: SERVER_ROLES
-   :type:  tuple[str]
+   :type:  tuple[str, Ellipsis]
 
    The unique primary server role values.
 
 
 .. py:data:: SERVER_ROLES_ALIASES
-   :type:  tuple[str]
+   :type:  tuple[str, Ellipsis]
    :value: ('PRODUCTION', 'STAGING', 'TESTING', 'PROD', 'P', 'prod', 'p', 'STAGE', 'S', 'stage', 's',...
 
 
@@ -106,7 +119,7 @@ Module Contents
 
 
 .. py:data:: ALLOWED_LIFECYCLES
-   :type:  tuple[str]
+   :type:  tuple[str, Ellipsis]
 
    The available lifecycle states for a docset (without 'unknown').
 
@@ -118,7 +131,7 @@ Module Contents
 
 
 .. py:data:: ALLOWED_PRODUCTS
-   :type:  tuple[str]
+   :type:  tuple[str, Ellipsis]
 
    A tuple of valid product acronyms.
 
@@ -169,6 +182,36 @@ Module Contents
    The paths where the application will look for configuration files.
 
 
+.. py:data:: STATE_HOME
+   :type:  pathlib.Path
+
+   The base directory for application state, logs, and locks, per XDG Base Directory Specification.
+
+
+.. py:data:: CONFIG_HOME
+   :type:  pathlib.Path
+
+   The user-specific configuration directory, typically located at ~/.config/docbuild.
+
+
+.. py:data:: DATA_HOME
+   :type:  pathlib.Path
+
+   The user-specific data directory, typically located at ~/.local/share/docbuild.
+
+
+.. py:data:: CACHE_HOME
+   :type:  pathlib.Path
+
+   The user-specific cache directory, typically located at ~/.cache/docbuild.
+
+
+.. py:data:: RUNTIME_DIR
+   :type:  pathlib.Path
+
+   The user-specific runtime directory, typically located at /run/user/1000/docbuild.
+
+
 .. py:data:: APP_CONFIG_BASENAMES
    :type:  tuple[str | pathlib.Path, Ellipsis]
    :value: ('.config.toml', 'config.toml')
@@ -215,6 +258,12 @@ Module Contents
    The project-specific Git configuration file (relative to this project)
 
 
+.. py:data:: BASE_LOG_DIR
+   :type:  pathlib.Path
+
+   The directory where log files will be stored.
+
+
 .. py:data:: BASE_STATE_DIR
    :type:  pathlib.Path
 
@@ -236,12 +285,6 @@ Module Contents
 
 
    The standardized name for the Portal-related logger.
-
-
-.. py:data:: BASE_LOG_DIR
-   :type:  pathlib.Path
-
-   The directory where log files will be stored.
 
 
 .. py:data:: BASE_LOCK_DIR

--- a/docs/source/reference/_autoapi/docbuild/models/config/env/EnvPathsConfig.rst
+++ b/docs/source/reference/_autoapi/docbuild/models/config/env/EnvPathsConfig.rst
@@ -117,12 +117,30 @@ docbuild.models.config.env.EnvPathsConfig
 
 
 
-   .. py:attribute:: base_tmp_dir
+   .. py:attribute:: json_cache_dir
       :type:  docbuild.models.path.EnsureWritableDirectory
       :value: None
 
 
-      Base system temporary path.
+      JSON cache path.
+
+
+
+   .. py:attribute:: runtime_base_dir
+      :type:  docbuild.models.path.EnsureWritableDirectory
+      :value: None
+
+
+      Base runtime path.
+
+
+
+   .. py:attribute:: lock_dir
+      :type:  docbuild.models.path.EnsureWritableDirectory
+      :value: None
+
+
+      Directory for lock files.
 
 
 

--- a/docs/source/reference/_autoapi/docbuild/models/deliverable/view/DeliverableXMLView.rst
+++ b/docs/source/reference/_autoapi/docbuild/models/deliverable/view/DeliverableXMLView.rst
@@ -94,6 +94,14 @@ docbuild.models.deliverable.view.DeliverableXMLView
 
 
 
+   .. py:property:: translations
+      :type: set[str]
+
+
+      Return a set of all language codes available for this deliverable.
+
+
+
    .. py:property:: kind
       :type: str | None
 
@@ -146,6 +154,14 @@ docbuild.models.deliverable.view.DeliverableXMLView
 
 
 
+   .. py:property:: category_title
+      :type: str | None
+
+
+      Return the resolved category title, or the raw ID if not found.
+
+
+
    .. py:method:: desc() -> collections.abc.Generator[lxml.etree._Element, None, None]
 
       Yield product ``<desc>`` elements.
@@ -170,7 +186,7 @@ docbuild.models.deliverable.view.DeliverableXMLView
 
 
 
-   .. py:method:: git_remote() -> docbuild.models.repo.Repo | None
+   .. py:method:: git_remote() -> docbuild.models.repo.Repo | str | None
 
       Return git remote URL from sibling ``<git>`` node.
 

--- a/docs/source/reference/_autoapi/docbuild/utils/paths/index.rst
+++ b/docs/source/reference/_autoapi/docbuild/utils/paths/index.rst
@@ -15,6 +15,7 @@ Functions
 .. autoapisummary::
 
    docbuild.utils.paths.calc_max_len
+   docbuild.utils.paths.mark_cache_dir
 
 
 Module Contents
@@ -38,5 +39,16 @@ Module Contents
        >>> files = (Path('/path/to/file1.xml'), Path('/another/path/to/file2.xml'))
        >>> calc_max_len(files)
        30
+
+
+.. py:function:: mark_cache_dir(path: pathlib.Path | str) -> None
+
+   Add a standard CACHEDIR.TAG file to a directory.
+
+   This tag informs backup tools that the directory contains cached data
+   that can be safely excluded from backups. The directory is created if
+   it does not exist.
+
+   For more information, see: https://bford.info/cachedir/
 
 

--- a/docs/source/reference/env-toml/env-toml-ref.rst.inc
+++ b/docs/source/reference/env-toml/env-toml-ref.rst.inc
@@ -105,14 +105,6 @@ Key naming convention:
 
     The root directory where all configuration files are stored.
 
-.. _envtoml-paths-jinja-dir:
-
-``jinja_dir``
-    :Type: :code:`str`
-    :Default: ``{root_config_dir}/jinja-doc-suse-com``
-
-    Path to the directory containing Jinja templates.
-
 .. _envtoml-paths-config-dir:
 
 ``config_dir``
@@ -137,6 +129,14 @@ Key naming convention:
 
     Absolute path to the Portal RELAX NG (RNC) schema file used for validation.
 
+.. _envtoml-paths-jinja-dir:
+
+``jinja_dir``
+    :Type: :code:`str`
+    :Default: ``{root_config_dir}/jinja-doc-suse-com``
+
+    Path to the directory containing Jinja templates.
+
 .. _envtoml-paths-server-rootfiles-dir:
 
 ``server_rootfiles_dir``
@@ -145,13 +145,28 @@ Key naming convention:
 
     Path to the directory containing server root files like robots.txt.
 
+.. _envtoml-paths-tmp-repo-dir:
+
+``tmp_repo_dir``
+    :Type: :code:`str`
+    :Default: ``/data/docserv/repos/temporary-branches/``
+
+    The directory for storing temporary repositories from branches.
+
+.. _envtoml-paths-repo-dir:
+
+``repo_dir``
+    :Type: :code:`str`
+    :Default: ``/data/docserv/repos/permanent-full/``
+
+    The directory where permanent full repositories are stored.
+
 .. _envtoml-paths-base-cache-dir:
 
 ``base_cache_dir``
     :Type: :code:`str`
-    :Default: ``/var/cache/docserv``
+    :Default: ``~/.cache/docbuild``
 
-    
     The base directory for storing cached data.
 
 .. _envtoml-paths-base-server-cache-dir:
@@ -162,30 +177,6 @@ Key naming convention:
 
     The server-specific cache directory, derived from base_cache_dir and server name.
 
-.. _envtoml-paths-base-tmp-dir:
-
-``base_tmp_dir``
-    :Type: :code:`str`
-    :Default: ``/var/tmp/docbuild``
-
-    The base directory for temporary files.
-
-.. _envtoml-paths-repo-dir:
-
-``repo_dir``
-    :Type: :code:`str`
-    :Default: ``/data/docserv/repos/permanent-full/``
-
-    The directory where permanent full repositories are stored.
-
-.. _envtoml-paths-tmp-repo-dir:
-
-``tmp_repo_dir``
-    :Type: :code:`str`
-    :Default: ``/data/docserv/repos/temporary-branches/``
-
-    The directory for storing temporary repositories from branches.
-
 .. _envtoml-paths-meta-cache-dir:
 
 ``meta_cache_dir``
@@ -193,6 +184,30 @@ Key naming convention:
     :Default: ``{base_cache_dir}/{server.name}/meta``
 
     The directory for caching metadata.
+
+.. _envtoml-paths-runtime-base-dir:
+
+``runtime_base_dir``
+    :Type: :code:`str`
+    :Default: ````
+
+    The base directory for lightweight runtime artifacts
+
+.. _envtoml-paths-lock-dir:
+
+``lock_dir``
+    :Type: :code:`str`
+    :Default: ``{runtime_base_dir}/locks``
+
+    Directory for lock files used to prevent concurrent builds
+
+.. _envtoml-paths-json-cache-dir:
+
+``json_cache_dir``
+    :Type: :code:`str`
+    :Default: ``{base_server_cache_dir}/json``
+
+    JSON cache path
 
 .. _envtoml-section-paths-tmp:
 

--- a/etc/docbuild/env.example.toml
+++ b/etc/docbuild/env.example.toml
@@ -5,7 +5,7 @@
 # Deals with all config about server settings
 
 # name(str): Name of the server, used for logging and cache paths
-name = "doc-example-com"
+name = "default-env"
 # role(str): Role of the server, used for logging and other purposes. Possible values: "production", "staging", "development"
 role = "production"
 # host(str): Hostname or IP address to bind the server to.
@@ -48,50 +48,70 @@ canonical_url_domain = "https://docs.example.com"
 
 # root_config_dir(str): The root directory where all configuration files are stored.
 root_config_dir = "/etc/docbuild"
-# jinja_dir(str): Path to the directory containing Jinja templates.
-jinja_dir = "{root_config_dir}/jinja-doc-suse-com"
+
 # config_dir(str): Path to the directory for additional configuration files.
 config_dir = "{root_config_dir}/config.d"
+
 # main_portal_config(str): Absolute path to the main Portal XML configuration file.
 main_portal_config = "{config_dir}/portal.xml"
-# portal_schema(str): Absolute path to the Portal RELAX NG (RNC) schema file used for validation.
-portal_schema = "{root_config_dir}/portal-schema.rnc"
+
+# portal_rncschema(str): Absolute path to the Portal RELAX NG (RNC) schema file used for validation.
+portal_rncschema = "{root_config_dir}/portal-config.rnc"
+
+# jinja_dir(str): Path to the directory containing Jinja templates.
+jinja_dir = "{root_config_dir}/jinja-doc-suse-com"
+
 # server_rootfiles_dir(str): Path to the directory containing server root files like robots.txt.
 server_rootfiles_dir = "{root_config_dir}/server-root-files-doc-suse-com"
-#
+
+# tmp_repo_dir(str): The directory for storing temporary repositories from branches.
+tmp_repo_dir = "~/.local/state/docbuild/repos/branches"
+
+# repo_dir(str): The directory where permanent full repositories are stored.
+repo_dir = "~/.local/state/docbuild/repos/permanent"
+
 # base_cache_dir(str): The base directory for storing cached data.
-base_cache_dir = "/var/cache/docserv"
+base_cache_dir = "~/.cache/docbuild"
+
 # base_server_cache_dir(str): The server-specific cache directory, derived from base_cache_dir and server name.
 base_server_cache_dir = "{base_cache_dir}/{server.name}"
-# base_tmp_dir(str): The base directory for temporary files.
-base_tmp_dir = "/var/tmp/docbuild"
-# repo_dir(str): The directory where permanent full repositories are stored.
-repo_dir = "/data/docserv/repos/permanent-full/"
-# tmp_repo_dir(str): The directory for storing temporary repositories from branches.
-tmp_repo_dir = "/data/docserv/repos/temporary-branches/"
-# meta_cache_dir(str): The directory for caching metadata.
-meta_cache_dir = "{base_cache_dir}/{server.name}/meta"
 
+# meta_cache_dir(str): The directory for caching metadata.
+meta_cache_dir = "{base_server_cache_dir}/meta"
+
+# runtime_base_dir(str): The base directory for lightweight runtime artifacts.
+runtime_base_dir = "{base_cache_dir}/runtime"
+
+# lock_dir(str): Directory for lock files used to prevent concurrent builds.
+lock_dir = "{runtime_base_dir}/locks"
+
+# json_cache_dir(str): JSON cache path
+json_cache_dir = "{base_server_cache_dir}/json"
 
 [paths.tmp]
 # Defines temporary paths
 # Paths can hold placeholders in brackets.
 
-# tmp_base_dir(str): The base directory for temporary files, referencing paths.base_tmp_dir.
-tmp_base_dir = "{paths.base_tmp_dir}"
+# tmp_base_dir(str): The base directory for temporary files.
+tmp_base_dir = "/tmp/docbuild"
+
 # tmp_dir(str): A server-specific temporary directory.
 tmp_dir = "{tmp_base_dir}/doc-example-com"
 # tmp_metadata_dir(str): A temporary directory for storing metadata during processing.
 tmp_metadata_dir = "{tmp_dir}/metadata"
+
 # tmp_deliverable_dir(str): A temporary directory for storing deliverables.
 tmp_deliverable_dir = "{paths.tmp.tmp_dir}/deliverable/"
+
 # tmp_build_base_dir(str): The base directory for build outputs.
 tmp_build_base_dir = "{tmp_dir}/build"
+
 # tmp_build_dir_dyn(str): A dynamic template for creating build-specific directories.
 tmp_build_dir_dyn = "{{product}}-{{docset}}-{{lang}}"
 
 # tmp_out_dir(str): The final temporary output directory before deployment.
 tmp_out_dir = "{tmp_dir}/out/"
+
 # log_dir(str): The directory for storing log files.
 log_dir = "{tmp_dir}/log/"
 
@@ -107,7 +127,7 @@ target_base_dir = "doc@10.100.60.1:/srv/docs"
 # target_dir_dyn(str): A dynamic template for the final target directory on the remote server.
 target_dir_dyn = "{{product}}"
 # backup_dir(str): The directory where backups of external builds are stored.
-backup_dir = "/data/docbuild/external-builds/"
+backup_dir = "~/.local/state/docbuild/default-env/backup"
 
 
 [build]

--- a/src/docbuild/cli/cmd_cli.py
+++ b/src/docbuild/cli/cmd_cli.py
@@ -240,16 +240,21 @@ def cli(
         current_files = (app_config,) if app_config else None
         load_app_config(ctx, app_config, max_workers)
 
-        # Setup logging
-        logging_config = context.appconfig.logging.model_dump(
-            by_alias=True, exclude_none=True
-        )
-        setup_logging(cliverbosity=verbose, user_config={"logging": logging_config})
-
         # --- PHASE 2: Load Environment Config ---
         current_model = EnvConfig
         current_files = (env_config,) if env_config else None
         load_env_config(ctx, env_config)
+
+        # Setup logging
+        logging_config = context.appconfig.logging.model_dump(
+            by_alias=True, exclude_none=True
+        )
+        setup_logging(cliverbosity=verbose,
+                      log_dir=context.envconfig.paths.tmp.log_dir,
+                      user_config={"logging": logging_config}
+        )
+        # log.debug("Logging initialized with config: %s", logging_config)
+
 
     except (ValueError, ValidationError, tomllib.TOMLDecodeError) as e:
         handle_validation_error(e, current_model, current_files, verbose, ctx)

--- a/src/docbuild/cli/defaults.py
+++ b/src/docbuild/cli/defaults.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 from ..constants import (
     APP_NAME,
-    BASE_LOG_DIR,
     CACHE_HOME,
     CONFIG_HOME,
     DATA_HOME,
@@ -80,7 +79,7 @@ DEFAULT_ENV_CONFIG = {
             "tmp_metadata_dir": "{tmp_dir}/metadata",
             "tmp_build_base_dir": "{tmp_dir}/build",
             "tmp_out_dir": "{tmp_dir}/out",
-            "log_dir": BASE_LOG_DIR,
+            "log_dir": f"{STATE_HOME}/{{server.name}}/log",
             "tmp_deliverable_name_dyn": "{{product}}_{{docset}}_{{lang}}_XXXXXX",
         },
         "target": {

--- a/src/docbuild/cli/defaults.py
+++ b/src/docbuild/cli/defaults.py
@@ -9,20 +9,17 @@ They can be overridden by the user through configuration files or command-line o
 
 from pathlib import Path
 
-import platformdirs
-
-from ..constants import APP_NAME
+from ..constants import (
+    APP_NAME,
+    BASE_LOG_DIR,
+    CACHE_HOME,
+    CONFIG_HOME,
+    DATA_HOME,
+    DEFAULT_SERVER_NAME,
+    RUNTIME_DIR,
+    STATE_HOME,
+)
 from ..utils.paths import mark_cache_dir
-
-# --- XDG Base Directory Setup ---
-CONFIG_HOME = platformdirs.user_config_dir(APP_NAME)
-DATA_HOME = platformdirs.user_data_dir(APP_NAME)
-STATE_HOME = platformdirs.user_state_dir(APP_NAME)
-CACHE_HOME = platformdirs.user_cache_dir(APP_NAME)
-
-# Dynamically resolve POSIX runtime dir (/run/user/1000/docbuild)
-RUNTIME_DIR = platformdirs.user_runtime_dir(APP_NAME)
-
 
 DEFAULT_APP_CONFIG = {
     "debug": False,
@@ -41,11 +38,16 @@ DEFAULT_APP_CONFIG = {
 }
 """Default configuration for the application."""
 
+
 # --- FIXED DEFAULT_ENV_CONFIG ---
 DEFAULT_ENV_CONFIG = {
-    # 1. ROOT SECTIONS MUST BE PRESENT AND VALIDATED AGAINST EnvConfig
+    # ROOT SECTIONS MUST BE PRESENT AND VALIDATED AGAINST EnvConfig
+    # Rule of thumb:
+    # * Put it in cache if deleting it is safe and the app can rebuild it automatically.
+    # * Put it in state if it is authoritative local state that should survive cache cleanup.
+    # * Put it in tmp/runtime if it is per-run scratch space.
     "server": {
-        "name": "default-local-env",
+        "name": DEFAULT_SERVER_NAME,
         "role": "production",
         "host": "127.0.0.1",
         "enable_mail": False,
@@ -56,31 +58,35 @@ DEFAULT_ENV_CONFIG = {
         "canonical_url_domain": "http://localhost/",
     },
     "paths": {
-        "config_dir": f"{CONFIG_HOME}/config.d",
-        "main_portal_config": f"{CONFIG_HOME}/config.d/portal.xml",
         "root_config_dir": f"{CONFIG_HOME}",
+        "config_dir": "{root_config_dir}/config.d",
+        "main_portal_config": "{config_dir}/portal.xml",
+        "portal_rncschema": "{root_config_dir}/portal-config.rnc",
         "jinja_dir": f"{DATA_HOME}/jinja",
-        "server_rootfiles_dir": f"{CONFIG_HOME}/server-root-files",
+        "server_rootfiles_dir": "{root_config_dir}/server-root-files",
         "tmp_repo_dir": f"{STATE_HOME}/repos/branches",
         "repo_dir": f"{STATE_HOME}/repos/permanent",
         "base_cache_dir": f"{CACHE_HOME}",
-        "base_server_cache_dir": f"{CACHE_HOME}/default",
-        "meta_cache_dir": f"{CACHE_HOME}/default/meta",
-        "base_tmp_dir": RUNTIME_DIR,
+        "base_server_cache_dir": "{base_cache_dir}/{server.name}",
+        "meta_cache_dir": "{base_server_cache_dir}/meta",
+        # "base_tmp_dir": "",
+        "runtime_base_dir": f"{RUNTIME_DIR}",
+        "lock_dir": "{runtime_base_dir}/locks",
+        "json_cache_dir": "{base_server_cache_dir}/json",
         "tmp": {
             "tmp_base_dir": f"/tmp/{APP_NAME}",
-            "tmp_dir": "{tmp_base_dir}/default-local",
+            "tmp_dir": "{tmp_base_dir}/{server.name}",
             "tmp_deliverable_dir": "{tmp_dir}/deliverable",
-            "tmp_metadata_dir": f"{STATE_HOME}/metadata",
-            "tmp_build_base_dir": f"{CACHE_HOME}/build",
+            "tmp_metadata_dir": "{tmp_dir}/metadata",
+            "tmp_build_base_dir": "{tmp_dir}/build",
             "tmp_out_dir": "{tmp_dir}/out",
-            "log_dir": f"{STATE_HOME}/log",
-            "tmp_deliverable_name_dyn": "{{product}}_{{docset}}_{{lang}}_XXXXXX",
+            "log_dir": BASE_LOG_DIR,
+            "tmp_deliverable_name_dyn": "{{{product}}}_{{{docset}}}_{{{lang}}}_XXXXXX",
         },
         "target": {
             "target_base_dir": f"{Path.home()}/Documents/{APP_NAME}/target",
-            "target_dir_dyn": "{{product}}",
-            "backup_dir": f"{STATE_HOME}/backup",
+            "target_dir_dyn": "{{{product}}}",
+            "backup_dir": f"{STATE_HOME}/{{server.name}}/backup",
         },
     },
     "build": {
@@ -95,6 +101,8 @@ DEFAULT_ENV_CONFIG = {
     "xslt-params": {},
 }
 """Default configuration for the environment."""
+
+
 
 # --- Apply CACHEDIR.TAG to required directories ---
 for _cache_dir in [

--- a/src/docbuild/cli/defaults.py
+++ b/src/docbuild/cli/defaults.py
@@ -81,11 +81,11 @@ DEFAULT_ENV_CONFIG = {
             "tmp_build_base_dir": "{tmp_dir}/build",
             "tmp_out_dir": "{tmp_dir}/out",
             "log_dir": BASE_LOG_DIR,
-            "tmp_deliverable_name_dyn": "{{{product}}}_{{{docset}}}_{{{lang}}}_XXXXXX",
+            "tmp_deliverable_name_dyn": "{{product}}_{{docset}}_{{lang}}_XXXXXX",
         },
         "target": {
             "target_base_dir": f"{Path.home()}/Documents/{APP_NAME}/target",
-            "target_dir_dyn": "{{{product}}}",
+            "target_dir_dyn": "{{product}}",
             "backup_dir": f"{STATE_HOME}/{{server.name}}/backup",
         },
     },

--- a/src/docbuild/constants.py
+++ b/src/docbuild/constants.py
@@ -3,11 +3,16 @@
 from pathlib import Path
 import re
 
+import platformdirs
+
 from .models.lifecycle import LifecycleFlag
 from .models.serverroles import ServerRole
 
 APP_NAME: str = "docbuild"
 """The name of the application, used in paths and config files."""
+
+DEFAULT_SERVER_NAME = "default-env"
+"""The default server name used in the application configuration."""
 
 DEFAULT_LANGS: tuple[str, ...]= ("en-us",)
 """The default languages used by the application."""
@@ -21,20 +26,20 @@ DEFAULT_DELIVERABLES: str = "*/@supported/en-us"
 """The default deliverables when no specific doctype is provided."""
 
 # The primary, unique values of the Enum ('production', 'staging', 'testing')
-SERVER_ROLES: tuple[str]= tuple(
+SERVER_ROLES: tuple[str, ...]= tuple(
     [role.value for role in ServerRole]
 )
 """The unique primary server role values."""
 
 # Every single valid name and alias defined in the Enum
 # ('PRODUCTION', 'PROD', 'P', 'production', 'prod', 'p', 'devel', etc.)
-SERVER_ROLES_ALIASES: tuple[str] = tuple(ServerRole.__members__.keys())
+SERVER_ROLES_ALIASES: tuple[str, ...] = tuple(ServerRole.__members__.keys())
 """All valid server role names and aliases for validation and testing."""
 
 DEFAULT_LIFECYCLE: str = "supported"
 """The default lifecycle state for a docset."""
 
-ALLOWED_LIFECYCLES: tuple[str] = tuple(lc.name for lc in LifecycleFlag)
+ALLOWED_LIFECYCLES: tuple[str, ...] = tuple(lc.name for lc in LifecycleFlag)
 # ('supported', 'beta', 'hidden', 'unsupported')
 """The available lifecycle states for a docset (without 'unknown')."""
 
@@ -56,10 +61,11 @@ cloudnative Cloud Native
 compliance Compliance Documentation
 container Container Documentation
 liberty SUSE Multi-Linux Support
+releasenotes SUSE Release Notes
 sbp SUSE Best Practices
 ses SUSE Enterprise Storage
 sled SUSE Linux Enterprise Desktop
-sle-ha SUSE Linux Enterprise High Availability (incl. SLE HA GEO)
+sle-ha SUSE Linux Enterprise High Availability
 sle-hpc SUSE Linux Enterprise High-Performance Computing
 sle-micro SUSE Linux Micro
 sle-public-cloud SUSE Linux Enterprise in Public Clouds
@@ -74,17 +80,19 @@ style SUSE Documentation Style Guide
 subscription Subscription Management
 suma-retail SUSE Multi-Linux Manager for Retail
 suma SUSE Multi-Linux Manager
+suse-ai-factory SUSE AI Factory
 suse-ai SUSE AI
 suse-caasp SUSE CaaS Platform
 suse-cap SUSE Cloud Application Platform
 suse-distribution-migration-system SUSE Distribution Migration System
 suse-edge SUSE Edge
+suse-telco SUSE Telco Cloud
 trd Technical Reference Documentation""".strip().splitlines()
     )
 }
 """A dictionary of valid products acronyms and their full names."""
 
-ALLOWED_PRODUCTS: tuple[str]= tuple([item for item in VALID_PRODUCTS])
+ALLOWED_PRODUCTS: tuple[str, ...]= tuple([item for item in VALID_PRODUCTS])
 """A tuple of valid product acronyms."""
 
 SINGLE_LANG_REGEX: re.Pattern = re.compile(r"[a-z]{2}-[a-z]{2}")
@@ -122,6 +130,24 @@ CONFIG_PATHS: tuple[Path, ...] = (
 )
 """The paths where the application will look for configuration files."""
 
+# --- XDG Base Directory Setup ---
+STATE_HOME: Path = platformdirs.user_state_path(APP_NAME)
+"""The base directory for application state, logs, and locks, per XDG Base Directory Specification."""
+
+CONFIG_HOME: Path = platformdirs.user_config_path(APP_NAME)
+"""The user-specific configuration directory, typically located at ~/.config/docbuild."""
+
+DATA_HOME: Path = platformdirs.user_data_path(APP_NAME)
+"""The user-specific data directory, typically located at ~/.local/share/docbuild."""
+
+CACHE_HOME: Path = platformdirs.user_cache_path(APP_NAME)
+"""The user-specific cache directory, typically located at ~/.cache/docbuild."""
+
+RUNTIME_DIR: Path = platformdirs.user_runtime_path(APP_NAME)
+"""The user-specific runtime directory, typically located at /run/user/1000/docbuild."""
+
+
+# --- Config files ---
 APP_CONFIG_BASENAMES: tuple[str|Path, ...] = (".config.toml", "config.toml")
 """The base filenames for the application configuration files, in
 order of priority."""
@@ -147,8 +173,10 @@ GIT_CONFIG_FILENAME: Path = Path(__file__).parent / "etc/git/gitconfig"
 """The project-specific Git configuration file (relative to this project)"""
 
 # --- State and Logging Constants ---
+BASE_LOG_DIR: Path = Path(f"{STATE_HOME}/{DEFAULT_SERVER_NAME}/log")
+"""The directory where log files will be stored."""
 
-BASE_STATE_DIR: Path = Path.home() / ".local" / "state" / APP_NAME
+BASE_STATE_DIR: Path = STATE_HOME / DEFAULT_SERVER_NAME
 """The directory where application state, logs, and locks are stored,
 per XDG Base Directory Specification."""
 
@@ -158,12 +186,8 @@ GITLOGGER_NAME: str = f"{APP_NAME}.git"
 PORTALLOGGER_NAME: str = f"{APP_NAME}.portal"
 """The standardized name for the Portal-related logger."""
 
-# --- State constants ---
-BASE_LOG_DIR: Path = BASE_STATE_DIR / "logs"
-"""The directory where log files will be stored."""
-
 # --- Locking constants ---
-BASE_LOCK_DIR: Path = BASE_STATE_DIR / "locks"
+BASE_LOCK_DIR: Path = RUNTIME_DIR / "locks"
 """The directory where PID lock files will be stored."""
 
 XMLDATADIR: Path = Path(__file__).parent / "config" / "xml" / "data"

--- a/src/docbuild/logging.py
+++ b/src/docbuild/logging.py
@@ -7,14 +7,13 @@ import copy
 import importlib
 import logging
 import logging.handlers
-import os
 from pathlib import Path
 import queue
 import threading
 import time
 from typing import Any, Self
 
-from .constants import APP_NAME, BASE_LOG_DIR, GITLOGGER_NAME
+from .constants import APP_NAME, GITLOGGER_NAME
 
 # --- Defensive macOS-safe patch ---
 logging.raiseExceptions = False  # Suppress internal logging exception tracebacks
@@ -52,7 +51,7 @@ DEFAULT_LOGGING_CONFIG = {
         "file": {
             "class": "logging.FileHandler",
             "formatter": "standard",
-            "filename": "",
+            "filename": "",  # will be set later
             "level": "DEBUG",
         },
     },
@@ -89,7 +88,7 @@ _LOGGING_STATE: dict[str, contextvars.ContextVar] = {
 def _shutdown_logging() -> None:
     """Ensure all logging threads and handlers shut down cleanly."""
     listener = _LOGGING_STATE["listener"].get()
-    handlers: list[logging.Handler] = _LOGGING_STATE["handlers"].get()
+    handlers: list[logging.Handler] | None = _LOGGING_STATE["handlers"].get()
     bg_threads: list[threading.Thread] | None = _LOGGING_STATE[
         "background_threads"
     ].get()
@@ -99,6 +98,9 @@ def _shutdown_logging() -> None:
     # list to avoid TypeErrors during shutdown.
     if not isinstance(bg_threads, list):
         bg_threads = []
+
+    if not isinstance(handlers, list):
+        handlers = []
 
     if listener:
         with suppress(Exception):
@@ -129,11 +131,11 @@ def register_background_thread(thread: threading.Thread) -> None:
     _LOGGING_STATE["background_threads"].set(threads)
 
 
-def create_base_log_dir(base_log_dir: str | Path = BASE_LOG_DIR) -> Path:
-    """Create the base log directory if it doesn't exist."""
-    log_dir = Path(os.getenv("XDG_STATE_HOME", base_log_dir))
-    log_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
-    return log_dir
+# def create_base_log_dir(base_log_dir: str | Path = BASE_LOG_DIR) -> Path:
+#     """Create the base log directory if it doesn't exist."""
+#     log_dir = Path(os.getenv("XDG_STATE_HOME", base_log_dir))
+#     log_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+#     return log_dir
 
 
 def _resolve_class(path: str) -> type:
@@ -183,7 +185,9 @@ def build_handlers_from_config(config: dict[str, Any]) -> list[logging.Handler]:
     return built_handlers
 
 
-def setup_logging(cliverbosity: int, user_config: dict[str, Any] | None = None) -> None:
+def setup_logging(
+    cliverbosity: int, log_dir: Path, user_config: dict[str, Any] | None = None
+) -> None:
     """Set up a non-blocking, configurable logging system."""
     config = copy.deepcopy(DEFAULT_LOGGING_CONFIG)
 
@@ -202,11 +206,9 @@ def setup_logging(cliverbosity: int, user_config: dict[str, Any] | None = None) 
     verbosity_level = LOGLEVELS.get(min(cliverbosity, 2), logging.WARNING)
     config["handlers"]["console"]["level"] = logging.getLevelName(verbosity_level)
 
-    log_dir = create_base_log_dir()
     timestamp = time.strftime("%Y-%m-%d_%H-%M-%S")
     log_filename = f"{APP_NAME}_{timestamp}.log"
-    log_path = log_dir / log_filename
-    config["handlers"]["file"]["filename"] = str(log_path)
+    config["handlers"]["file"]["filename"] = str(log_dir / log_filename)
 
     # Build handlers (use helper to keep logic in one place)
     handlers = build_handlers_from_config(config)

--- a/src/docbuild/models/config/env.py
+++ b/src/docbuild/models/config/env.py
@@ -353,7 +353,7 @@ class EnvPathsConfig(BaseModel):
     base_cache_dir: EnsureWritableDirectory = Field(
         title="Base Cache Directory",
         description="The root directory for all application-level caches.",
-        examples=["/var/cache/docserv"],
+        examples=["/var/cache/docserv", "~/.cache/docbuild"],
     )
     "Base path for all caches."
 
@@ -367,16 +367,43 @@ class EnvPathsConfig(BaseModel):
     meta_cache_dir: EnsureWritableDirectory = Field(
         title="Metadata Cache Directory",
         description="Cache specifically for repository and deliverable metadata.",
-        examples=["/var/cache/docbuild/doc-example-com/meta"],
+        examples=[
+            "/var/cache/docbuild/doc-example-com/meta",
+            "~/.local/state/docbuild/devel/meta/",
+        ],
     )
     "Metadata cache path."
 
-    base_tmp_dir: EnsureWritableDirectory = Field(
-        title="Base Temporary Directory (System Wide)",
-        description="The root directory for all temporary artifacts (used for placeholder resolution).",
-        examples=["/var/tmp/docbuild"],
+    json_cache_dir: EnsureWritableDirectory = Field(
+        title="JSON Cache Directory",
+        description="Cache specifically for JSON data used in the portal.",
+        examples=[
+            "/var/cache/docbuild/doc-example-com/json",
+            "~/.local/state/docbuild/devel/json/",
+        ],
     )
-    "Base system temporary path."
+    "JSON cache path."
+
+    runtime_base_dir: EnsureWritableDirectory = Field(
+        title="Base Runtime Directory (Per-Run)",
+        description=(
+            "The base directory for lightweight runtime artifacts such as "
+            "lock files, PID files, and sockets (not for general build "
+            "temporary data)."
+        ),
+        examples=["/run/user/1000/docbuild"],
+    )
+    "Base runtime path."
+
+    lock_dir: EnsureWritableDirectory = Field(
+        title="Lock Directory",
+        description=(
+            "Directory for lock files used to prevent concurrent builds or "
+            "operations on the same deliverable or repository."
+        ),
+        examples=["/run/user/1000/docbuild/locks"],
+    )
+    "Directory for lock files."
 
     tmp: EnvTmpPaths
     "Temporary build paths."

--- a/tests/cli/cmd_config/test_init.py
+++ b/tests/cli/cmd_config/test_init.py
@@ -28,7 +28,8 @@ def test_config_list_flat(mock_logging, mock_env, mock_app, runner):
     """Test that 'config list --flat' shows dotted notation."""
     mock_ctx = MagicMock()
     mock_ctx.appconfig.model_dump.return_value = {"logging": {"level": "INFO"}}
-    mock_ctx.envconfig = None
+    mock_ctx.envconfig = MagicMock()
+    mock_ctx.envconfig.paths.tmp.log_dir = Path("/tmp")
     mock_ctx.envconfigfiles = []
 
     result = runner.invoke(cli, ["config", "list", "--app", "--flat"], obj=mock_ctx)

--- a/tests/cli/test_cmd_cli.py
+++ b/tests/cli/test_cmd_cli.py
@@ -61,8 +61,9 @@ def mock_config_models(monkeypatch):
     mock_app_instance.logging = mock_logging_attribute
 
     mock_env_dump = Mock(return_value={"env_data": "from_mock_dump"})
-    mock_env_instance = Mock(spec=EnvConfig)
+    mock_env_instance = Mock()
     mock_env_instance.model_dump.return_value = mock_env_dump
+    mock_env_instance.paths.tmp.log_dir = Path("/tmp")
 
     # Mock the static methods that perform validation
     mock_app_from_dict = Mock(return_value=mock_app_instance)

--- a/tests/cli/test_worker_option.py
+++ b/tests/cli/test_worker_option.py
@@ -9,7 +9,7 @@ def test_workers_option_integration():
     # We use a command that exists but we don't care if it fails
     # due to the directory permissions seen above.
     # We are testing the CLI parsing logic here.
-    result = runner.invoke(cli, ["-j", "1", "config", "show"])
+    result = runner.invoke(cli, ["-j", "1", "config", "list"])
 
     # If '-j' was invalid, exit code would be 2 (Click usage error)
     # Since it's valid, it should proceed to validation logic (exit code 1 or 0)
@@ -20,7 +20,7 @@ def test_workers_option_invalid_value():
     runner = CliRunner()
 
     # Test an invalid string that should trigger our Pydantic ValueError
-    result = runner.invoke(cli, ["-j", "not-a-number", "config", "show"])
+    result = runner.invoke(cli, ["-j", "not-a-number", "config", "list"])
 
     # This should trigger our 'handle_validation_error' logic
     assert result.exit_code == 1

--- a/tests/models/config/test_env.py
+++ b/tests/models/config/test_env.py
@@ -40,7 +40,10 @@ def _mock_successful_placeholder_resolver(data: dict[str, Any]) -> dict[str, Any
     resolved_data["paths"]["meta_cache_dir"] = (
         "/var/cache/docbuild/doc-example-com/meta"
     )
-    resolved_data["paths"]["base_tmp_dir"] = "/var/tmp/docbuild"
+    resolved_data["paths"]["json_cache_dir"] = (
+        "/var/cache/docbuild/doc-example-com/json"
+    )
+    # runtime_base_dir and lock_dir are already concrete paths in the raw test data used by this test.
     resolved_data["paths"]["tmp"]["tmp_base_dir"] = "/var/tmp/docbuild"
     resolved_data["paths"]["tmp"]["tmp_dir"] = tmp_general
     resolved_data["paths"]["tmp"]["tmp_deliverable_dir"] = tmp_general + "/deliverable"
@@ -124,10 +127,12 @@ def mock_valid_raw_env_data(tmp_path: Path) -> dict[str, Any]:
             # These use EnsureWritableDirectory - MUST be in tmp_path
             "base_cache_dir": str(base / "cache"),
             "base_server_cache_dir": str(base / "cache/server"),
-            "base_tmp_dir": str(base / "var/tmp"),
+            "runtime_base_dir": str(base / "runtime"),
+            "lock_dir": str(base / "runtime/locks"),
             "repo_dir": str(base / "repos/perm"),
             "tmp_repo_dir": str(base / "repos/temp"),
             "meta_cache_dir": str(base / "cache/meta"),
+            "json_cache_dir": str(base / "cache/json"),
 
             "tmp": {
                 "tmp_base_dir": str(base / "var/tmp"),
@@ -243,7 +248,9 @@ def test_envconfig_strictness_extra_field_forbid(tmp_path: Path, monkeypatch: An
             "base_cache_dir": str(tmp_path),
             "base_server_cache_dir": str(tmp_path),
             "meta_cache_dir": str(tmp_path),
-            "base_tmp_dir": str(tmp_path),
+            "json_cache_dir": str(tmp_path),
+            "runtime_base_dir": str(tmp_path),
+            "lock_dir": str(tmp_path),
             "tmp": {
                 "tmp_base_dir": str(tmp_path),
                 "tmp_dir": str(tmp_path),

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -11,7 +11,6 @@ from docbuild.logging import (
     _resolve_class,
     _shutdown_logging,
     build_handlers_from_config,
-    create_base_log_dir,
     register_background_thread,
     setup_logging,
 )
@@ -47,10 +46,10 @@ def _get_logged_messages(memory_handler):
     return [record.getMessage() for record in memory_handler.buffer]
 
 
-def test_console_verbosity_levels(logger, memory_handler):
+def test_console_verbosity_levels(logger, memory_handler, tmp_path):
     """Test that console logging respects verbosity levels."""
     # Setup logging with verbosity 0 (console WARNING)
-    setup_logging(cliverbosity=0)
+    setup_logging(cliverbosity=0, log_dir=tmp_path)
 
     # Replace existing StreamHandlers with MemoryHandler
     for h in logger.handlers[:]:
@@ -73,9 +72,9 @@ def test_console_verbosity_levels(logger, memory_handler):
     logger.removeHandler(memory_handler)
 
 
-def test_file_logs_all_levels(logger, memory_handler):
+def test_file_logs_all_levels(logger, memory_handler, tmp_path):
     """Test that file logging captures all levels regardless of console verbosity."""
-    setup_logging(cliverbosity=0)
+    setup_logging(cliverbosity=0, log_dir=tmp_path)
 
     # Replace StreamHandlers with MemoryHandler
     for h in logger.handlers[:]:
@@ -97,7 +96,7 @@ def test_file_logs_all_levels(logger, memory_handler):
     logger.removeHandler(memory_handler)
 
 
-def test_setup_with_user_config(logger):
+def test_setup_with_user_config(logger, tmp_path):
     """Test that user-provided logging configuration is correctly applied."""
     user_config = {
         "logging": {
@@ -107,7 +106,7 @@ def test_setup_with_user_config(logger):
     }
 
     # Apply user logging setup
-    setup_logging(cliverbosity=2, user_config=user_config)
+    setup_logging(cliverbosity=2, log_dir=tmp_path, user_config=user_config)
 
     # Attach MemoryHandler to capture logs
     memory_handler = MemoryHandler(capacity=10 * 1024, target=None)
@@ -128,15 +127,6 @@ def test_setup_with_user_config(logger):
     assert "A warning." not in msgs
 
 
-def test_create_base_log_dir(tmp_path, monkeypatch):
-    """Test that the base log directory is created correctly."""
-    base = tmp_path / "state"
-    # ensure function uses provided base when env var absent
-    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
-    p = create_base_log_dir(base)
-    assert p.exists() and p.is_dir()
-
-
 def test_resolve_class_stdlib():
     """Test that _resolve_class correctly imports a standard library class."""
     cls = _resolve_class("logging.Formatter")
@@ -151,7 +141,7 @@ def test_setup_logging_creates_logfile_and_listener(tmp_path, monkeypatch):
     # Make sure any prior state is cleaned
     _shutdown_logging()
 
-    setup_logging(2, None)
+    setup_logging(2, tmp_path)
 
     listener = _LOGGING_STATE["listener"].get()
     handlers = _LOGGING_STATE["handlers"].get()
@@ -183,7 +173,7 @@ def test_setup_logging_bad_formatter(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     _shutdown_logging()
     with pytest.raises(Exception):  # noqa: B017
-        setup_logging(1, user_config)
+        setup_logging(1, tmp_path, user_config=user_config)
     _shutdown_logging()
 
 


### PR DESCRIPTION
Reason for this PR was to have a config that its paths are based on the user's home directory. It also fixes some oddities with log and runtime directories (mainly lock files).

* Reorg in `constants.py`:
  * Use module `platformdirs` to use a consistent
  * Fix some `tuple[str, ...]` types
  * Update `VALID_PRODUCTS`
  * Introduce XDG directory setup variables for state, config, data, cache, and runtime.
  * Derive `BASE_STATE_DIR` from `STATE_HOME` of platformdirs, not from `Path.home()`.
  * Use `RUNTIME_DIR / "locks"` for locking files

* Reorg in `defaults.py`:
  * Adjust `DEFAULT_ENV_CONFIG` to use XDG variables from `constants.py` or use config placeholders to allow customization in user or repo configs
  * Use home directory as a place for storage as this is writeable and doesn't need additional write privileges.
  * Fix logging directory in `paths.tmp.log_dir` key. Previously, it was in `STATE_HOME/log`, but it makes more sense to have a `server.name` part in between to distinguish between different names.

* Additions in `env.py`:
  * Add `json_cache_dir`: Cache specifically for JSON data used in the portal.
  * Add `runtime_base_dir`: Base Runtime Directory (Per-Run) We didn't have that before
  * Add `lock_dir`: Directory for lock files used to prevent concurrent builds, usually for lock files. Is
  * Disable `base_tmp_dir` as it's not really needed; we have already `paths.tmp.tmp_base_dir`.

* Add missing keys in `env.example.toml`; make order follow the file `defaults.py`

* Adjust test cases