### PR TITLE
feat(portal): add --flat option to portal list command

### DIFF
--- a/changelog.d/382.feature.rst
+++ b/changelog.d/382.feature.rst
@@ -1,0 +1,1 @@
+Add a ``--flat`` option to ``docbuild portal list`` to display the output as a flat, non-hierarchical list.

--- a/src/docbuild/cli/cmd_portal/cmd_list.py
+++ b/src/docbuild/cli/cmd_portal/cmd_list.py
@@ -172,6 +172,60 @@ def print_hierarchy(
         console.print()
 
 
+def print_flat(
+    deliverables: list[Deliverable],
+    console: Console,
+    show_trans: bool,
+    show_formats: bool,
+    show_categories: bool,
+    repo_format: str | None,
+) -> None:
+    """Render and print the deliverables as a flat list."""
+    # Sort logically: lang -> product -> docset -> id
+    sorted_deliverables = sorted(
+        deliverables,
+        key=lambda d: (
+            str(d.xml.lang),
+            d.xml.productid or "",
+            d.xml.docsetid or "",
+            d.xml.node.get("id", ""),
+        )
+    )
+
+    for deliv in sorted_deliverables:
+        lang = str(deliv.xml.lang)
+        product = deliv.xml.productid or "unknown-product"
+        docset = deliv.xml.docsetid or "unknown-docset"
+        d_id = deliv.xml.deliverableid or "unnamed-deliverable"
+
+        display_name = get_display_name(deliv, d_id)
+
+        # Build the flat root string
+        flat_title = f"{lang}/{product}/{docset}:{display_name}"
+        deliv_tree = Tree(flat_title)
+
+        # Attach metadata if requested
+        if deliv.xml.is_prebuilt:
+            for url_node in deliv.xml.node.xpath("prebuilt/url"):
+                if href := url_node.get("href"):
+                    deliv_tree.add(f"URL: [link={href}]{href}[/link]")
+
+        if show_trans:
+            append_translations(deliv_tree, deliv, lang)
+        if show_formats:
+            append_formats(deliv_tree, deliv)
+        if show_categories:
+            append_categories(deliv_tree, deliv)
+        if repo_format:
+            append_repo(deliv_tree, deliv, repo_format)
+
+        # Print cleanly if there's no metadata branches, otherwise print the tree block
+        if deliv_tree.children:
+            console.print(deliv_tree)
+        else:
+            console.print(flat_title)
+
+
 def validate_docsets_against_xml(
     doctypes: list[Doctype], tree: etree._ElementTree | etree._Element, console: Console
 ) -> None:
@@ -216,6 +270,7 @@ async def async_list_cmd(
     show_formats: bool,
     show_categories: bool,
     repo_format: str | None,
+    flat: bool,
 ) -> None:
     """Async worker to fetch the XML, parse Doctypes, and build the tree."""
     parsed_doctypes = parse_doctypes(doctypes, console)
@@ -248,16 +303,25 @@ async def async_list_cmd(
         console.print("[yellow]No deliverables found matching the criteria.[/yellow]")
         return
 
-    hierarchy = build_hierarchy(deliverables)
-
-    print_hierarchy(
-        hierarchy,
-        console,
-        show_trans,
-        show_formats,
-        show_categories,
-        repo_format
-    )
+    if flat:
+        print_flat(
+            deliverables,
+            console,
+            show_trans,
+            show_formats,
+            show_categories,
+            repo_format
+        )
+    else:
+        hierarchy = build_hierarchy(deliverables)
+        print_hierarchy(
+            hierarchy,
+            console,
+            show_trans,
+            show_formats,
+            show_categories,
+            repo_format
+        )
 
 
 @click.command(name="list")
@@ -271,6 +335,7 @@ async def async_list_cmd(
     default=None,
     help="List repository origin (requires 'short' or 'long')."
 )
+@click.option("--flat", is_flag=True, help="Display the output as a flat list.")
 @click.argument("doctypes", nargs=-1)
 @click.pass_obj
 def list_cmd(
@@ -280,6 +345,7 @@ def list_cmd(
     formats: bool,
     categories: bool,
     repo: str | None,
+    flat: bool,
 ) -> None:
     """List products, docsets, and deliverables from the portal config.
 
@@ -297,8 +363,8 @@ def list_cmd(
     :param formats: Show output formats metadata.
     :param categories: Show categories metadata.
     :param repo: Show repository metadata (short or long).
+    :param flat: Display a flat list instead of a hierarchy tree.
 
     """ # noqa: D301
     console = Console()
-    asyncio.run(async_list_cmd(ctx, doctypes, console, trans, formats, categories, repo))
-
+    asyncio.run(async_list_cmd(ctx, doctypes, console, trans, formats, categories, repo, flat))

--- a/src/docbuild/cli/cmd_portal/cmd_list.py
+++ b/src/docbuild/cli/cmd_portal/cmd_list.py
@@ -200,8 +200,8 @@ def print_flat(
 
         display_name = get_display_name(deliv, d_id)
 
-        # Build the flat root string
-        flat_title = f"{lang}/{product}/{docset}:{display_name}"
+        # Build the flat root string with colors matching the hierarchy
+        flat_title = f"[bold blue]{lang}[/bold blue]/[bold]{product}[/bold]/[cyan]{docset}[/cyan]:{display_name}"
         deliv_tree = Tree(flat_title)
 
         # Attach metadata if requested

--- a/tests/cli/cmd_portal/test_cmd_list.py
+++ b/tests/cli/cmd_portal/test_cmd_list.py
@@ -398,7 +398,7 @@ def test_portal_list_repo_requires_argument() -> None:
 
 
 @patch.object(cmd_list, "parse_portal_config", new_callable=AsyncMock)
-def test_portal_list_flat_mode(mock_parse, tmp_path) -> None:
+def test_portal_list_flat_mode_basic(mock_parse, tmp_path) -> None:
     """Test that the --flat flag formats the output as a flat list."""
     runner = CliRunner()
     mock_parse.return_value = etree.fromstring(COMPREHENSIVE_MOCK_XML.encode("utf-8"))
@@ -407,14 +407,23 @@ def test_portal_list_flat_mode(mock_parse, tmp_path) -> None:
     mock_ctx.envconfig = MagicMock()
     mock_ctx.envconfig.paths.main_portal_config.expanduser.return_value = tmp_path / "portal.xml"
 
-    # 1. Basic flat output
     res_flat = runner.invoke(list_cmd, ["--flat", "sles/16.0/*"], obj=mock_ctx)
     assert res_flat.exit_code == 0
     assert "en-us/sles/16.0:admin_guide (DC-admin-guide)" in res_flat.output
     assert "en-us/sles/16.0:SUSE Docs (Prebuilt)" in res_flat.output
     assert "de-de/sles/16.0:admin_guide (DC-admin-guide)" in res_flat.output
 
-    # 2. Flat output with metadata branches appended
+
+@patch.object(cmd_list, "parse_portal_config", new_callable=AsyncMock)
+def test_portal_list_flat_mode_metadata(mock_parse, tmp_path) -> None:
+    """Test that the --flat flag properly appends metadata branches."""
+    runner = CliRunner()
+    mock_parse.return_value = etree.fromstring(COMPREHENSIVE_MOCK_XML.encode("utf-8"))
+
+    mock_ctx = DocBuildContext()
+    mock_ctx.envconfig = MagicMock()
+    mock_ctx.envconfig.paths.main_portal_config.expanduser.return_value = tmp_path / "portal.xml"
+
     res_flat_meta = runner.invoke(list_cmd, ["--flat", "--trans", "--formats", "--repo", "short", "sles/16.0/*"], obj=mock_ctx)
     assert res_flat_meta.exit_code == 0
     assert "en-us/sles/16.0:admin_guide (DC-admin-guide)" in res_flat_meta.output

--- a/tests/cli/cmd_portal/test_cmd_list.py
+++ b/tests/cli/cmd_portal/test_cmd_list.py
@@ -301,7 +301,7 @@ COMPREHENSIVE_MOCK_XML = """<?xml version="1.0" encoding="UTF-8"?>
             <language id="tuning-and-performance" title="Tuning and performance" />
         </category>
     </categories>
-    <product id="sles">=
+    <product id="sles">
         <docset path="16.0" lifecycle="supported">
             <resources>
                 <git remote="https://github.com/SUSE/doc-modular.git" />
@@ -395,3 +395,29 @@ def test_portal_list_repo_requires_argument() -> None:
     assert result.exit_code != 0
     assert "Invalid value for '--repo' / '-R'" in result.output
     assert "is not one of 'short', 'long'" in result.output
+
+
+@patch.object(cmd_list, "parse_portal_config", new_callable=AsyncMock)
+def test_portal_list_flat_mode(mock_parse, tmp_path) -> None:
+    """Test that the --flat flag formats the output as a flat list."""
+    runner = CliRunner()
+    mock_parse.return_value = etree.fromstring(COMPREHENSIVE_MOCK_XML.encode("utf-8"))
+
+    mock_ctx = DocBuildContext()
+    mock_ctx.envconfig = MagicMock()
+    mock_ctx.envconfig.paths.main_portal_config.expanduser.return_value = tmp_path / "portal.xml"
+
+    # 1. Basic flat output
+    res_flat = runner.invoke(list_cmd, ["--flat", "sles/16.0/*"], obj=mock_ctx)
+    assert res_flat.exit_code == 0
+    assert "en-us/sles/16.0:admin_guide (DC-admin-guide)" in res_flat.output
+    assert "en-us/sles/16.0:SUSE Docs (Prebuilt)" in res_flat.output
+    assert "de-de/sles/16.0:admin_guide (DC-admin-guide)" in res_flat.output
+
+    # 2. Flat output with metadata branches appended
+    res_flat_meta = runner.invoke(list_cmd, ["--flat", "--trans", "--formats", "--repo", "short", "sles/16.0/*"], obj=mock_ctx)
+    assert res_flat_meta.exit_code == 0
+    assert "en-us/sles/16.0:admin_guide (DC-admin-guide)" in res_flat_meta.output
+    assert "Translations: de-de" in res_flat_meta.output
+    assert "Formats: HTML, PDF" in res_flat_meta.output
+    assert "gh://suse/doc-modular" in res_flat_meta.output.lower()


### PR DESCRIPTION
Closes #382

**What was done:**

* **Added `--flat` option:** Integrated the new boolean flag into the `list_cmd` Click command.
* **Implemented `print_flat`:** Created a new rendering function that outputs deliverables linearly as `lang/product/docset:deliverable (dcfile)` instead of using the deeply nested `rich` tree.
* **Preserved metadata branches:** Ensured that optional flags like `--repo`, `--trans`, and `--formats` still function properly in flat mode, appending cleanly as child nodes to their respective flat entry.
* **Updated Tests:** Added `test_portal_list_flat_mode` to `test_cmd_list.py` to verify both the pure flat output and the flat output with metadata flags.
* **Added Changelog:** Created `changelog.d/382.feature.rst`.

### Checklist
- [x] Code is properly formatted (`uvx ruff check --fix`)
- [x] Tests have been updated and are passing locally
- [x] A changelog entry was added to `changelog.d/`