### PR TITLE
Iterate over all possible doctypes

### DIFF
--- a/changelog.d/428.feature.rst
+++ b/changelog.d/428.feature.rst
@@ -1,0 +1,1 @@
+Add :meth:`~docbuild.models.doctype.Doctype.iter_doctypes` to iterate over all docset and language combinations. This is the Cartesian product of ``docset`` and ``langs``.

--- a/docs/source/reference/_autoapi/docbuild/cli/cmd_cli/index.rst
+++ b/docs/source/reference/_autoapi/docbuild/cli/cmd_cli/index.rst
@@ -35,7 +35,7 @@ Module Contents
       (AppConfig or EnvConfig).
    :param config_files: The list of config files that were attempted to be
       loaded, used for error context.
-   :param verbose: The verbosity level from the CLI options, which can be
+    :param verbose: The verbosity level from the CLI options, which can be
       used to control the level of detail in the error output.
    :param ctx: The Click context, used to exit the CLI with an appropriate
       status code after handling the error.

--- a/docs/source/reference/_autoapi/docbuild/cli/context/DocBuildContext.rst
+++ b/docs/source/reference/_autoapi/docbuild/cli/context/DocBuildContext.rst
@@ -33,6 +33,15 @@ docbuild.cli.context.DocBuildContext
 
 
 
+   .. py:attribute:: appconfig_candidates
+      :type:  tuple[str | pathlib.Path, Ellipsis]
+      :value: ()
+
+
+      Candidate app config files considered during discovery.
+
+
+
    .. py:attribute:: appconfig_from_defaults
       :type:  bool
       :value: False
@@ -57,6 +66,15 @@ docbuild.cli.context.DocBuildContext
 
 
       The env's config files to load, if any
+
+
+
+   .. py:attribute:: envconfig_candidates
+      :type:  tuple[str | pathlib.Path, Ellipsis]
+      :value: ()
+
+
+      Candidate env config files considered during discovery.
 
 
 

--- a/docs/source/reference/_autoapi/docbuild/config/load/index.rst
+++ b/docs/source/reference/_autoapi/docbuild/config/load/index.rst
@@ -14,12 +14,26 @@ Functions
 
 .. autoapisummary::
 
+   docbuild.config.load.build_config_candidates
    docbuild.config.load.load_single_config
    docbuild.config.load.handle_config
 
 
 Module Contents
 ---------------
+
+.. py:function:: build_config_candidates(user_path: pathlib.Path | str | None, search_dirs: collections.abc.Iterable[str | pathlib.Path], basenames: collections.abc.Iterable[str | pathlib.Path] | None, default_filename: str | pathlib.Path | None = None) -> tuple[pathlib.Path, Ellipsis]
+
+   Build an ordered list of candidate config files.
+
+   The list reflects the lookup order used by :func:`handle_config`.
+
+   :param user_path: Path to the user-defined config file, if any.
+   :param search_dirs: Iterable of directories to search for config files.
+   :param basenames: Iterable of base filenames to search for.
+   :param default_filename: Fallback filename if ``basenames`` is empty.
+   :return: Ordered tuple of candidate config paths.
+
 
 .. py:function:: load_single_config(configfile: str | pathlib.Path) -> dict[str, Any]
 
@@ -32,7 +46,7 @@ Module Contents
        or cannot be decoded.
 
 
-.. py:function:: handle_config(user_path: pathlib.Path | str | None, search_dirs: collections.abc.Iterable[str | pathlib.Path], basenames: collections.abc.Iterable[str] | None, default_filename: str | None = None, default_config: object | None = None) -> tuple[tuple[pathlib.Path, Ellipsis] | None, object | dict, bool]
+.. py:function:: handle_config(user_path: pathlib.Path | str | None, search_dirs: collections.abc.Iterable[str | pathlib.Path], basenames: collections.abc.Iterable[str | pathlib.Path] | None, default_filename: str | pathlib.Path | None = None, default_config: object | None = None) -> tuple[tuple[pathlib.Path, Ellipsis] | None, object | dict, bool]
 
    Return (config_files, config, from_defaults) for config file handling.
 

