### PR TITLE
fix: ENV config list merging to replace instead of concatenate

### DIFF
--- a/changelog.d/368.bugfix.rst
+++ b/changelog.d/368.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue where overriding list values (such as ``languages``) in the environment configuration appended to the default list instead of cleanly replacing it.

--- a/src/docbuild/config/merge.py
+++ b/src/docbuild/config/merge.py
@@ -13,9 +13,8 @@ def deep_merge(*dcts: Mapping[str, Any]) -> dict[str, Any]:
 
     * If a key exists in both dictionaries and both values are Mappings,
       they will be merged iteratively.
-    * If both values are lists or tuples, they will be concatenated.
     * If both values are sets, they will be unioned.
-    * Otherwise (different types or primitive values), the value from the
+    * Otherwise (different types, lists, tuples, or primitive values), the value from the
       subsequent dictionary will overwrite the previous one.
 
     This means that the order of dictionaries matters. The first dictionary
@@ -52,17 +51,11 @@ def deep_merge(*dcts: Mapping[str, Any]) -> dict[str, Any]:
                         dest[key] = existing
                     stack.append((existing, value))
 
-                # Lists / tuples → concatenate
-                elif (isinstance(existing, list) and isinstance(value, list)) or (
-                    isinstance(existing, tuple) and isinstance(value, tuple)
-                ):
-                    dest[key] = existing + deepcopy(value)  # type: ignore[operator]
-
                 # Sets → union
                 elif isinstance(existing, set) and isinstance(value, set):
                     dest[key] = existing | deepcopy(value)
 
-                # Fallback → overwrite
+                # Fallback → overwrite (including lists and tuples)
                 else:
                     dest[key] = deepcopy(value)
 

--- a/tests/config/app/test_deep_merge.py
+++ b/tests/config/app/test_deep_merge.py
@@ -25,14 +25,14 @@ from docbuild.config.merge import deep_merge
         #
         pytest.param(
             [{"a": [1, 2]}, {"a": [3, 4]}],
-            {"a": [1, 2, 3, 4]},
-            id="list_concatenation",
+            {"a": [3, 4]},
+            id="list_replacement",
         ),
         #
         pytest.param(
             [{"t": (1, 2)}, {"t": (3, 4)}],
-            {"t": (1, 2, 3, 4)},
-            id="tuple_concatenation",
+            {"t": (3, 4)},
+            id="tuple_replacement",
         ),
         #
         pytest.param(
@@ -49,14 +49,14 @@ from docbuild.config.merge import deep_merge
         #
         pytest.param(
             [{"x": {"l": ["a"]}}, {"x": {"l": ["b"]}}],
-            {"x": {"l": ["a", "b"]}},
-            id="nested_list_concatenation",
+            {"x": {"l": ["b"]}},
+            id="nested_list_replacement",
         ),
         #
         pytest.param(
             [{"a": [{"x": 1}]}, {"a": [{"y": 2}]}],
-            {"a": [{"x": 1}, {"y": 2}]},
-            id="list_of_dicts_concatenation",
+            {"a": [{"y": 2}]},
+            id="list_of_dicts_replacement",
         ),
         #
         pytest.param(


### PR DESCRIPTION
Closes #368

Adjusted the deep merge logic so that overriding a list in an environment configuration (like `languages`) cleanly replaces the default list rather than appending to it, aligning with expected user behavior.

### Changes Made

* Updated `src/docbuild/config/merge.py` to remove list and tuple concatenation; they now fall through to the default overwrite behavior.
* Corrected the docstring in `deep_merge` to accurately reflect the new handling of lists and tuples.
* Updated test assertions in `tests/config/app/test_deep_merge.py` to expect replacement instead of concatenation, and renamed the relevant test IDs (for example, `list_concatenation` to `list_replacement`).
* Added news fragment `368.bugfix.rst`.

### Self-Review Checklist

**Conventions & Implementation**:

* [x] List and tuple overrides now correctly replace existing values.
* [x] Existing tests updated to validate the new behavior and pass successfully.

**Documentation & CI**:

* [x] Does the news fragment file exist?