### PR TITLE
Fix description logic in output JSON

### DIFF
--- a/changelog.d/416.bugfix.rst
+++ b/changelog.d/416.bugfix.rst
@@ -1,0 +1,1 @@
+Fix description logic in output JSON and how global and local descriptions are merged.

--- a/src/docbuild/tasks/metadata/manifest.py
+++ b/src/docbuild/tasks/metadata/manifest.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 import json
 import logging
 from pathlib import Path
+from typing import Literal
 
 from lxml import etree  # type: ignore
 from pydantic import ValidationError
@@ -24,17 +25,7 @@ def apply_parity_fixes(descriptions: list, categories: list) -> None:
     :param descriptions: List of Description objects to patch.
     :param categories: List of Category objects to patch.
     """
-    # TODO: These strings are hard-coded for legacy parity but should be moved to
-    # Docserv config files to allow for proper translation and localization.
-    legacy_tail = (
-        "<p>The default view of this page is the ```Table of Contents``` sorting order. "
-        "To search for a particular document, you can narrow down the results using the "
-        "```Filter as you type``` option. It dynamically filters the document titles and "
-        "descriptions for what you enter.</p>"
-    )
     for desc in descriptions:
-        if legacy_tail not in desc.description:
-            desc.description += legacy_tail
         desc.description = desc.description.replace("& ", "&amp; ")
 
     for cat in categories:
@@ -123,6 +114,57 @@ def load_and_validate_documents(
             log.error("Error processing metadata file %s: %s", actual_file, e)
 
 
+def merge_descriptions_with_treatment(
+    product_descriptions: list[Description],
+    docset_descriptions: list[Description],
+    treatment: Literal["append", "prepend", "replace"] = "replace",
+) -> list[Description]:
+    """Merge product and docset descriptions according to treatment policy.
+
+    :param product_descriptions: Descriptions from the product scope.
+    :param docset_descriptions: Descriptions from the docset scope.
+    :param treatment: How docset descriptions interact with product descriptions.
+    :return: Merged descriptions list.
+    """
+    if not docset_descriptions:
+        return [d.model_copy(deep=True) for d in product_descriptions]
+
+    if treatment == "replace":
+        return [d.model_copy(deep=True) for d in docset_descriptions]
+
+    product_by_lang = {str(d.lang): d for d in product_descriptions}
+    docset_by_lang = {str(d.lang): d for d in docset_descriptions}
+
+    ordered_langs = [str(d.lang) for d in product_descriptions]
+    ordered_langs.extend(
+        str(d.lang) for d in docset_descriptions if str(d.lang) not in product_by_lang
+    )
+
+    merged: list[Description] = []
+    for lang in ordered_langs:
+        p_desc = product_by_lang.get(lang)
+        d_desc = docset_by_lang.get(lang)
+
+        if p_desc and d_desc:
+            if treatment == "prepend":
+                text = f"{d_desc.description}{p_desc.description}"
+            else:
+                text = f"{p_desc.description}{d_desc.description}"
+            merged.append(
+                Description(
+                    lang=lang,
+                    default=p_desc.default or d_desc.default,
+                    description=text,
+                )
+            )
+        elif d_desc:
+            merged.append(d_desc.model_copy(deep=True))
+        elif p_desc:
+            merged.append(p_desc.model_copy(deep=True))
+
+    return merged
+
+
 def configured_languages_from_docset(docsetnode: etree._Element) -> list[LanguageCode]:
     """Return configured locale languages from a docset node.
 
