### PR TITLE
Fix #386 `docbuild portal list` to fix "unnamed-deliverable"

### DIFF
--- a/changelog.d/400.bugfix.rst
+++ b/changelog.d/400.bugfix.rst
@@ -1,0 +1,1 @@
+Correct :command:`docbuild portal list` to fix "unnamed-deliverable" output for translated deliverables. The deliverable ID is now correctly retrieved from the English locale node when the current node is a reference deliverable.

--- a/src/docbuild/cli/cmd_portal/cmd_list.py
+++ b/src/docbuild/cli/cmd_portal/cmd_list.py
@@ -115,13 +115,13 @@ def build_deliverable_branch(
     repo_format: str | None,
 ) -> None:
     """Format and append a single deliverable node to the Rich Tree."""
-    d_id = deliv.xml.node.get("id", "unnamed-deliverable")
+    d_id = deliv.xml.deliverableid or "unnamed-deliverable"
 
     # 1. Format the main display name
     display_name = get_display_name(deliv, d_id)
     deliv_branch = docset_branch.add(display_name)
 
-    # 2. Automatically show URLs for prebuilt deliverables
+    # 2a. Automatically show URLs for prebuilt deliverables
     if deliv.xml.is_prebuilt:
         for url_node in deliv.xml.node.xpath("prebuilt/url"):
             if href := url_node.get("href"):

--- a/src/docbuild/models/deliverable/view.py
+++ b/src/docbuild/models/deliverable/view.py
@@ -64,6 +64,11 @@ class DeliverableXMLView:
         return self.docset_node.attrib.get("path", None)
 
     @cached_property
+    def locale_en(self) -> etree._Element | None:
+        """Return the English locale node (``<locale lang="en-us">``) or None if absent."""
+        return self.docset_node.find("resources/locale[@lang='en-us']")
+
+    @cached_property
     def lang(self) -> LanguageCode:
         """Return the language and country code (e.g. ``'en-us'``)."""
         return LanguageCode(language=self.node.getparent().attrib.get("lang").strip())
@@ -73,7 +78,37 @@ class DeliverableXMLView:
         """Return the DC filename, or ``None`` if absent."""
         if (dcnode := self.node.find("dc")) is not None:
             return dcnode.attrib.get("file")
+
+        elif self.is_ref:
+            # If validation is correct, we don't explicitly need to check for a
+            # ref/@linkend attribute.
+            refid = self.node.find("ref").get("linkend")
+            dcnode = cast(etree._Element, self.locale_en).find(
+                f"deliverable[@id={refid!r}]/dc"
+            )
+            if dcnode is not None:
+                return dcnode.attrib.get("file")  # is already the @file attribute
+
         return None
+
+    @cached_property
+    def deliverableid(self) -> str | None:
+        """Return the deliverable ID (``<deliverable id=…>``) or None if absent."""
+        # d_id = self.node.attrib.get("id")
+        if (d_id := self.node.get("id")) is not None:
+            return d_id  # is already the @id attribute
+
+        elif self.is_ref:
+            # If this is a reference deliverable, we can try to get the ID from the
+            # linked English deliverable.
+            refid = self.node.find("ref").get("linkend")
+            dcnode = cast(etree._Element, self.locale_en).find(
+                f"deliverable[@id={refid!r}]"
+            )
+            if dcnode is not None:
+                return dcnode.attrib.get("id")  # is already the @id attribute
+        return d_id
+
 
     @cached_property
     def basefile(self) -> str | None:
@@ -117,9 +152,10 @@ class DeliverableXMLView:
         """Return True if the deliverable is marked as DC."""
         if self.kind is not None:
             return self._is_kind("dc")
-        # Fallback: if no type is specified, we can infer DC from the
-        # presence of a DC file
-        return self.dcfile is not None
+        # Fallback: infer DC from a local <dc> child only.
+        # A translated <ref> may resolve dcfile from English, but should
+        # still be classified as ref when @type is missing.
+        return self.node.find("dc") is not None
 
     @cached_property
     def is_ref(self) -> bool:

--- a/tests/cli/cmd_portal/test_cmd_list.py
+++ b/tests/cli/cmd_portal/test_cmd_list.py
@@ -90,7 +90,7 @@ def test_portal_list_invalid_docset_for_product(mock_parse, tmp_path) -> None:
     clean_output = result.output.replace("\n", "")
     assert "Allowed values are: '*', '15sp4', '15sp5'" in clean_output
 
-@patch("docbuild.cli.cmd_portal.cmd_list.parse_portal_config", new_callable=AsyncMock)
+@patch.object(cmd_list, "parse_portal_config", new_callable=AsyncMock)
 def test_portal_list_malformed_xml(mock_parse, tmp_path) -> None:
     """Test that the command gracefully aborts if the portal.xml contains unparseable syntax."""
     runner = CliRunner()
@@ -108,7 +108,7 @@ def test_portal_list_malformed_xml(mock_parse, tmp_path) -> None:
     assert "Error loading XML schema:" in result.output
 
 
-@patch("docbuild.cli.cmd_portal.cmd_list.parse_portal_config", new_callable=AsyncMock)
+@patch.object(cmd_list, "parse_portal_config", new_callable=AsyncMock)
 def test_portal_list_success(mock_parse, tmp_path) -> None:
     """Test that 'portal list' parses a valid configuration and displays the tree structure."""
     runner = CliRunner()
@@ -145,7 +145,7 @@ def test_portal_list_success(mock_parse, tmp_path) -> None:
     assert "admin_guide (DC-admin-guide)" in result.output
 
 
-@patch("docbuild.cli.cmd_portal.cmd_list.parse_portal_config", new_callable=AsyncMock)
+@patch.object(cmd_list, "parse_portal_config", new_callable=AsyncMock)
 def test_portal_list_with_doctype_filter(mock_parse, tmp_path) -> None:
     """Test that 'portal list' successfully accepts and processes valid Doctype filtering arguments."""
     runner = CliRunner()
@@ -182,7 +182,88 @@ def test_portal_list_with_doctype_filter(mock_parse, tmp_path) -> None:
     assert "admin_guide (DC-admin-guide)" in result.output
 
 