--- a/docs/source/reference/_autoapi/docbuild/models/doctype/Doctype.rst
+++ b/docs/source/reference/_autoapi/docbuild/models/doctype/Doctype.rst
@@ -114,6 +114,26 @@ docbuild.models.doctype.Doctype
 
 
 
+   .. py:method:: iter_doctypes(portal_root: lxml.etree._Element | None = None) -> collections.abc.Iterator[Doctype]
+
+      Iterate over all docset and language combinations.
+
+      The iteration order is docset-major: for each docset, iterate all
+      languages. This is the Cartesian product of ``docset`` and ``langs``.
+
+      If ``portal_root`` is given, wildcard values (``*``) are expanded from
+      the parsed portal XML tree. Without ``portal_root``, wildcards remain
+      symbolic.
+
+      >>> doctype = Doctype.from_str("sles/15-SP6,15-SP7/en-us,de-de")
+      >>> [
+      ...     f"{item.product.value}/{item.docset[0]}/{item.langs[0].language}"
+      ...     for item in doctype.iter_doctypes()
+      ... ]
+      ['sles/15-SP6/de-de', 'sles/15-SP6/en-us', 'sles/15-SP7/de-de', 'sles/15-SP7/en-us']
+
+
+
    .. py:method:: coerce_product(value: str | docbuild.models.product.Product) -> docbuild.models.product.Product
       :classmethod:
 

--- a/src/docbuild/models/doctype.py
+++ b/src/docbuild/models/doctype.py
@@ -1,9 +1,12 @@
 """Module for defining the Doctype model."""
 
+from collections.abc import Iterator
+from itertools import product
 import re
 from re import Pattern
-from typing import ClassVar, Self
+from typing import ClassVar, Self, cast
 
+from lxml import etree  # type: ignore
 from pydantic import BaseModel, Field, field_validator
 
 from .language import LanguageCode
@@ -151,7 +154,7 @@ class Doctype(BaseModel):
 
         return all(
             [
-                self.product == other.product or self.product == Product.ALL,
+                self.product == other.product or self.product is Product.ALL,
                 set(other.docset).issubset(self.docset) or "*" in self.docset,
                 other.lifecycle in self.lifecycle,
                 set(other.langs).issubset(self.langs) or "*" in self.langs,
@@ -167,6 +170,95 @@ class Doctype(BaseModel):
                 tuple(self.langs),
             ),
         )
