### PR TITLE
Refactor Product enum

### DIFF
--- a/changelog.d/427.refactor.rst
+++ b/changelog.d/427.refactor.rst
@@ -1,0 +1,1 @@
+Refactor :class:`~docbuild.models.product.Product` to use `acronym` as the primary identifier instead of `value`. Switch from a dynamic class to a static enum class due to problems with dynamic class generation and type-checking. This change improves type safety and simplifies the codebase.

--- a/docs/source/developer/howto/add-rm-product.rst
+++ b/docs/source/developer/howto/add-rm-product.rst
@@ -2,4 +2,28 @@ Adding or removing a new product
 ================================
 
 Product names are checked against typos. Whenever you change a product acronym,
-you need to update the constant :data:`docbuild.constants.VALID_PRODUCTS`.
+you need to update the enum class :class:`docbuild.models.product.Product`, see
+the file :file:`src/docbuild/models/product.py`.
+
+The :class:`~docbuild.models.product.Product` members are the source of
+truth:
+
+* the member name (for example, ``sle_ha``) maps to the acronym ``sle-ha``
+* the member value contains the full product name
+
+Some recommendations, when modifying a product:
+
+* Use the acronym as the enum member name, and the full product name as the value.
+* Use only lowercase letters.
+* Use underscores in the enum member name. This is automatically converted to hyphens in the acronym.
+* Try to keep the enum members in alphabetical order, to make it easier to find them.
+
+Example: If you want to add a new product with the acronym ``sle-foo``and the
+full name ``SUSE Linux Enterprise Foo``, you would add the following enum member:
+
+.. code-block:: python
+   :caption: Adding a new product to the :class:`Product` class
+
+   class Product(BaseProductEnum):
+      # --- snip ---
+      sle_foo = "SUSE Linux Enterprise Foo"

--- a/docs/source/reference/_autoapi/docbuild/constants/index.rst
+++ b/docs/source/reference/_autoapi/docbuild/constants/index.rst
@@ -23,8 +23,6 @@ Attributes
    docbuild.constants.SERVER_ROLES_ALIASES
    docbuild.constants.DEFAULT_LIFECYCLE
    docbuild.constants.ALLOWED_LIFECYCLES
-   docbuild.constants.VALID_PRODUCTS
-   docbuild.constants.ALLOWED_PRODUCTS
    docbuild.constants.SINGLE_LANG_REGEX
    docbuild.constants.MULTIPLE_LANG_REGEX
    docbuild.constants.LIFECYCLES_STR
@@ -122,18 +120,6 @@ Module Contents
    :type:  tuple[str, Ellipsis]
 
    The available lifecycle states for a docset (without 'unknown').
-
-
-.. py:data:: VALID_PRODUCTS
-   :type:  dict[str, str]
-
-   A dictionary of valid products acronyms and their full names.
-
-
-.. py:data:: ALLOWED_PRODUCTS
-   :type:  tuple[str, Ellipsis]
-
-   A tuple of valid product acronyms.
 
 
 .. py:data:: SINGLE_LANG_REGEX

--- a/docs/source/reference/_autoapi/docbuild/models/product/Product.rst
+++ b/docs/source/reference/_autoapi/docbuild/models/product/Product.rst
@@ -1,0 +1,22 @@
+docbuild.models.product.Product
+===============================
+
+.. py:class:: docbuild.models.product.Product
+
+   Bases: :py:obj:`BaseProductEnum`
+
+   .. autoapi-inheritance-diagram:: docbuild.models.product.Product
+      :parts: 1
+
+
+   A :class:`~enum.StrEnum` for all known products, including wildcard ``*``.
+
+   The enum value stores the full product name, while :attr:`acronym` exposes
+   the canonical short ID used in doctypes and XML product IDs.
+
+
+   .. py:property:: acronym
+      :type: str
+
+
+      Return the canonical product acronym used in doctypes and XML IDs.

--- a/docs/source/reference/_autoapi/docbuild/models/product/StrEnumMeta.rst
+++ b/docs/source/reference/_autoapi/docbuild/models/product/StrEnumMeta.rst
@@ -12,7 +12,7 @@ docbuild.models.product.StrEnumMeta
    Custom metaclass for StrEnum to allow attribute-style access.
 
 
