### PR TITLE
Add "skip-changelog" label for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
       default-days: 7
     labels:
       - "area:dependencies"
+      - "skip-changelog"
 
   - package-ecosystem: "pip"
     directory: "/"

--- a/changelog.d/395.infra.rst
+++ b/changelog.d/395.infra.rst
@@ -1,0 +1,1 @@
+Added ``skip-chanagelog`` label for Dependabot pull requests.


### PR DESCRIPTION
When Dependabot opens a new PR, the PR fails due to a missing newsfragment file.
This is the correct and expected behavior. But I usually collect these things when I create a release.

This PR adds this label to avoid any failures.

Is this a good idea? Or should we create the missing news fragment file (manually or automatically)?