### PR TITLE
Fix missing check for skip-repo-update option

### DIFF
--- a/changelog.d/415.bugfix.rst
+++ b/changelog.d/415.bugfix.rst
@@ -1,0 +1,2 @@
+Fix handling of option ``--skip-repo-update``.
+Previously, this flag was ignored and repos were always updated.

--- a/src/docbuild/tasks/metadata/daps.py
+++ b/src/docbuild/tasks/metadata/daps.py
@@ -64,6 +64,7 @@ async def process_deliverable(
     meta_cache_dir: Path,
     *,
     dapstmpl: str,
+    skip_repo_update: bool = False,
 ) -> tuple[bool, Deliverable]:
     """Process a single deliverable asynchronously.
 
@@ -75,6 +76,7 @@ async def process_deliverable(
     :param tmp_repo_dir: Path to the temporary worktree directory.
     :param meta_cache_dir: Path to the metadata cache output directory.
     :param dapstmpl: A template string with the daps command and potential placeholders.
+    :param skip_repo_update: If True, do not update/fetch the bare repository.
     :return: A tuple of ``(success, deliverable)``.
     """
     log.info("> Processing deliverable: %s", deliverable.full_id)
@@ -105,10 +107,11 @@ async def process_deliverable(
             ),
         ) as worktree_dir:
             mg = ManagedGitRepo(deliverable.git.url, repo_dir)
-            if not await mg.clone_bare():
-                raise RuntimeError(
-                    f"Failed to ensure bare repository for {deliverable.full_id}"
-                )
+            if not skip_repo_update:
+                if not await mg.clone_bare():
+                    raise RuntimeError(
+                        f"Failed to ensure bare repository for {deliverable.full_id}"
+                    )
 
             try:
                 await mg.create_worktree(worktree_dir, deliverable.branch)

--- a/src/docbuild/tasks/metadata/runner.py
+++ b/src/docbuild/tasks/metadata/runner.py
@@ -23,6 +23,21 @@ stdout = Console()
 console_err = Console(stderr=True, style="red")
 
 
+def get_deliverable_worker_limit(
+    max_workers: int, deliverable_count: int
+) -> int:
+    """Resolve the concurrency limit for deliverable processing.
+
+    :param max_workers: The maximum number of concurrent workers allowed.
+    :param deliverable_count: Number of deliverables to process.
+    :return: A worker limit between 1 and ``deliverable_count``.
+    """
+    if deliverable_count <= 0:
+        return 1
+
+    return max(1, min(max_workers, deliverable_count))
+
+
 async def run_tasks_fail_fast(tasks: list[asyncio.Task]) -> list[Deliverable]:
     """Execute tasks and stop immediately on the first failure.
 
@@ -101,7 +116,7 @@ async def process_doctype(
 
     :param root: The stitched XML node containing configuration.
     :param doctype: The Doctype object to process.
-    :param repo_dir: Path to the repositories directory.
+    :param repo_dir: Path to the repository directory.
     :param tmp_repo_dir: Path to the temporary repositories directory.
     :param meta_cache_dir: Path to the metadata cache output directory.
     :param dapsmetatmpl: Template string for the DAPS command.
@@ -119,7 +134,7 @@ async def process_doctype(
     else:
         await update_repositories(deliverables, repo_dir)
 
-    worker_limit = max(1, min(max_workers, len(deliverables)))
+    worker_limit = get_deliverable_worker_limit(max_workers, len(deliverables))
     semaphore = asyncio.Semaphore(worker_limit)
 
     async def process_deliverable_limited(
@@ -132,6 +147,7 @@ async def process_doctype(
                 tmp_repo_dir,
                 meta_cache_dir,
                 dapstmpl=dapsmetatmpl,
+                skip_repo_update=skip_repo_update,
             )
 
     tasks = [
@@ -161,20 +177,22 @@ async def process(
 ) -> int:
     """Asynchronous entry point for metadata retrieval.
 
-    :param main_portal_config: Path to the main portal XML configuration.
+    :param main_portal_config: Path to the main portal XML configuration file.
     :param tmp_metadata_dir: Path to the temporary metadata directory.
-    :param repo_dir: Path to the repositories directory.
-    :param tmp_repo_dir: Path to the temporary repositories directory.
-    :param meta_cache_dir: Path to the metadata cache output directory.
-    :param json_cache_dir: Path to the JSON cache output directory.
-    :param dapsmetatmpl: Template string for the DAPS command.
-    :param max_workers: Maximum number of concurrent workers allowed.
+    :param repo_dir: Path to the local repository directory.
+    :param tmp_repo_dir: Path to the temporary worktree repository directory.
+    :param meta_cache_dir: Path to metadata output cache.
+    :param json_cache_dir: Path to JSON output cache.
+    :param dapsmetatmpl: Template string for the DAPS metadata command.
+    :param max_workers: Maximum number of concurrent deliverable workers.
     :param doctypes: A sequence of Doctype objects to process.
     :param exitfirst: If True, stop processing on the first failure.
     :param skip_repo_update: If True, skip updating Git repositories before processing.
     :return: 0 if all files passed validation, 1 if any failures occurred.
     """
-    stitchnode: etree._ElementTree = await parse_portal_config(main_portal_config)
+    stitchnode: etree._ElementTree = await parse_portal_config(
+        Path(main_portal_config).expanduser()
+    )
 
     tmp_metadata_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tests/tasks/metadata/test_daps.py
+++ b/tests/tasks/metadata/test_daps.py
@@ -275,3 +275,42 @@ class TestProcessDeliverable:
         assert success is False
         assert res_deliverable is deliverable
         assert any("Error processing" in r.message for r in caplog.records)
+
+    @patch.object(daps_pkg, "update_metadata_json")
+    @patch.object(daps_pkg.asyncio, "create_subprocess_exec", new_callable=AsyncMock)
+    @patch.object(daps_pkg, "ManagedGitRepo")
+    async def test_skip_repo_update_bypasses_clone_bare(
+        self,
+        mock_managed_git_repo: Mock,
+        mock_subprocess_exec: AsyncMock,
+        mock_update_metadata_json: Mock,
+        deliverable: Deliverable,
+        setup_paths: dict,
+    ):
+        """When skip_repo_update=True, clone_bare is not called."""
+        mock_repo_instance = AsyncMock()
+        mock_managed_git_repo.return_value = mock_repo_instance
+        mock_repo_instance.create_worktree.return_value = None
+
+        mock_daps_proc = AsyncMock()
+        mock_daps_proc.communicate.return_value = (b"", b"")
+        mock_daps_proc.returncode = 0
+        mock_subprocess_exec.return_value = mock_daps_proc
+
+        (setup_paths["repo_dir"] / deliverable.git.slug).mkdir()
+
+        # Using explicit paths instead of mock_context!
+        success, res_deliverable = await process_deliverable(
+            deliverable=deliverable,
+            repo_dir=setup_paths["repo_dir"],
+            tmp_repo_dir=setup_paths["tmp_repo_dir"],
+            meta_cache_dir=setup_paths["meta_cache_dir"],
+            dapstmpl="daps --dc-file={dcfile} --output={output}",
+            skip_repo_update=True,
+        )
+
+        assert success is True
+        assert res_deliverable is deliverable
+        mock_repo_instance.clone_bare.assert_not_awaited()
+        mock_repo_instance.create_worktree.assert_awaited_once()
+        mock_update_metadata_json.assert_called_once()


### PR DESCRIPTION
Previously, this flag was ignored and repos were always updated.