-   .. py:method:: __getitem__(key: str) -> StrEnumMeta
+   .. py:method:: __getitem__(name: str) -> object
 
       Access enum members using attribute-style names with underscores.
 

--- a/docs/source/reference/_autoapi/docbuild/models/product/index.rst
+++ b/docs/source/reference/_autoapi/docbuild/models/product/index.rst
@@ -9,14 +9,6 @@ docbuild.models.product
 
 
 
-Attributes
-----------
-
-.. autoapisummary::
-
-   docbuild.models.product.Product
-
-
 Classes
 -------
 
@@ -25,18 +17,12 @@ Classes
 
    /reference/_autoapi/docbuild/models/product/StrEnumMeta
    /reference/_autoapi/docbuild/models/product/BaseProductEnum
+   /reference/_autoapi/docbuild/models/product/Product
 
 .. autoapisummary::
 
    docbuild.models.product.StrEnumMeta
    docbuild.models.product.BaseProductEnum
-
-
-Module Contents
----------------
-
-.. py:data:: Product
-
-   A :py:class:`~enum.StrEnum` for the products of the docbuild application.
+   docbuild.models.product.Product
 
 

--- a/src/docbuild/cli/cmd_portal/cmd_list.py
+++ b/src/docbuild/cli/cmd_portal/cmd_list.py
@@ -8,11 +8,12 @@ from lxml import etree  # type: ignore
 from rich.console import Console
 from rich.tree import Tree
 
