### PR TITLE
Mention user story in the GH issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -20,8 +20,10 @@ body:
   - type: textarea
     id: use_case
     attributes:
-      label: Use Case
-      description: Why is this feature useful? What problem does it solve?
+      label: Use Case / User Story
+      description: >
+         Why is this feature useful? What problem does it solve?
+         As a [persona], I [want to], [so that].
     validations:
       required: true
 

--- a/changelog.d/412.infra.rst
+++ b/changelog.d/412.infra.rst
@@ -1,0 +1,1 @@
+Minor fix in the GitHub issue template and mentions user stories 


### PR DESCRIPTION
Clarifying that the "Use Case" area can also be a user story. Also added the typical user story template.