### PR TITLE
Change dependency group "devel" -> "dev"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Docbuild builds documentation from DocBook 5/ASCIIDoc, manages XML configs, clon
 ## Setup
 
 1. Create a virtual environment with `uv venv`
-2. Install dependencies: `uv sync --frozen --no-sync --group devel`
+2. Install dependencies: `uv sync --frozen --no-sync`
 
 ## Testing with `uv`
 

--- a/changelog.d/413.infra.rst
+++ b/changelog.d/413.infra.rst
@@ -1,0 +1,1 @@
+Change dependency group ``devel`` to ``dev`` to simplify calling :command:`uv`.

--- a/docs/source/developer/prepare-environment.rst
+++ b/docs/source/developer/prepare-environment.rst
@@ -85,7 +85,7 @@ The following steps are recommended to set up your development environment:
       :caption: Synchronizing the virtual environment with the development dependencies
       :name: uv-sync-devel
 
-      $ uv sync --frozen --group devel
+      $ uv sync --frozen
 
    The option ``--frozen`` ensures that the dependencies are installed exactly as specified in the lock file, preventing any unexpected changes.
 

--- a/docs/source/developer/update-package.rst
+++ b/docs/source/developer/update-package.rst
@@ -8,4 +8,4 @@ time keep the development group dependencies intact, use the following command:
 
 .. code-block:: shell-session
 
-   $ uv sync --group devel --upgrade-package pydantic-core
+   $ uv sync --upgrade-package pydantic-core

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ github-action = [
   {include-group = "tests"},
   {include-group = "docs"},
 ]
-devel = [
+dev = [
   {include-group = "typing"},
   {include-group = "formatting"},
   {include-group = "changelog"},
@@ -103,6 +103,8 @@ devel = [
   {include-group = "repl"},
   # {include-group = "publish"},
 ]
+# Introduce compatibility layer
+devel = [{include-group = "dev"}]
 
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -295,6 +295,27 @@ dependencies = [
 changelog = [
     { name = "towncrier" },
 ]
+dev = [
+    { name = "docformatter" },
+    { name = "ipython" },
+    { name = "myst-parser" },
+    { name = "pydata-sphinx-theme" },
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+    { name = "setuptools-scm" },
+    { name = "sphinx" },
+    { name = "sphinx-autoapi" },
+    { name = "sphinx-autodoc-typehints" },
+    { name = "sphinx-click" },
+    { name = "sphinx-copybutton" },
+    { name = "sphinx-design" },
+    { name = "sphinxcontrib-mermaid" },
+    { name = "sphobjinv" },
+    { name = "towncrier" },
+]
 devel = [
     { name = "docformatter" },
     { name = "ipython" },
@@ -375,6 +396,27 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 changelog = [{ name = "towncrier", specifier = ">=25.8.0" }]
+dev = [
+    { name = "docformatter", specifier = ">=1.7.8" },
+    { name = "ipython", specifier = ">=9.15.0" },
+    { name = "myst-parser", specifier = ">=5.1.0" },
+    { name = "pydata-sphinx-theme", specifier = ">=0.20.0" },
+    { name = "pyright", specifier = ">=1.1.411" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "ruff", specifier = ">=0.15.22" },
+    { name = "setuptools-scm", specifier = ">=10.2.1" },
+    { name = "sphinx", specifier = ">=9.1.0" },
+    { name = "sphinx-autoapi", specifier = ">=3.8.0" },
+    { name = "sphinx-autodoc-typehints", specifier = ">=3.13.0" },
+    { name = "sphinx-click", specifier = ">=6.2.0" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2" },
+    { name = "sphinx-design", specifier = ">=0.7.0" },
+    { name = "sphinxcontrib-mermaid", specifier = ">=2.1.0" },
+    { name = "sphobjinv", specifier = ">=2.4" },
+    { name = "towncrier", specifier = ">=25.8.0" },
+]
 devel = [
     { name = "docformatter", specifier = ">=1.7.8" },
     { name = "ipython", specifier = ">=9.15.0" },


### PR DESCRIPTION
This PR renames the `devel` group dependency name to `dev`.

### Reason
This makes it a bit easier with `uv` as you don't have to select this group explicitly anymore. The uv tool [syncs the `dev` group by default](https://docs.astral.sh/uv/concepts/projects/dependencies/#default-groups).

### Changes
* Change the name in `pyproject.toml`. Keep the name `devel` as a compatibility layer; it's just an alias to `dev` now.
* Update `uv.lock`
* Update the documentation

### See also

* https://docs.astral.sh/uv/concepts/projects/dependencies/#development-dependencies
* https://docs.astral.sh/uv/reference/cli/#uv-add--dev
* https://docs.astral.sh/uv/reference/environment/#uv_dev