@@ -168,7 +210,17 @@ def store_productdocset_json(
         docsetxpath = f"./{doctype.docset_xpath_segment(docset)}"
         docsetnode: etree.Element = productnode.find(docsetxpath)
 
-        descriptions = list(Description.from_xml_node(productnode))
+        product_descriptions = list(Description.from_xml_node(productnode))
+        docset_descriptions = list(Description.from_xml_node(docsetnode))
+        descriptions_node = docsetnode.find("descriptions")
+        treatment = "replace"
+        if descriptions_node is not None:
+            treatment = descriptions_node.attrib.get("treatment", treatment)
+        descriptions = merge_descriptions_with_treatment(
+            product_descriptions,
+            docset_descriptions,
+            treatment=treatment if treatment in {"append", "prepend", "replace"} else "replace",
+        )
 
         # Global (portal-level) categories first, then local (product-level) ones
         categories = list(Category.from_xml_node(stitchnode.getroot()))

--- a/tests/tasks/metadata/test_manifest.py
+++ b/tests/tasks/metadata/test_manifest.py
@@ -12,6 +12,7 @@ from docbuild.models.doctype import Doctype
 import docbuild.tasks.metadata.manifest as manifest_pkg
 from docbuild.tasks.metadata.manifest import (
     configured_languages_from_docset,
+    merge_descriptions_with_treatment,
     store_productdocset_json,
 )
 
@@ -208,6 +209,87 @@ def test_store_productdocset_json_handles_read_error(
     mock_log.error.assert_called()
 
 
+@pytest.mark.parametrize(
+    ("treatment", "docset_lang", "expected_lang", "expected_description"),
+    [
+        ("append", "en-us", "en-us", "<p>global</p><p>local</p>"),
+        ("prepend", "en-us", "en-us", "<p>local</p><p>global</p>"),
+        ("replace", "de-de", "de-de", "<p>local</p>"),
+    ],
+)
+def test_merge_descriptions_with_treatment(
+    treatment: str,
+    docset_lang: str,
+    expected_lang: str,
+    expected_description: str,
+) -> None:
+    """Merges descriptions according to append/prepend/replace treatment."""
+    product_desc = [
+        manifest_pkg.Description(lang="en-us", default=True, description="<p>global</p>")
+    ]
+    docset_desc = [
+        manifest_pkg.Description(lang=docset_lang, default=False, description="<p>local</p>")
+    ]
+
+    merged = merge_descriptions_with_treatment(
+        product_desc,
+        docset_desc,
+        treatment=treatment,
+    )
+
+    assert len(merged) == 1
+    assert str(merged[0].lang) == expected_lang
+    assert merged[0].description == expected_description
+
+
+def test_store_productdocset_json_applies_docset_description_treatment(
+    tmp_path: Path,
+) -> None:
+    """Docset descriptions with treatment=append are merged with product descriptions."""
+    xml_string = """
+    <docservconfig>
+      <product id="sles">
+        <name>SUSE Linux Enterprise Server</name>
+        <acronym>SLES</acronym>
+        <descriptions>
+          <desc lang="en-us"><p>Global</p></desc>
+        </descriptions>
+        <docset id="sles.16.0" path="16.0" lifecycle="supported">
+          <descriptions treatment="append">
+            <desc lang="en-us"><p>Local</p></desc>
+          </descriptions>
+          <resources>
+            <git remote="https://github.com/SUSE/doc-sle.git"/>
+            <locale lang="en-us"/>
+          </resources>
+        </docset>
+      </product>
+    </docservconfig>
+    """
+    stitchnode_local = etree.ElementTree(etree.fromstring(xml_string))
+    doctype = Doctype.from_str("sles/16.0/en-us")
+    meta_cache_dir = tmp_path / "cache" / "metadata"
+    meta_cache_dir.mkdir(parents=True, exist_ok=True)
+    json_cache_dir = tmp_path / "cache" / "json"
+    json_cache_dir.mkdir(parents=True, exist_ok=True)
+
+    with patch.object(
+        manifest_pkg,
+        "collect_files_flat",
+        return_value=[(doctype, "16.0", [])],
+    ):
+        store_productdocset_json(
+            doctypes=[doctype],
+            stitchnode=stitchnode_local,
+            meta_cache_dir=meta_cache_dir,
+            json_cache_dir=json_cache_dir,
+        )
+
+    out_file = json_cache_dir / "sles" / "16.0.json"
+    data = json.loads(out_file.read_text(encoding="utf-8"))
+    assert data["descriptions"][0]["description"] == "<p>Global</p><p>Local</p>"
+
+
 def test_configured_languages_from_docset_preserves_order_and_uniqueness() -> None:
     """Extract configured locale languages in order while removing duplicates."""
     docset_node = etree.fromstring(
@@ -216,9 +298,6 @@ def test_configured_languages_from_docset_preserves_order_and_uniqueness() -> No
           <resources>
             <locale lang="en-us"/>
             <locale lang="de-de"/>
-            <locale lang="en-us"/>
-            <locale lang=""/>
-            <locale/>
             <locale lang="fr-fr"/>
           </resources>
         </docset>


### PR DESCRIPTION
The "global" and "local" descriptions need to be merged in the correct way.

* `src/docbuild/tasks/metadata/manifest.py`
   Take into account the "treatment" attribute