-@patch("docbuild.cli.cmd_portal.cmd_list.parse_portal_config", new_callable=AsyncMock)
+@patch.object(cmd_list, "parse_portal_config", new_callable=AsyncMock)
+def test_portal_list_ref_uses_english_dcfile(mock_parse, tmp_path) -> None:
+    """Test that translated ref deliverables display the linked English DC file."""
+    runner = CliRunner()
+
+    portal_content = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<portal schemaversion="7.0">\n'
+        '    <product id="sles">\n'
+        '        <docset path="16.0" lifecycle="supported">\n'
+        '            <resources>\n'
+        '                <locale lang="en-us">\n'
+        '                    <deliverable id="admin_guide" type="dc">\n'
+        '                        <dc file="DC-admin-guide">\n'
+        '                            <format html="1"/>\n'
+        '                        </dc>\n'
+        '                    </deliverable>\n'
+        '                </locale>\n'
+        '                <locale lang="de-de">\n'
+        '                    <deliverable id="admin_guide_de" type="ref">\n'
+        '                        <ref linkend="admin_guide"/>\n'
+        '                    </deliverable>\n'
+        '                </locale>\n'
+        '            </resources>\n'
+        '        </docset>\n'
+        '    </product>\n'
+        '</portal>\n'
+    )
+    mock_parse.return_value = etree.fromstring(portal_content.encode("utf-8"))
+
+    mock_ctx = DocBuildContext()
+    mock_ctx.envconfig = MagicMock()
+    mock_ctx.envconfig.paths.main_portal_config.expanduser.return_value = tmp_path / "portal.xml"
+
+    result = runner.invoke(list_cmd, ["sles/16.0/de-de"], obj=mock_ctx)
+
+    assert result.exit_code == 0, result.output
+    assert "admin_guide_de (DC-admin-guide)" in result.output
+
+
+@patch.object(cmd_list, "parse_portal_config", new_callable=AsyncMock)
+def test_portal_list_ref_without_id_uses_linked_id(mock_parse, tmp_path) -> None:
+    """Test that translated ref deliverables without @id use linked English ID."""
+    runner = CliRunner()
+
+    portal_content = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<portal schemaversion="7.0">\n'
+        '    <product id="sles">\n'
+        '        <docset path="16.0" lifecycle="supported">\n'
+        '            <resources>\n'
+        '                <locale lang="en-us">\n'
+        '                    <deliverable id="admin_guide" type="dc">\n'
+        '                        <dc file="DC-admin-guide">\n'
+        '                            <format html="1"/>\n'
+        '                        </dc>\n'
+        '                    </deliverable>\n'
+        '                </locale>\n'
+        '                <locale lang="de-de">\n'
+        '                    <deliverable type="ref">\n'
+        '                        <ref linkend="admin_guide"/>\n'
+        '                    </deliverable>\n'
+        '                </locale>\n'
+        '            </resources>\n'
+        '        </docset>\n'
+        '    </product>\n'
+        '</portal>\n'
+    )
+    mock_parse.return_value = etree.fromstring(portal_content.encode("utf-8"))
+
+    mock_ctx = DocBuildContext()
+    mock_ctx.envconfig = MagicMock()
+    mock_ctx.envconfig.paths.main_portal_config.expanduser.return_value = tmp_path / "portal.xml"
+
+    result = runner.invoke(list_cmd, ["sles/16.0/de-de"], obj=mock_ctx)
+
+    assert result.exit_code == 0, result.output
+    assert "admin_guide (DC-admin-guide)" in result.output
+    assert "unnamed-deliverable" not in result.output
+
+
+@patch.object(cmd_list, "parse_portal_config", new_callable=AsyncMock)
 def test_portal_list_no_matching_deliverables(mock_parse, tmp_path) -> None:
     """Test that the command displays a yellow notice if filters yield zero results."""
     runner = CliRunner()
@@ -259,7 +340,8 @@ COMPREHENSIVE_MOCK_XML = """<?xml version="1.0" encoding="UTF-8"?>
 </portal>
 """
 
-@patch("docbuild.cli.cmd_portal.cmd_list.parse_portal_config", new_callable=AsyncMock)
+
+@patch.object(cmd_list, "parse_portal_config", new_callable=AsyncMock)
 def test_portal_list_metadata_flags(mock_parse, tmp_path) -> None:
     """Test that all metadata flags successfully inject info into the tree."""
     runner = CliRunner()

--- a/tests/models/deliverables/test_identity.py
+++ b/tests/models/deliverables/test_identity.py
@@ -50,3 +50,10 @@ def test_dcfile_on_prebuilt(first_prebuilt_deliverable: Deliverable) -> None:
 
 def test_basefile(first_deliverable: Deliverable) -> None:
     assert first_deliverable.xml.basefile == "SLES-administration"
+
+
+def test_locale_en_on_translated_deliverable(first_ref_deliverable: Deliverable) -> None:
+    """Test that translated deliverables can resolve the English locale node."""
+    locale_en = first_ref_deliverable.xml.locale_en
+    assert locale_en is not None
+    assert locale_en.get("lang") == "en-us"


### PR DESCRIPTION
The command `docbuild portal list` shows `unnamed-deliverable` for translations.

This fix makes the following changes:

* Introduces the `locale_en` cached property to return the English locale. This is used in `dcfile` and `deliverableid`.
* The property `dcfile` considers translations (a deliverable with `<ref/>`) now.
* Introduces `deliverableid` to return the correct ID for a translation.