### PR TITLE
Optimise metadata by grouping deliverables

### DIFF
--- a/changelog.d/426.feature.rst
+++ b/changelog.d/426.feature.rst
@@ -1,0 +1,5 @@
+Optimise :command:`docbuild metadata` by grouping deliverables that share
+the same repository and branch into a single shared ``git worktree``.
+This reduces the number of worktree checkout operations from one per
+deliverable to one per unique ``(repository, branch)`` pair, significantly
+reducing overhead when many DC files live on the same branch.

--- a/src/docbuild/cli/cmd_metadata/__init__.py
+++ b/src/docbuild/cli/cmd_metadata/__init__.py
@@ -66,6 +66,7 @@ def metadata(
     tmp_metadata_dir = Path(env.paths.tmp.tmp_metadata_dir)
     repo_dir = Path(env.paths.repo_dir)
     tmp_repo_dir = Path(env.paths.tmp_repo_dir)
+    tmp_dir = Path(env.paths.tmp.tmp_dir)
     meta_cache_dir = Path(env.paths.meta_cache_dir)
     json_cache_dir = Path(env.paths.json_cache_dir)
     dapsmetatmpl = str(env.build.daps.meta)
@@ -84,6 +85,7 @@ def metadata(
                     tmp_metadata_dir=tmp_metadata_dir,
                     repo_dir=repo_dir,
                     tmp_repo_dir=tmp_repo_dir,
+                    tmp_dir=tmp_dir,
                     meta_cache_dir=meta_cache_dir,
                     json_cache_dir=json_cache_dir,
                     dapsmetatmpl=dapsmetatmpl,

--- a/src/docbuild/tasks/metadata/daps.py
+++ b/src/docbuild/tasks/metadata/daps.py
@@ -13,14 +13,14 @@ log = logging.getLogger(__name__)
 
 
 def get_daps_command(
-    worktree_dir: Path,
+    builddir: Path,
     dcfile_path: Path,
     outputjson: Path,
     dapstmpl: str,
 ) -> list[str]:
     """Construct the DAPS command for native execution.
 
-    :param worktree_dir: The working directory for the git worktree.
+    :param builddir: The build directory DAPS should write its artifacts to.
     :param dcfile_path: Absolute path to the DC file within the worktree.
     :param outputjson: Path where DAPS should write its JSON output.
     :param dapstmpl: A template string with ``{builddir}``, ``{dcfile}``,
@@ -28,7 +28,7 @@ def get_daps_command(
     :return: A list of command arguments suitable for ``subprocess.exec``.
     """
     raw_daps_cmd = dapstmpl.format(
-        builddir=str(worktree_dir),
+        builddir=str(builddir),
         dcfile=str(dcfile_path),
         output=str(outputjson),
     )
@@ -99,20 +99,20 @@ async def process_deliverable(
     outputjson = outputdir / deliverable.xml.dcfile
 
     try:
+        mg = ManagedGitRepo(deliverable.git.url, repo_dir)
+        if not skip_repo_update:
+            if not await mg.clone_bare():
+                raise RuntimeError(
+                    f"Failed to ensure bare repository for {deliverable.full_id}"
+                )
+
         async with PersistentOnErrorTemporaryDirectory(
             dir=str(tmp_repo_dir),
             prefix=(
-                f"clone-{deliverable.xml.productid}-{deliverable.xml.docsetid}"
+                f"wt-{deliverable.xml.productid}-{deliverable.xml.docsetid}"
                 f"-{deliverable.xml.lang}-{deliverable.xml.dcfile}_"
             ),
         ) as worktree_dir:
-            mg = ManagedGitRepo(deliverable.git.url, repo_dir)
-            if not skip_repo_update:
-                if not await mg.clone_bare():
-                    raise RuntimeError(
-                        f"Failed to ensure bare repository for {deliverable.full_id}"
-                    )
-
             try:
                 await mg.create_worktree(worktree_dir, deliverable.branch)
             except Exception as e:
@@ -143,6 +143,7 @@ async def process_deliverable(
                 log.error("DAPS Error: %s", stderr_data.decode())
                 raise RuntimeError(f"DAPS failed for {deliverable.full_id}")
 
+        await mg.prune_worktrees()
         update_metadata_json(outputjson, deliverable)
         log.debug("Updated metadata JSON for %s", deliverable.full_id)
         return True, deliverable
@@ -150,3 +151,142 @@ async def process_deliverable(
     except Exception as e:
         log.error("Error processing %s: %s", deliverable.full_id, str(e))
         return False, deliverable
+
+
+async def _run_daps_for_deliverable(
+    deliverable: Deliverable,
+    worktree_dir: Path,
+    tmp_dir: Path,
+    meta_cache_dir: Path,
+    dapstmpl: str,
+) -> tuple[bool, Deliverable]:
+    """Run daps for one deliverable inside an existing worktree.
+
+    :param deliverable: The Deliverable to process.
+    :param worktree_dir: Path to an already-checked-out working tree.
+    :param tmp_dir: Path to the general temporary directory holding build dirs.
+    :param meta_cache_dir: Path to the metadata cache output directory.
+    :param dapstmpl: Template string for the DAPS metadata command.
+    :return: A tuple of ``(success, deliverable)``.
+    """
+    log.info("> Processing deliverable: %s", deliverable.full_id)
+
+    if not deliverable.xml.dcfile:
+        log.debug("Deliverable %s has no DC file (prebuilt), skipping.", deliverable.full_id)
+        return True, deliverable
+
+    outputdir = meta_cache_dir / deliverable.paths.relpath
+    outputdir.mkdir(parents=True, exist_ok=True)
+    outputjson = outputdir / deliverable.xml.dcfile
+
+    full_dcfile_path = worktree_dir / deliverable.subdir / deliverable.xml.dcfile
+
+    try:
+        # The worktree is shared by the whole group, so every daps run needs its
+        # own build directory; a shared one makes concurrent runs clobber each other.
+        async with PersistentOnErrorTemporaryDirectory(
+            dir=str(tmp_dir),
+            prefix=f"daps-{deliverable.make_safe_name(deliverable.full_id)}_",
+            suffix="-build",
+        ) as build_dir:
+            cmd = get_daps_command(build_dir, full_dcfile_path, outputjson, dapstmpl)
+
+            daps_proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr_data = await daps_proc.communicate()
+
+            if daps_proc.returncode != 0:
+                log.error(
+                    "DAPS Error for %s: %s", deliverable.full_id, stderr_data.decode()
+                )
+                raise RuntimeError(f"DAPS failed for {deliverable.full_id}")
+
+        update_metadata_json(outputjson, deliverable)
+        log.debug("Updated metadata JSON for %s", deliverable.full_id)
+        return True, deliverable
+
+    except Exception as e:
+        log.error("Error processing %s: %s", deliverable.full_id, str(e))
+        return False, deliverable
+
+
+async def process_deliverable_group(
+    deliverables: list[Deliverable],
+    repo_dir: Path,
+    tmp_repo_dir: Path,
+    tmp_dir: Path,
+    meta_cache_dir: Path,
+    dapstmpl: str,
+    semaphore: asyncio.Semaphore,
+    *,
+    skip_repo_update: bool = False,
+) -> list[Deliverable]:
+    """Process all deliverables that share the same repository and branch.
+
+    Creates a single worktree for the group and runs daps for each deliverable
+    concurrently within it, subject to the shared semaphore.
+
+    :param deliverables: Deliverables sharing the same ``(git.url, branch)`` pair.
+    :param repo_dir: Path to the base repositories directory.
+    :param tmp_repo_dir: Path to the temporary worktree directory.
+    :param tmp_dir: Path to the general temporary directory holding build dirs.
+    :param meta_cache_dir: Path to the metadata cache output directory.
+    :param dapstmpl: Template string for the DAPS metadata command.
+    :param semaphore: Shared semaphore bounding total concurrent daps processes.
+    :param skip_repo_update: If True, do not update/fetch the bare repository.
+    :return: A list of Deliverables that failed.
+    """
+    first = deliverables[0]
+    mg = ManagedGitRepo(first.git.url, repo_dir)
+
+    bare_repo_path = repo_dir / first.git.slug
+    if not bare_repo_path.is_dir():
+        log.error("Bare repository not found for %s at %s", first.git.name, bare_repo_path)
+        return list(deliverables)
+
+    if not skip_repo_update:
+        if not await mg.clone_bare():
+            log.error("Failed to ensure bare repository for %s", first.git.name)
+            return list(deliverables)
+
+    prefix = (
+        f"wt-{first.xml.productid}-{first.xml.docsetid}"
+        f"-{first.branch.replace('/', '-')}_"
+    )
+    log.info(
+        "Processing group %s/%s: %d deliverable(s).",
+        first.git.name, first.branch, len(deliverables),
+    )
+    failed: list[Deliverable] = []
+    async with PersistentOnErrorTemporaryDirectory(dir=str(tmp_repo_dir), prefix=prefix) as worktree_dir:
+        try:
+            await mg.create_worktree(worktree_dir, first.branch)
+        except Exception as e:
+            log.error("Failed to create worktree for %s/%s: %s", first.git.name, first.branch, e)
+            return list(deliverables)
+
+        async def _limited(d: Deliverable) -> tuple[bool, Deliverable]:
+            async with semaphore:
+                return await _run_daps_for_deliverable(
+                    d, worktree_dir, tmp_dir, meta_cache_dir, dapstmpl
+                )
+
+        tasks = [
+            asyncio.create_task(_limited(d), name=f"daps_{d.full_id}")
+            for d in deliverables
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        for d, result in zip(deliverables, results, strict=False):
+            if isinstance(result, Exception):
+                log.error("Task error for %s: %s", d.full_id, result)
+                failed.append(d)
+            elif not result[0]:
+                failed.append(result[1])
+
+    await mg.prune_worktrees()
+    return failed

--- a/src/docbuild/tasks/metadata/runner.py
+++ b/src/docbuild/tasks/metadata/runner.py
@@ -4,6 +4,7 @@ import asyncio
 from collections.abc import Sequence
 import logging
 from pathlib import Path
+from typing import Any
 
 from aiostream import pipe, stream
 from lxml import etree  # type: ignore
@@ -14,7 +15,7 @@ from docbuild.models.deliverable import Deliverable
 from docbuild.models.doctype import Doctype
 from docbuild.tasks.portal import parse_portal_config
 
-from .daps import process_deliverable
+from .daps import process_deliverable_group
 from .deliverables import get_deliverable_from_doctype
 from .manifest import store_productdocset_json
 from .repos import update_repositories
@@ -44,6 +45,7 @@ async def process_doctype(
     doctype: Doctype,
     repo_dir: Path,
     tmp_repo_dir: Path,
+    tmp_dir: Path,
     meta_cache_dir: Path,
     dapsmetatmpl: str,
     max_workers: int,
@@ -57,6 +59,7 @@ async def process_doctype(
     :param doctype: The Doctype object to process.
     :param repo_dir: Path to the repository directory.
     :param tmp_repo_dir: Path to the temporary repositories directory.
+    :param tmp_dir: Path to the general temporary directory holding build dirs.
     :param meta_cache_dir: Path to the metadata cache output directory.
     :param dapsmetatmpl: Template string for the DAPS command.
     :param max_workers: Maximum number of concurrent workers allowed.
@@ -78,36 +81,60 @@ async def process_doctype(
 
     worker_limit = get_deliverable_worker_limit(max_workers, len(deliverables))
 
-    # Wrapper to catch exceptions safely and match the MapCallable signature
-    async def process_deliverable_wrapper(
-        deliverable: Deliverable, *args: object
-    ) -> tuple[bool, Deliverable]:
+    # Group by (repo URL, branch) so each unique checkout is shared
+    groups: dict[tuple[str, str], list[Deliverable]] = {}
+    failed: list[Deliverable] = []
+
+    for d in deliverables:
         try:
-            return await process_deliverable(
-                deliverable,
+            groups.setdefault((d.git.url, d.branch), []).append(d)
+        except Exception as e:
+            log.error("Failed to determine Git routing for %s: %s", d.pdlangdc, e)
+            failed.append(d)
+
+    log.info(
+        "Processing %d deliverables across %d worktree group(s).",
+        len(deliverables) - len(failed),
+        len(groups),
+    )
+
+    # The pipeline bounds concurrent worktrees, the semaphore bounds concurrent
+    # daps processes across all worktrees.
+    worktree_limit = get_deliverable_worker_limit(max_workers, len(groups))
+    semaphore = asyncio.Semaphore(worker_limit)
+
+    # Wrapper to catch exceptions safely and match the MapCallable signature
+    async def process_group_wrapper(
+        group: list[Deliverable], *args: object
+    ) -> list[Deliverable]:
+        try:
+            return await process_deliverable_group(
+                group,
                 repo_dir,
                 tmp_repo_dir,
+                tmp_dir,
                 meta_cache_dir,
-                dapstmpl=dapsmetatmpl,
+                dapsmetatmpl,
+                semaphore,
                 skip_repo_update=skip_repo_update,
             )
         except Exception as e:
-            log.error("Error in task for %s: %s", deliverable.full_id, e)
-            return False, deliverable
+            log.error("Group task failed unexpectedly: %s", e)
+            return list(group)
 
     # The elegant aiostream pipeline!
-    pipeline = stream.iterate(deliverables) | pipe.map(
-        process_deliverable_wrapper, task_limit=worker_limit, ordered=True
+    pipeline: Any = stream.iterate(groups.values()) | pipe.map(
+        process_group_wrapper,  # type: ignore[arg-type]
+        task_limit=worktree_limit,
+        ordered=True,
     )
-
-    failed: list[Deliverable] = []
 
     try:
         # Evaluate the pipeline and collect results
         async with pipeline.stream() as streamer:
-            async for success, deliverable in streamer:
-                if not success:
-                    failed.append(deliverable)
+            async for group_failures in streamer:
+                if group_failures:
+                    failed.extend(group_failures)
                     if exitfirst:
                         break  # Breaking automatically safely cancels pending tasks!
     except Exception as e:
@@ -121,6 +148,7 @@ async def process(
     tmp_metadata_dir: Path,
     repo_dir: Path,
     tmp_repo_dir: Path,
+    tmp_dir: Path,
     meta_cache_dir: Path,
     json_cache_dir: Path,
     dapsmetatmpl: str,
@@ -136,6 +164,7 @@ async def process(
     :param tmp_metadata_dir: Path to the temporary metadata directory.
     :param repo_dir: Path to the local repository directory.
     :param tmp_repo_dir: Path to the temporary worktree repository directory.
+    :param tmp_dir: Path to the general temporary directory holding build dirs.
     :param meta_cache_dir: Path to metadata output cache.
     :param json_cache_dir: Path to JSON output cache.
     :param dapsmetatmpl: Template string for the DAPS metadata command.
@@ -171,6 +200,7 @@ async def process(
             dt,
             repo_dir,
             tmp_repo_dir,
+            tmp_dir,
             meta_cache_dir,
             dapsmetatmpl,
             max_workers,
@@ -190,7 +220,7 @@ async def process(
     if all_failed_deliverables:
         console_err.print(f"Found {len(all_failed_deliverables)} failed deliverables:")
         for d in all_failed_deliverables:
-            console_err.print(f"- {d.full_id}")
+            console_err.print(f"- {d.pdlangdc}")
         return 1
 
     return 0

--- a/src/docbuild/utils/git.py
+++ b/src/docbuild/utils/git.py
@@ -153,7 +153,6 @@ class ManagedGitRepo:
         target_dir: Path,
         branch: str,
         *,
-        is_local: bool = True,
         options: list[str] | None = None,
     ) -> None:
         """Create a temporary worktree from the bare repository."""
@@ -163,19 +162,44 @@ class ManagedGitRepo:
                 f"{self.bare_repo_path}"
             )
 
-        clone_args = ["clone"]
-        if is_local:
-            pass
-        clone_args.extend(["--branch", branch])
+        worktree_args = ["worktree", "add", "--detach", str(target_dir), branch]
         if options:
-            clone_args.extend(options)
-        clone_args.extend([str(self.bare_repo_path), str(target_dir)])
+            worktree_args.extend(options)
 
         self.result = await execute_git_command(
-            *clone_args,
-            cwd=target_dir.parent,
+            *worktree_args,
+            cwd=self.bare_repo_path,
             gitconfig=self._gitconfig,
         )
+
+    async def prune_worktrees(self: Self) -> None:
+        """Remove stale worktree metadata from the bare repository."""
+        if not self.bare_repo_path.exists():
+            return
+        try:
+            self.result = await execute_git_command(
+                "worktree", "prune",
+                cwd=self.bare_repo_path,
+                gitconfig=self._gitconfig,
+            )
+        except RuntimeError as e:
+            log.warning("Failed to prune worktrees for '%s': %s", self.slug, e)
+
+    async def remove_worktree(self: Self, path: Path) -> None:
+        """Unregister and delete a worktree from the bare repository.
+
+        :param path: Path to the worktree directory to remove.
+        """
+        if not self.bare_repo_path.exists():
+            return
+        try:
+            self.result = await execute_git_command(
+                "worktree", "remove", "--force", str(path),
+                cwd=self.bare_repo_path,
+                gitconfig=self._gitconfig,
+            )
+        except RuntimeError as e:
+            log.warning("Failed to remove worktree '%s': %s", path, e)
 
     async def fetch_updates(self: Self) -> bool:
         """Fetch updates for all branches from the remote.

--- a/tests/cli/cmd_metadata/test_cmd_metadata.py
+++ b/tests/cli/cmd_metadata/test_cmd_metadata.py
@@ -26,6 +26,7 @@ def test_metadata_command_delegates_to_task(runner, tmp_path, mock_generate_meta
     mock_env.paths.tmp.tmp_metadata_dir = tmp_path / "tmp_meta"
     mock_env.paths.repo_dir = tmp_path / "repos"
     mock_env.paths.tmp_repo_dir = tmp_path / "tmp_repos"
+    mock_env.paths.tmp.tmp_dir = tmp_path / "tmp"
     mock_env.paths.meta_cache_dir = tmp_path / "cache_meta"
     mock_env.paths.json_cache_dir = tmp_path / "cache_json"
     mock_env.build.daps.meta = "daps --meta"
@@ -44,6 +45,7 @@ def test_metadata_command_delegates_to_task(runner, tmp_path, mock_generate_meta
         tmp_metadata_dir=tmp_path / "tmp_meta",
         repo_dir=tmp_path / "repos",
         tmp_repo_dir=tmp_path / "tmp_repos",
+        tmp_dir=tmp_path / "tmp",
         meta_cache_dir=tmp_path / "cache_meta",
         json_cache_dir=tmp_path / "cache_json",
         dapsmetatmpl="daps --meta",

--- a/tests/tasks/metadata/test_daps.py
+++ b/tests/tasks/metadata/test_daps.py
@@ -1,5 +1,6 @@
 """Unit tests for docbuild.tasks.metadata.daps."""
 
+import asyncio
 from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -204,6 +205,7 @@ class TestProcessDeliverable:
         mock_managed_git_repo.return_value = mock_repo_instance
         mock_repo_instance.clone_bare.return_value = clone_returns
         mock_repo_instance.create_worktree.return_value = None
+        mock_repo_instance.prune_worktrees.return_value = None
 
         mock_daps_proc = AsyncMock()
         mock_daps_proc.communicate.return_value = (b"", b"")
@@ -291,6 +293,7 @@ class TestProcessDeliverable:
         mock_repo_instance = AsyncMock()
         mock_managed_git_repo.return_value = mock_repo_instance
         mock_repo_instance.create_worktree.return_value = None
+        mock_repo_instance.prune_worktrees.return_value = None
 
         mock_daps_proc = AsyncMock()
         mock_daps_proc.communicate.return_value = (b"", b"")
@@ -299,7 +302,6 @@ class TestProcessDeliverable:
 
         (setup_paths["repo_dir"] / deliverable.git.slug).mkdir()
 
-        # Using explicit paths instead of mock_context!
         success, res_deliverable = await process_deliverable(
             deliverable=deliverable,
             repo_dir=setup_paths["repo_dir"],
@@ -313,4 +315,121 @@ class TestProcessDeliverable:
         assert res_deliverable is deliverable
         mock_repo_instance.clone_bare.assert_not_awaited()
         mock_repo_instance.create_worktree.assert_awaited_once()
+        mock_repo_instance.prune_worktrees.assert_awaited_once()
         mock_update_metadata_json.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# process_deliverable_group tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestProcessDeliverableGroup:
+    """Tests for process_deliverable_group."""
+
+    @pytest.fixture
+    def paths(self, tmp_path: Path) -> dict:
+        """Create directories needed by process_deliverable_group."""
+        p = {
+            "repo_dir": tmp_path / "repos",
+            "tmp_repo_dir": tmp_path / "tmp_repos",
+            "tmp_dir": tmp_path / "tmp",
+            "meta_cache_dir": tmp_path / "cache" / "metadata",
+        }
+        for d in p.values():
+            d.mkdir(parents=True, exist_ok=True)
+        return p
+
+    @patch.object(daps_pkg, "ManagedGitRepo")
+    async def test_group_creates_one_worktree_for_all_members(
+        self,
+        mock_managed_git_repo: Mock,
+        deliverable: Deliverable,
+        paths: dict,
+    ):
+        """All deliverables in a group share a single worktree."""
+        mock_repo_instance = AsyncMock()
+        mock_managed_git_repo.return_value = mock_repo_instance
+        mock_repo_instance.clone_bare.return_value = True
+        mock_repo_instance.create_worktree.return_value = None
+        mock_repo_instance.prune_worktrees.return_value = None
+
+        (paths["repo_dir"] / deliverable.git.slug).mkdir()
+
+        semaphore = asyncio.Semaphore(4)
+
+        with patch.object(daps_pkg, "_run_daps_for_deliverable", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (True, deliverable)
+            from docbuild.tasks.metadata.daps import process_deliverable_group
+            failed = await process_deliverable_group(
+                deliverables=[deliverable, deliverable],
+                repo_dir=paths["repo_dir"],
+                tmp_repo_dir=paths["tmp_repo_dir"],
+                tmp_dir=paths["tmp_dir"],
+                meta_cache_dir=paths["meta_cache_dir"],
+                dapstmpl="daps --dc-file={dcfile} --output={output}",
+                semaphore=semaphore,
+                skip_repo_update=False,
+            )
+
+        assert failed == []
+        mock_repo_instance.create_worktree.assert_awaited_once()
+        assert mock_run.call_count == 2
+
+    @patch.object(daps_pkg, "ManagedGitRepo")
+    async def test_group_returns_failed_deliverables(
+        self,
+        mock_managed_git_repo: Mock,
+        deliverable: Deliverable,
+        paths: dict,
+    ):
+        """Deliverables whose daps run fails are included in the returned list."""
+        mock_repo_instance = AsyncMock()
+        mock_managed_git_repo.return_value = mock_repo_instance
+        mock_repo_instance.clone_bare.return_value = True
+        mock_repo_instance.create_worktree.return_value = None
+        mock_repo_instance.prune_worktrees.return_value = None
+
+        (paths["repo_dir"] / deliverable.git.slug).mkdir()
+
+        semaphore = asyncio.Semaphore(4)
+
+        with patch.object(daps_pkg, "_run_daps_for_deliverable", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (False, deliverable)
+            from docbuild.tasks.metadata.daps import process_deliverable_group
+            failed = await process_deliverable_group(
+                deliverables=[deliverable],
+                repo_dir=paths["repo_dir"],
+                tmp_repo_dir=paths["tmp_repo_dir"],
+                tmp_dir=paths["tmp_dir"],
+                meta_cache_dir=paths["meta_cache_dir"],
+                dapstmpl="daps --dc-file={dcfile} --output={output}",
+                semaphore=semaphore,
+            )
+
+        assert failed == [deliverable]
+
+    @patch.object(daps_pkg, "ManagedGitRepo")
+    async def test_group_missing_bare_repo_fails_all(
+        self,
+        mock_managed_git_repo: Mock,
+        deliverable: Deliverable,
+        paths: dict,
+    ):
+        """All deliverables are returned as failed when the bare repo is absent."""
+        mock_managed_git_repo.return_value = AsyncMock()
+        semaphore = asyncio.Semaphore(4)
+        # bare repo directory is NOT created
+
+        from docbuild.tasks.metadata.daps import process_deliverable_group
+        failed = await process_deliverable_group(
+            deliverables=[deliverable, deliverable],
+            repo_dir=paths["repo_dir"],
+            tmp_repo_dir=paths["tmp_repo_dir"],
+            tmp_dir=paths["tmp_dir"],
+            meta_cache_dir=paths["meta_cache_dir"],
+            dapstmpl="daps --dc-file={dcfile} --output={output}",
+            semaphore=semaphore,
+        )
+
+        assert len(failed) == 2

--- a/tests/tasks/metadata/test_runner.py
+++ b/tests/tasks/metadata/test_runner.py
@@ -38,6 +38,7 @@ def runner_kwargs(tmp_path: Path) -> dict[str, Any]:
         "tmp_metadata_dir": tmp_path / "tmp" / "metadata",
         "repo_dir": tmp_path / "repos",
         "tmp_repo_dir": tmp_path / "tmp_repos",
+        "tmp_dir": tmp_path / "tmp",
         "meta_cache_dir": tmp_path / "cache" / "metadata",
         "json_cache_dir": tmp_path / "cache" / "json",
         "dapsmetatmpl": "daps-command-template",
@@ -60,12 +61,12 @@ def empty_xml_root() -> etree._ElementTree:
 class TestProcessDoctype:
     """Tests for process_doctype."""
 
-    @patch.object(runner_pkg, "process_deliverable", new_callable=AsyncMock)
+    @patch.object(runner_pkg, "process_deliverable_group", new_callable=AsyncMock)
     @patch.object(runner_pkg, "get_deliverable_from_doctype")
     async def test_success_with_deliverables(
         self,
         mock_get_deliverables: Mock,
-        mock_process_deliverable: AsyncMock,
+        mock_process_group: AsyncMock,
         empty_xml_root: etree._ElementTree,
         tmp_path: Path,
     ) -> None:
@@ -76,23 +77,26 @@ class TestProcessDoctype:
         d1 = SortableMock(
             spec=Deliverable,
             full_id="sles/15/en-us:DC-A",
-            git=Mock(spec=Repo, url="gh://SUSE/doc-test")
+            git=Mock(spec=Repo, url="gh://SUSE/doc-test"),
+            branch="main",
         )
         d2 = SortableMock(
             spec=Deliverable,
             full_id="sles/15/en-us:DC-B",
-            git=Mock(spec=Repo, url="gh://SUSE/doc-test")
+            git=Mock(spec=Repo, url="gh://SUSE/doc-test"),
+            branch="main",
         )
 
         # Feed them in reverse order to ensure sorting works without crashing
         mock_get_deliverables.return_value = [d2, d1]
-        mock_process_deliverable.return_value = (True, d1)
+        mock_process_group.return_value = []  # no failures
 
         result = await process_doctype(
             root=empty_xml_root,
             doctype=doctype,
             repo_dir=tmp_path / "repos",
             tmp_repo_dir=tmp_path / "tmp_repos",
+            tmp_dir=tmp_path / "tmp",
             meta_cache_dir=tmp_path / "cache" / "metadata",
             dapsmetatmpl="daps-template",
             max_workers=8,
@@ -102,18 +106,19 @@ class TestProcessDoctype:
 
         assert result == []
         mock_get_deliverables.assert_called_once_with(empty_xml_root, doctype)
-        assert mock_process_deliverable.call_count == 2
+        # Both deliverables share the same (url, branch) → exactly one group call
+        assert mock_process_group.call_count == 1
 
-    @patch.object(runner_pkg, "process_deliverable", new_callable=AsyncMock)
+    @patch.object(runner_pkg, "process_deliverable_group", new_callable=AsyncMock)
     @patch.object(runner_pkg, "get_deliverable_from_doctype")
     async def test_no_deliverables_found(
         self,
         mock_get_deliverables: Mock,
-        mock_process_deliverable: AsyncMock,
+        mock_process_group: AsyncMock,
         empty_xml_root: etree._ElementTree,
         tmp_path: Path,
     ) -> None:
-        """When no deliverables are found, process_deliverable is never called."""
+        """When no deliverables are found, process_deliverable_group is never called."""
         doctype = Doctype.from_str("sles/15/en-us")
         mock_get_deliverables.return_value = []
 
@@ -122,6 +127,7 @@ class TestProcessDoctype:
             doctype=doctype,
             repo_dir=tmp_path / "repos",
             tmp_repo_dir=tmp_path / "tmp_repos",
+            tmp_dir=tmp_path / "tmp",
             meta_cache_dir=tmp_path / "cache" / "metadata",
             dapsmetatmpl="daps-template",
             max_workers=8,
@@ -130,34 +136,84 @@ class TestProcessDoctype:
         )
 
         assert result == []
-        mock_process_deliverable.assert_not_called()
+        mock_process_group.assert_not_called()
 
-    @patch.object(runner_pkg, "process_deliverable", new_callable=AsyncMock)
+    @patch.object(runner_pkg, "process_deliverable_group", new_callable=AsyncMock)
     @patch.object(runner_pkg, "get_deliverable_from_doctype")
     @patch.object(runner_pkg, "update_repositories", new_callable=AsyncMock)
-    async def test_exitfirst_stops_on_first_failure(
+    async def test_failures_are_collected_across_groups(
         self,
         mock_update_repositories: AsyncMock,
         mock_get_deliverables: Mock,
-        mock_process_deliverable: AsyncMock,
+        mock_process_group: AsyncMock,
         empty_xml_root: etree._ElementTree,
         tmp_path: Path,
     ) -> None:
-        """With exitfirst=True, only the first failing deliverable is reported."""
+        """Failures from all groups are collected and returned."""
         doctype = Doctype.from_str("sles/15/en-us")
-        d1 = SortableMock(spec=Deliverable, full_id="sles/15/en-us:DC-ONE")
-        d2 = SortableMock(spec=Deliverable, full_id="sles/15/en-us:DC-TWO")
+        d1 = SortableMock(
+            spec=Deliverable,
+            full_id="sles/15/en-us:DC-ONE",
+            git=Mock(spec=Repo, url="u1"),
+            branch="b1",
+        )
+        d2 = SortableMock(
+            spec=Deliverable,
+            full_id="sles/15/en-us:DC-TWO",
+            git=Mock(spec=Repo, url="u2"),
+            branch="b2",
+        )
         mock_get_deliverables.return_value = [d1, d2]
-
-        # In a real aiostream pipeline, breaking the loop cancels the rest.
-        # We test that `exitfirst=True` correctly breaks the stream and only returns `d1`.
-        mock_process_deliverable.side_effect = [(False, d1), (True, d2)]
+        # group for d1 fails, group for d2 succeeds
+        mock_process_group.side_effect = [[d1], []]
 
         failed = await process_doctype(
             root=empty_xml_root,
             doctype=doctype,
             repo_dir=tmp_path / "repos",
             tmp_repo_dir=tmp_path / "tmp_repos",
+            tmp_dir=tmp_path / "tmp",
+            meta_cache_dir=tmp_path / "cache" / "metadata",
+            dapsmetatmpl="daps-template",
+            max_workers=8,
+        )
+
+        assert failed == [d1]
+
+    @patch.object(runner_pkg, "process_deliverable_group", new_callable=AsyncMock)
+    @patch.object(runner_pkg, "get_deliverable_from_doctype")
+    async def test_exitfirst_stops_after_first_failing_group(
+        self,
+        mock_get_deliverables: Mock,
+        mock_process_group: AsyncMock,
+        empty_xml_root: etree._ElementTree,
+        tmp_path: Path,
+    ) -> None:
+        """With exitfirst=True, only the first failing group is reported."""
+        doctype = Doctype.from_str("sles/15/en-us")
+        d1 = SortableMock(
+            spec=Deliverable,
+            full_id="sles/15/en-us:DC-ONE",
+            git=Mock(spec=Repo, url="u1"),
+            branch="b1",
+        )
+        d2 = SortableMock(
+            spec=Deliverable,
+            full_id="sles/15/en-us:DC-TWO",
+            git=Mock(spec=Repo, url="u2"),
+            branch="b2",
+        )
+        mock_get_deliverables.return_value = [d1, d2]
+
+        # In a real aiostream pipeline, breaking the loop cancels the rest.
+        mock_process_group.side_effect = [[d1], [d2]]
+
+        failed = await process_doctype(
+            root=empty_xml_root,
+            doctype=doctype,
+            repo_dir=tmp_path / "repos",
+            tmp_repo_dir=tmp_path / "tmp_repos",
+            tmp_dir=tmp_path / "tmp",
             meta_cache_dir=tmp_path / "cache" / "metadata",
             dapsmetatmpl="daps-template",
             max_workers=1,  # Force sequential to guarantee order in test
@@ -167,26 +223,32 @@ class TestProcessDoctype:
 
         assert failed == [d1]
 
-    @patch.object(runner_pkg, "process_deliverable", new_callable=AsyncMock)
+    @patch.object(runner_pkg, "process_deliverable_group", new_callable=AsyncMock)
     @patch.object(runner_pkg, "get_deliverable_from_doctype")
-    async def test_exception_in_process_deliverable_caught(
+    async def test_exception_in_group_caught(
         self,
         mock_get_deliverables: Mock,
-        mock_process_deliverable: AsyncMock,
+        mock_process_group: AsyncMock,
         empty_xml_root: etree._ElementTree,
         tmp_path: Path,
     ) -> None:
         """Exceptions in the pipeline wrapper are caught and treated as failures."""
         doctype = Doctype.from_str("sles/15/en-us")
-        mock_d = SortableMock(spec=Deliverable, full_id="test:DC-ERROR")
+        mock_d = SortableMock(
+            spec=Deliverable,
+            full_id="test:DC-ERROR",
+            git=Mock(spec=Repo, url="u1"),
+            branch="b1",
+        )
         mock_get_deliverables.return_value = [mock_d]
-        mock_process_deliverable.side_effect = RuntimeError("Simulated failure")
+        mock_process_group.side_effect = RuntimeError("Simulated failure")
 
         failed = await process_doctype(
             root=empty_xml_root,
             doctype=doctype,
             repo_dir=tmp_path / "repos",
             tmp_repo_dir=tmp_path / "tmp_repos",
+            tmp_dir=tmp_path / "tmp",
             meta_cache_dir=tmp_path / "cache" / "metadata",
             dapsmetatmpl="daps-template",
             max_workers=8,
@@ -195,6 +257,48 @@ class TestProcessDoctype:
         )
 
         assert failed == [mock_d]
+
+    @patch.object(runner_pkg, "process_deliverable_group", new_callable=AsyncMock)
+    @patch.object(runner_pkg, "get_deliverable_from_doctype")
+    async def test_deliverables_grouped_by_repo_and_branch(
+        self,
+        mock_get_deliverables: Mock,
+        mock_process_group: AsyncMock,
+        empty_xml_root: etree._ElementTree,
+        tmp_path: Path,
+    ) -> None:
+        """Deliverables sharing (repo, branch) are batched into a single group call."""
+        doctype = Doctype.from_str("sles/15/en-us")
+        shared_branch = SortableMock(
+            spec=Deliverable,
+            full_id="sles/15/en-us:DC-A",
+            git=Mock(spec=Repo, url="u1"),
+            branch="b1",
+        )
+        other_branch = SortableMock(
+            spec=Deliverable,
+            full_id="sles/15/en-us:DC-B",
+            git=Mock(spec=Repo, url="u1"),
+            branch="b2",
+        )
+        mock_get_deliverables.return_value = [shared_branch, shared_branch, other_branch]
+        mock_process_group.return_value = []
+
+        result = await process_doctype(
+            root=empty_xml_root,
+            doctype=doctype,
+            repo_dir=tmp_path / "repos",
+            tmp_repo_dir=tmp_path / "tmp_repos",
+            tmp_dir=tmp_path / "tmp",
+            meta_cache_dir=tmp_path / "cache" / "metadata",
+            dapsmetatmpl="daps-template",
+            max_workers=4,
+            skip_repo_update=True,
+        )
+
+        assert result == []
+        # Two unique (url, branch) pairs → two group tasks
+        assert mock_process_group.call_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -244,6 +348,7 @@ class TestProcess:
             default_doctype,
             runner_kwargs["repo_dir"],
             runner_kwargs["tmp_repo_dir"],
+            runner_kwargs["tmp_dir"],
             runner_kwargs["meta_cache_dir"],
             runner_kwargs["dapsmetatmpl"],
             runner_kwargs["max_workers"],
@@ -309,6 +414,7 @@ class TestProcess:
             provided_doctype,
             runner_kwargs["repo_dir"],
             runner_kwargs["tmp_repo_dir"],
+            runner_kwargs["tmp_dir"],
             runner_kwargs["meta_cache_dir"],
             runner_kwargs["dapsmetatmpl"],
             runner_kwargs["max_workers"],

--- a/tests/utils/test_git.py
+++ b/tests/utils/test_git.py
@@ -106,12 +106,12 @@ async def test_managed_repo_create_worktree_success(
     await repo.create_worktree(target_dir, "main")
 
     mock_execute_git.assert_awaited_once_with(
-        "clone",
-        "--branch",
-        "main",
-        str(repo.bare_repo_path),
+        "worktree",
+        "add",
+        "--detach",
         str(target_dir),
-        cwd=target_dir.parent,
+        "main",
+        cwd=repo.bare_repo_path,
         gitconfig=None,
     )
 
@@ -119,7 +119,7 @@ async def test_managed_repo_create_worktree_success(
 async def test_managed_repo_create_worktree_with_options(
     tmp_path: Path, mock_execute_git: AsyncMock, monkeypatch
 ):
-    """Test create_worktree with additional clone options."""
+    """Test create_worktree with additional options."""
     mock_execute_git.return_value = CompletedProcess(
         args=[], returncode=0, stdout="", stderr=""
     )
@@ -131,14 +131,14 @@ async def test_managed_repo_create_worktree_with_options(
     await repo.create_worktree(target_dir, "develop", options=["--depth", "1"])
 
     mock_execute_git.assert_awaited_once_with(
-        "clone",
-        "--branch",
+        "worktree",
+        "add",
+        "--detach",
+        str(target_dir),
         "develop",
         "--depth",
         "1",
-        str(repo.bare_repo_path),
-        str(target_dir),
-        cwd=target_dir.parent,
+        cwd=repo.bare_repo_path,
         gitconfig=None,
     )
 
@@ -158,30 +158,67 @@ async def test_managed_repo_create_worktree_no_bare_repo(
     mock_execute_git.assert_not_awaited()
 
 
-async def test_managed_repo_create_worktree_not_local(
+async def test_managed_repo_prune_worktrees_success(
     tmp_path: Path, mock_execute_git: AsyncMock, monkeypatch
 ):
-    """Test create_worktree without the --local flag."""
+    """Test prune_worktrees calls git worktree prune on the bare repo."""
     mock_execute_git.return_value = CompletedProcess(
         args=[], returncode=0, stdout="", stderr=""
     )
     repo = ManagedGitRepo("http://a.b/org/c.git", tmp_path)
-    # Simulate bare repo exists
+    monkeypatch.setattr(Path, "exists", lambda self: True)
+
+    await repo.prune_worktrees()
+
+    mock_execute_git.assert_awaited_once_with(
+        "worktree", "prune",
+        cwd=repo.bare_repo_path,
+        gitconfig=None,
+    )
+
+
+async def test_managed_repo_prune_worktrees_no_bare_repo(
+    tmp_path: Path, mock_execute_git: AsyncMock, monkeypatch
+):
+    """Test prune_worktrees is a no-op when the bare repo does not exist."""
+    repo = ManagedGitRepo("http://a.b/org/c.git", tmp_path)
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+
+    await repo.prune_worktrees()
+
+    mock_execute_git.assert_not_awaited()
+
+
+async def test_managed_repo_remove_worktree_success(
+    tmp_path: Path, mock_execute_git: AsyncMock, monkeypatch
+):
+    """Test remove_worktree calls git worktree remove --force."""
+    mock_execute_git.return_value = CompletedProcess(
+        args=[], returncode=0, stdout="", stderr=""
+    )
+    repo = ManagedGitRepo("http://a.b/org/c.git", tmp_path)
     monkeypatch.setattr(Path, "exists", lambda self: True)
     target_dir = tmp_path / "worktree"
 
-    # Explicitly call with is_local=False
-    await repo.create_worktree(target_dir, "main", is_local=False)
+    await repo.remove_worktree(target_dir)
 
     mock_execute_git.assert_awaited_once_with(
-        "clone",
-        "--branch",
-        "main",
-        str(repo.bare_repo_path),
-        str(target_dir),
-        cwd=target_dir.parent,
+        "worktree", "remove", "--force", str(target_dir),
+        cwd=repo.bare_repo_path,
         gitconfig=None,
     )
+
+
+async def test_managed_repo_remove_worktree_no_bare_repo(
+    tmp_path: Path, mock_execute_git: AsyncMock, monkeypatch
+):
+    """Test remove_worktree is a no-op when the bare repo does not exist."""
+    repo = ManagedGitRepo("http://a.b/org/c.git", tmp_path)
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+
+    await repo.remove_worktree(tmp_path / "worktree")
+
+    mock_execute_git.assert_not_awaited()
 
 
 def test_managed_git_repo_repr(tmp_path: Path):


### PR DESCRIPTION
Optimise `docbuild metadata` by grouping deliverables that share the same repository and branch into a single shared `git worktree`. This reduces the number of worktree checkout operations from one per deliverable to one per unique `(repository, branch)` pair, significantly reducing overhead when many DC files live on the same branch.

This PR may lead to nowhere, depending on the outcome.