+
+    def iter_doctypes(self: Self,
+                      portal_root: etree._Element | None = None) -> Iterator["Doctype"]:
+        """Iterate over all docset and language combinations.
+
+        The iteration order is docset-major: for each docset, iterate all
+        languages. This is the Cartesian product of ``docset`` and ``langs``.
+
+        If ``portal_root`` is given, wildcard values (``*``) are expanded from
+        the parsed portal XML tree. Without ``portal_root``, wildcards remain
+        symbolic.
+
+        >>> doctype = Doctype.from_str("sles/15-SP6,15-SP7/en-us,de-de")
+        >>> [
+        ...     f"{item.product.value}/{item.docset[0]}/{item.langs[0].language}"
+        ...     for item in doctype.iter_doctypes()
+        ... ]
+        ['sles/15-SP6/de-de', 'sles/15-SP6/en-us', 'sles/15-SP7/de-de', 'sles/15-SP7/en-us']
+        """
+        has_product_wildcard = self.product is Product.ALL
+        has_docset_wildcard = "*" in self.docset
+        has_lang_wildcard = any(lang.language == "*" for lang in self.langs)
+
+        product_values = [self.product]
+        if portal_root is not None and has_product_wildcard:
+            product_values = [
+                self.coerce_product(product_id)
+                for product_id in sorted(
+                    {
+                        product_id
+                        for product_id in portal_root.xpath("product/@id")
+                        if product_id
+                    },
+                )
+            ]
+
+        combinations: set[tuple[Product, str, LanguageCode]] = set()
+
+        for product_value in product_values:
+            docsets = self.docset
+            if portal_root is not None and has_docset_wildcard:
+                docsets = sorted(
+                    {
+                        cast(str, docset)
+                        for docset in portal_root.xpath(
+                            f"product[@id={product_value.acronym!r}]/docset/@path",
+                        )
+                        if docset
+                    },
+                )
+
+            docset_lang_pairs = {
+                (docset, lang) for docset, lang in product(docsets, self.langs)
+            }
+            if portal_root is not None and has_lang_wildcard:
+                docset_lang_pairs: set[tuple[str, LanguageCode]] = {
+                    (docset, LanguageCode(language=lang))
+                    for docset in docsets
+                    for lang in sorted(
+                        {
+                            cast(str, lang)
+                            for lang in portal_root.xpath(
+                                (
+                                    f"product[@id={product_value.acronym!r}]"
+                                    f"/docset[@path={docset!r}]"
+                                    "/resources/locale/@lang"
+                                ),
+                            )
+                            if lang
+                        },
+                    )
+                }
+
+            combinations.update(
+                (product_value, docset, lang)
+                for docset, lang in docset_lang_pairs
+            )
+
+        for product_value, docset, lang in sorted(
+            combinations,
+            key=lambda item: (item[0].acronym, item[1], item[2].language),
+        ):
+            yield self.model_copy(
+                update={
+                    "product": product_value,
+                    "docset": [docset],
+                    "langs": [lang],
+                },
+            )
 
     # Validators
     @field_validator("product", mode="before")
@@ -222,7 +314,7 @@ class Doctype(BaseModel):
         lifecycle = "unknown" if lifecycle is None else lifecycle
         langs = default_lang if langs is None else langs
         return cls(
-            product=product,
+            product=cls.coerce_product(product),
             docset=docset,
             lifecycle=lifecycle,
             langs=langs,
@@ -245,7 +337,9 @@ class Doctype(BaseModel):
             deliverables that match this Doctype.
         """
         # Example: /sles/15-SP6@supported/en-us,de-de
-        product = f"//{self.product_xpath_segment()}" if absolute else self.product_xpath_segment()
+        product = "product"
+        if self.product is not Product.ALL:
+            product += f"[@id={self.product.acronym!r}]"
 
         docset = self.docset_xpath_segment()
         docset += self.lifecycle_xpath_segment()
@@ -257,7 +351,7 @@ class Doctype(BaseModel):
 
         Example: "product[@id='sles']" or "product"
         """
-        if self.product != Product.ALL:
+        if self.product is not Product.ALL:
             return f"product[@id={self.product.acronym!r}]"
         return "product"
 

--- a/tests/models/test_doctype.py
+++ b/tests/models/test_doctype.py
@@ -1,3 +1,4 @@
+from lxml import etree  # type: ignore
 import pytest
 
 # from docbuild.constants import ALLOWED_LIFECYCLES
@@ -239,12 +240,66 @@ def test_hash_with_doctype():
     assert hash(dt1) == hash(dt2)
 
 
+def test_iter_returns_doctype_items():
+    doctype = Doctype.from_str("sles/15-SP6,15-SP7/en-us,de-de")
+
+    items = list(doctype.iter_doctypes())
+
+    assert items
+    assert all(isinstance(item, Doctype) for item in items)
+    assert all(item.product == doctype.product for item in items)
+    assert all(item.lifecycle == doctype.lifecycle for item in items)
+    assert all(len(item.docset) == 1 for item in items)
+    assert all(len(item.langs) == 1 for item in items)
+
+
+def test_iter_is_docset_major_order():
+    doctype = Doctype.from_str("sles/15-SP6,15-SP7/en-us,de-de")
+
+    result = [
+        f"{item.product.acronym}/{item.docset[0]}/{item.langs[0].language}"
+        for item in doctype.iter_doctypes()
+    ]
+
+    assert result == [
+        "sles/15-SP6/de-de",
+        "sles/15-SP6/en-us",
+        "sles/15-SP7/de-de",
+        "sles/15-SP7/en-us",
+    ]
+
+
+def test_iter_wildcard_docset_expands_with_portal_root():
+    root = etree.fromstring(
+        """
+        <portal>
+           <product id="sles">
+              <docset path="15-SP6"><resources><locale lang="en-us"/><locale lang="de-de"/></resources></docset>
+              <docset path="16.0"><resources><locale lang="en-us"/></resources></docset>
+           </product>
+        </portal>
+        """,
+    )
+
+    doctype = Doctype.from_str("sles/*/*")
+    result = [
+        f"{item.product.acronym}/{item.docset[0]}/{item.langs[0].language}"
+        for item in doctype.iter_doctypes(portal_root=root)
+    ]
+
+    assert result == [
+        "sles/15-SP6/de-de",
+        "sles/15-SP6/en-us",
+        "sles/16.0/en-us",
+    ]
+
+
 def test_coerce_lifecycle_to_doctype():
     dt1 = Doctype(
         product="sles",
-        docset="15-SP5",
+        docset=["15-SP5"],
         lifecycle=LifecycleFlag.supported,
-        langs="en-us",
+        langs=["en-us"],
     )
     assert dt1.lifecycle == LifecycleFlag.supported
 
@@ -263,12 +318,48 @@ def test_sorted_langs_in_doctype():
     ]
 
 