-from docbuild.cli.context import DocBuildContext
-from docbuild.config.xml.list import list_all_deliverables
-from docbuild.models.deliverable import Deliverable
-from docbuild.models.doctype import Doctype
-from docbuild.tasks.portal import parse_portal_config
+from ...cli.context import DocBuildContext
+from ...config.xml.list import list_all_deliverables
+from ...models.deliverable import Deliverable
+from ...models.doctype import Doctype
+from ...models.product import Product
+from ...tasks.portal import parse_portal_config
 
 
 def build_hierarchy(
@@ -233,8 +234,8 @@ def validate_docsets_against_xml(
     errors = []
 
     for dt in doctypes:
-        if dt.product and "*" not in dt.product and dt.docset and "*" not in dt.docset:
-            prod_val = dt.product.value
+        if dt.product and dt.product != Product.ALL and dt.docset and "*" not in dt.docset:
+            prod_val = dt.product.acronym
 
             # Use the class's own string parser to bypass strict __init__ type-checking issues
             broad_dt = Doctype.from_str(f"{prod_val}/*/*")

--- a/src/docbuild/config/xml/list.py
+++ b/src/docbuild/config/xml/list.py
@@ -7,6 +7,7 @@ from lxml import etree  # type: ignore
 
 from ...models.doctype import Doctype
 from ...models.lifecycle import LifecycleFlag
+from ...models.product import Product
 
 xpathlog = logging.getLogger(__name__)
 log = logging.getLogger(__package__)
@@ -28,8 +29,8 @@ def list_all_deliverables(
             # Using flexible relative descendant selectors ensures compatibility
             # with both nested test fixtures and the absolute portal configuration schema.
             xpath = "//product"
-            if dt.product and "*" not in dt.product:
-                xpath += f"[@id={dt.product.value!r}]"
+            if dt.product and dt.product != Product.ALL:
+                xpath += f"[@id={dt.product.acronym!r}]"
 
             xpath += "/docset"
             # Protect against empty lists causing malformed [] XPath segments

--- a/src/docbuild/constants.py
+++ b/src/docbuild/constants.py
@@ -44,57 +44,6 @@ ALLOWED_LIFECYCLES: tuple[str, ...] = tuple(lc.name for lc in LifecycleFlag)
 """The available lifecycle states for a docset (without 'unknown')."""
 
 
-# All product acronyms and their names
-# - key: /product/@productid
-# - value: /product/name
-#
-# Use the following command to create the output below:
-# xmlstarlet sel -t -v '/product/@productid' -o ' '\
-#   -v '/product/name' -nl config.d/[a-z]*.xml
-VALID_PRODUCTS: dict[str, str] = {
-    key.strip(): value.strip()
-    for key, value in (
-        line.split(" ", 1)
-        # Syntax: acronym <SPACE> full name:
-        for line in """appliance Appliance building
-cloudnative Cloud Native
-compliance Compliance Documentation
-container Container Documentation
-liberty SUSE Multi-Linux Support
-releasenotes SUSE Release Notes
-sbp SUSE Best Practices
-ses SUSE Enterprise Storage
-sled SUSE Linux Enterprise Desktop
-sle-ha SUSE Linux Enterprise High Availability
-sle-hpc SUSE Linux Enterprise High-Performance Computing
-sle-micro SUSE Linux Micro
-sle-public-cloud SUSE Linux Enterprise in Public Clouds
-sle-rt SUSE Linux Enterprise Real Time
-sles-sap SUSE Linux Enterprise Server for SAP applications
-sles SUSE Linux Enterprise Server
-sle-vmdp SUSE Linux Enterprise Virtual Machine Driver Pack
-smart SUSE Smart Docs
-smt SUSE Linux Enterprise Subscription Management Tool
-soc SUSE OpenStack Cloud
-style SUSE Documentation Style Guide
-subscription Subscription Management
-suma-retail SUSE Multi-Linux Manager for Retail
-suma SUSE Multi-Linux Manager
-suse-ai-factory SUSE AI Factory
-suse-ai SUSE AI
-suse-caasp SUSE CaaS Platform
-suse-cap SUSE Cloud Application Platform
-suse-distribution-migration-system SUSE Distribution Migration System
-suse-edge SUSE Edge
-suse-telco SUSE Telco Cloud
-trd Technical Reference Documentation""".strip().splitlines()
-    )
-}
-"""A dictionary of valid products acronyms and their full names."""
-
-ALLOWED_PRODUCTS: tuple[str, ...]= tuple([item for item in VALID_PRODUCTS])
-"""A tuple of valid product acronyms."""
-
 SINGLE_LANG_REGEX: re.Pattern = re.compile(r"[a-z]{2}-[a-z]{2}")
 """Regex for a single language code in the format 'xx-XX' (e.g., 'en-us')."""
 

--- a/src/docbuild/models/doctype.py
+++ b/src/docbuild/models/doctype.py
@@ -125,14 +125,14 @@ class Doctype(BaseModel):
         """Implement str(self)."""
         langs_str = ",".join(lang.language for lang in self.langs)
         docset_str = ",".join(self.docset)
-        return f"{self.product.value}/{docset_str}@{self.lifecycle.name}/{langs_str}"
+        return f"{self.product.acronym}/{docset_str}@{self.lifecycle.name}/{langs_str}"
 
     def __repr__(self: Self) -> str:
         """Implement repr(self)."""
         langs_str = ",".join(lang.language for lang in self.langs)
         docset_str = ",".join(self.docset)
         return (
-            f"{self.__class__.__name__}(product={self.product.value!r}, "
+            f"{self.__class__.__name__}(product={self.product.acronym!r}, "
             f"docset=[{docset_str}], "
             f"lifecycle={self.lifecycle.name!r}, "
             f"langs=[{langs_str}]"
@@ -244,7 +244,7 @@ class Doctype(BaseModel):
         # Example: /sles/15-SP6@supported/en-us,de-de
         product = "product"
         if self.product != Product.ALL:
-            product += f"[@id={self.product.value!r}]"
+            product += f"[@id={self.product.acronym!r}]"
 
         setids = [f"@path={d!r}" for d in self.docset if d != "*"]
 
@@ -277,8 +277,8 @@ class Doctype(BaseModel):
 
         Example: "product[@id='sles']" or "product"
         """
-        if self.product != Product["ALL"]:
-            return f"product[@id={self.product.value!r}]"
+        if self.product != Product.ALL:
+            return f"product[@id={self.product.acronym!r}]"
         return "product"
 
     def docset_xpath_segment(self: Self, docset: str) -> str:

--- a/src/docbuild/models/product.py
+++ b/src/docbuild/models/product.py
@@ -1,24 +1,23 @@
 """Products for the docbuild application."""
 
 from enum import EnumMeta, StrEnum
-from typing import Never
-
-# from pydantic import BaseModel, computed_field
-from ..constants import ALLOWED_PRODUCTS
+from typing import Self, cast
 
 
 class StrEnumMeta(EnumMeta):
     """Custom metaclass for StrEnum to allow attribute-style access."""
 
-    def __getitem__(cls, key: str) -> "StrEnumMeta":
+    def __getitem__(cls, name: str) -> object:
         """Access enum members using attribute-style names with underscores."""
-        candidate = key.replace("-", "_")
+        candidate = name.replace("-", "_")
         try:
             return super().__getitem__(candidate)
         except KeyError:
-            allowed = ", ".join(repr(member.value) for member in cls)
+            allowed = ", ".join(
+                repr(cast(StrEnum, member).value) for member in cls
+            )
             raise KeyError(
-                f"{key!r} is not a valid member name or value for {cls.__name__}. "
+                f"{name!r} is not a valid member name or value for {cls.__name__}. "
                 f"Allowed (values): {allowed}",
             ) from None
 
@@ -27,7 +26,7 @@ class BaseProductEnum(StrEnum, metaclass=StrEnumMeta):
     """Base class for product enums with custom error handling."""
 
     @classmethod
-    def _missing_(cls, value: object) -> Never:
+    def _missing_(cls, value: object) -> Self | None:
         """Raise custom error for unknown values."""
         allowed = ", ".join(repr(v.value) for v in cls)
         raise ValueError(
@@ -35,12 +34,69 @@ class BaseProductEnum(StrEnum, metaclass=StrEnumMeta):
         )
 
 
-# Products allows all our SUSE product names, but also "*" (=ALL).
-# We only define "ALL" as uppercase to denote a constant, the rest is lowercase.
-# Product name with dashes are replace with underscores.
-# You can access "Product.sle_ha", but not "Product.sle-ha"
-Product = BaseProductEnum(
-    "Product",
-    {"ALL": "*"} | {item.replace("-", "_"): item for item in ALLOWED_PRODUCTS},
-)
-"""A :py:class:`~enum.StrEnum` for the products of the docbuild application."""
+class Product(BaseProductEnum):
+    """A :class:`~enum.StrEnum` for all known products, including wildcard ``*``.
+
+    The enum value stores the full product name, while :attr:`acronym` exposes
+    the canonical short ID used in doctypes and XML product IDs.
+    """
+
+    # Acronoym = Name
+    ALL = "*"
+    appliance = "Appliance building"
+    cloudnative = "Cloud Native"
+    compliance = "Compliance Documentation"
+    container = "Container Documentation"
+    liberty = "SUSE Multi-Linux Support"
+    releasenotes = "SUSE Release Notes"
+    sbp = "SUSE Best Practices"
+    ses = "SUSE Enterprise Storage"
+    sled = "SUSE Linux Enterprise Desktop"
+    sle_ha = "SUSE Linux Enterprise High Availability"
+    sle_hpc = "SUSE Linux Enterprise High-Performance Computing"
+    sle_micro = "SUSE Linux Micro"
+    sle_public_cloud = "SUSE Linux Enterprise in Public Clouds"
+    sle_rt = "SUSE Linux Enterprise Real Time"
+    sles_sap = "SUSE Linux Enterprise Server for SAP applications"
+    sles = "SUSE Linux Enterprise Server"
+    sle_vmdp = "SUSE Linux Enterprise Virtual Machine Driver Pack"
+    smart = "SUSE Smart Docs"
+    smt = "SUSE Linux Enterprise Subscription Management Tool"
+    soc = "SUSE OpenStack Cloud"
+    style = "SUSE Documentation Style Guide"
+    subscription = "Subscription Management"
+    suma_retail = "SUSE Multi-Linux Manager for Retail"
+    suma = "SUSE Multi-Linux Manager"
+    suse_ai_factory = "SUSE AI Factory"
+    suse_ai = "SUSE AI"
+    suse_caasp = "SUSE CaaS Platform"
+    suse_cap = "SUSE Cloud Application Platform"
+    suse_distribution_migration_system = "SUSE Distribution Migration System"
+    suse_edge = "SUSE Edge"
+    suse_telco = "SUSE Telco Cloud"
+    trd = "Technical Reference Documentation"
+
+    @property
+    def acronym(self) -> str:
+        """Return the canonical product acronym used in doctypes and XML IDs."""
+        if self is Product.ALL:
+            return "*"
+        return self.name.replace("_", "-")
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self | None:
+        """Accept acronym input in addition to the full product name.
+
+        This intentionally overrides :meth:`BaseProductEnum._missing_`, which
+        only raises a formatted :class:`ValueError`. Here we add product-specific
+        coercion rules (acronyms and ``*``), then fall back to the base method.
+        """
+        if isinstance(value, str):
+            if value == "*":
+                return cast(Self, cls.ALL)
+
+            candidate = value.strip().replace("-", "_")
+            if member := cls.__members__.get(candidate):
+                return cast(Self, member)
+
+        return super()._missing_(value)

--- a/src/docbuild/tasks/metadata/deliverables.py
+++ b/src/docbuild/tasks/metadata/deliverables.py
@@ -51,7 +51,7 @@ def collect_files_flat(
         # Case-insensitive filtering
         files = [
             f for f in all_files
-            if dt.product.value.lower() in [p.lower() for p in f.parts]
+            if dt.product.acronym.lower() in [p.lower() for p in f.parts]
             and docset.lower() in [p.lower() for p in f.parts]
         ]
 

--- a/src/docbuild/tasks/metadata/manifest.py
+++ b/src/docbuild/tasks/metadata/manifest.py
@@ -202,7 +202,7 @@ def store_productdocset_json(
     :param json_cache_dir: Path to the JSON cache directory.
     """
     for doctype, docset, files in collect_files_flat(doctypes, meta_cache_dir):
-        product = doctype.product.value
+        product = doctype.product.acronym
         version_str = str(docset)
 
         productxpath = f"./{doctype.product_xpath_segment()}"

--- a/tests/models/test_product.py
+++ b/tests/models/test_product.py
@@ -1,13 +1,17 @@
+from typing import cast
+
 import pytest
 
-from docbuild.constants import ALLOWED_PRODUCTS
 from docbuild.models.product import Product
 
 
-@pytest.mark.parametrize("product", ALLOWED_PRODUCTS)
+@pytest.mark.parametrize(
+    "product",
+    [member.acronym for member in Product if member is not Product.ALL],
+)
 def test_valid_product(product):
-    instance = Product[product]
-    assert instance.value == product
+    instance = cast(Product, Product[product])
+    assert instance.acronym == product
 
 
 def test_access_all_productname_constants():
@@ -33,7 +37,25 @@ def test_access_valid_productname_uppercase_key():
 
 
 def test_enum_productvalue_integrity():
-    assert Product.sle_ha.value == "sle-ha"
+    assert Product.sle_ha.value == "SUSE Linux Enterprise High Availability"
+    assert Product.sle_ha.acronym == "sle-ha"
+
+
+def test_access_product_from_acronym_value():
+    assert Product("sle-ha") == Product.sle_ha
+
+
+def test_missing_wildcard_branch_returns_all():
+    # Product("*") resolves directly and does not call _missing_.
+    # Call _missing_ explicitly to cover its wildcard branch.
+    assert Product._missing_("*") == Product.ALL
+
+
+def test_missing_non_string_input_raises_value_error():
+    with pytest.raises(ValueError) as excinfo:
+        Product._missing_(42)
+
+    assert "42" in str(excinfo.value)
 
 
 def test_invalid_key_raises_keyerror_with_hint():


### PR DESCRIPTION
The `Product` class needed a refactoring attempt. I had always some type problems in my VS Code editor which was annoying.

I think the refactoring created a more static class which is easier to handle for editors (and probably type checkers) than the dynamic one.

Changes in this PR:
* Remove obsolete `VALID_PRODUCTS` and `ALLOWED_PRODUCTS`, not really needed in the code anywhere.
* Replace dynamic Product enum construction with a direct static `Product` class.
* Store full product names as Product values and add `Product.acronym` for canonical short IDs.
* Extend `Product._missing_` to accept acronym input and wildcard (*) before falling back to base error handling.
* Make `_missing_` typing LSP-compatible by using `Self | None` in base and subclass definitions.
* Fix `StrEnumMeta.__getitem__` typing/signature issues (parameter naming and safe typing casts).
* Update `Product` docstrings to clarify full-name values, acronym semantics, and why `_missing_` overrides base behavior.