+def test_iter_wildcard_remains_symbolic_without_portal_root():
+    doctype = Doctype.from_str("sles/*/en-us")
+    result = [
+        f"{item.product.acronym}/{item.docset[0]}/{item.langs[0].language}"
+        for item in doctype.iter_doctypes()
+    ]
+
+    assert result == ["sles/*/en-us"]
+
+
+def test_iter_wildcard_product_expands_with_portal_root():
+    root = etree.fromstring(
+        """
+        <portal>
+            <product id="sles">
+            <docset path="15-SP6"><resources><locale lang="en-us"/></resources></docset>
+            </product>
+            <product id="smart">
+            <docset path="2.0"><resources><locale lang="en-us"/></resources></docset>
+            </product>
+        </portal>
+        """,
+    )
+
+    doctype = Doctype.from_str("*/*/en-us")
+    result = [
+        f"{item.product.acronym}/{item.docset[0]}/{item.langs[0].language}"
+        for item in doctype.iter_doctypes(portal_root=root)
+    ]
+
+    assert result == [
+        "sles/15-SP6/en-us",
+        "smart/2.0/en-us",
+    ]
+
+
 def test_sorted_docsets_in_doctype_instantiation():
     dt1 = Doctype(
         product="sles",
         docset=["16-SP0", "15-SP7"],
         lifecycle=LifecycleFlag.supported,
-        langs="en-us",
+        langs=["en-us"],
     )
     assert dt1.docset == ["15-SP7", "16-SP0"]
 
@@ -358,6 +449,10 @@ def test_product_xpath_segment():
     # Test with all products (*)
     dt_all = Doctype.from_str("*/15-SP6/en-us")
     assert dt_all.product_xpath_segment() == "product"
+
+    # Test with a specific product
+    dt_specific = Doctype.from_str("sles/15-SP6/en-us")
+    assert dt_specific.product_xpath_segment() == "product[@id='sles']"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This can be helpful if you need to "dissect" all possible values into distinct Doctypes.

Changes:
* Add `Doctype.iter_doctypes` to iterate over all docset and language combinations.
* Take into account wildcard values (`*`). They can only be expanded, if we pass the portal root tree.
* Amend test case
* Update API documentation