### PR TITLE
Refactor Doctype.xpath and list_all_deliverables

### DIFF
--- a/changelog.d/431.refactor.rst
+++ b/changelog.d/431.refactor.rst
@@ -1,0 +1,3 @@
+Consolidate XPath logic in :class:`~docbuild.models.doctype.Doctype` by introducing :meth:`~docbuild.models.doctype.Doctype.lifecycle_xpath_segment` and :meth:`~docbuild.models.doctype.Doctype.locale_xpath_segment` helper methods, refactoring :meth:`~docbuild.models.doctype.Doctype.xpath` to use them, and adding an optional ``absolute`` argument.
+
+Refactor :meth:`~docbuild.config.xml.list.list_all_deliverables` to delegate XPath construction to :meth:`~docbuild.models.doctype.Doctype.xpath` instead of building expressions manually.

--- a/docs/source/reference/_autoapi/docbuild/models/doctype/Doctype.rst
+++ b/docs/source/reference/_autoapi/docbuild/models/doctype/Doctype.rst
@@ -31,6 +31,7 @@ docbuild.models.doctype.Doctype
    >>> doctype = Doctype.from_str("sles/15-SP6@supported/en-us,de-de")
    >>> doctype.product
    <Product.sles: 'sles'>
+   <Product.sles: 'SUSE Linux Enterprise Server'>
    >>> doctype.docset
    ['15-SP6']
    >>> doctype.lifecycle.name
@@ -154,20 +155,21 @@ docbuild.models.doctype.Doctype
 
 
 
-   .. py:method:: xpath() -> str
+   .. py:method:: xpath(absolute: bool = False) -> str
 
       Return an XPath expression for this Doctype to find all deliverables.
 
-      >>> result = Doctype.from_str("sles/15-SP6@supported/en-us,de-de").xpath()
+      >>> result = Doctype.from_str("sles/15-SP6@supported/en-us,de-de").xpath(absolute=True)
       >>> expected = (
-      ...     "product[@id='sles']/docset[@path='15-SP6']"
+      ...     "//product[@id='sles']/docset[@path='15-SP6']"
       ...     "[@lifecycle='supported']"
       ...     "/resources/locale[@lang='de-de' or @lang='en-us']"
+      ...     "/deliverable"
       ... )
       >>> result == expected
       True
 
-      :return: A relative XPath expression that can be used to find all
+      :return: An XPath expression that can be used to find all
           deliverables that match this Doctype.
 
 
@@ -180,10 +182,26 @@ docbuild.models.doctype.Doctype
 
 
 
-   .. py:method:: docset_xpath_segment(docset: str) -> str
+   .. py:method:: docset_xpath_segment(docset: str | None = None) -> str
 
       Return the XPath segment for the docset node.
 
       Example: "docset[@path='15-SP6']" or "docset"
+
+
+
+   .. py:method:: lifecycle_xpath_segment() -> str
+
+      Return the XPath segment for the lifecycle node.
+
+      Example: "docset[@lifecycle='supported']" or "docset"
+
+
+
+   .. py:method:: locale_xpath_segment() -> str
+
+      Return the XPath segment for the language node.
+
+      Example: "resources/locale[@lang='en-us']" or "resources/locale"
 
 

--- a/docs/source/reference/_autoapi/docbuild/models/product/Product.rst
+++ b/docs/source/reference/_autoapi/docbuild/models/product/Product.rst
@@ -20,3 +20,5 @@ docbuild.models.product.Product
 
 
       Return the canonical product acronym used in doctypes and XML IDs.
+
+

--- a/src/docbuild/config/xml/list.py
+++ b/src/docbuild/config/xml/list.py
@@ -6,8 +6,6 @@ import logging
 from lxml import etree  # type: ignore
 
 from ...models.doctype import Doctype
-from ...models.lifecycle import LifecycleFlag
-from ...models.product import Product
 
 xpathlog = logging.getLogger(__name__)
 log = logging.getLogger(__package__)
@@ -26,38 +24,7 @@ def list_all_deliverables(
     if doctypes is not None:
         log.debug("Filtering for docset %r", doctypes)
         for dt in doctypes:
-            # Using flexible relative descendant selectors ensures compatibility
-            # with both nested test fixtures and the absolute portal configuration schema.
-            xpath = "//product"
-            if dt.product and dt.product != Product.ALL:
-                xpath += f"[@id={dt.product.acronym!r}]"
-
-            xpath += "/docset"
-            # Protect against empty lists causing malformed [] XPath segments
-            if dt.docset and "*" not in dt.docset:
-                xpath += "[" + " or ".join([f"@path={d!r}" for d in dt.docset]) + "]"
-
-            if dt.lifecycle and LifecycleFlag.unknown != dt.lifecycle:  # type: ignore
-                xpath += (
-                    "["
-                    + " or ".join([f"@lifecycle={lc.name!r}" for lc in dt.lifecycle])
-                    + "]"
-                )
-
-            xpath += "/resources/locale"
-
-            if dt.langs and "*" not in dt.langs:
-                xpath += (
-                    "["
-                    + " or ".join([f"@lang={lng.language!r}" for lng in dt.langs])
-                    + "]"
-                )
-            elif not dt.langs:
-                # Toms' Suggestion: Fallback to English if no language is specified
-                xpath += "[@lang='en-us']"
-
-            xpath += "/deliverable"
-
+            xpath = f"{dt.xpath(absolute=True)}/deliverable"
             nodes = tree.xpath(xpath)
             if nodes:
                 yield from nodes
@@ -66,10 +33,8 @@ def list_all_deliverables(
 
     else:
         # Default fallback route with a flexible relative search path pattern
-        xpath = "//product/docset/resources/locale[@lang='en-us']/deliverable"
-        # if not tree.xpath(xpath):
-        #    # Fallback alignment support variant for raw test fixtures
-        #    xpath = "//product/docset/resources/locale[@lang='en-us']/deliverable"
+        dt = Doctype.from_str("//en-us")
+        xpath = f"{dt.xpath(absolute=True)}/deliverable"
 
         xpathlog.debug("XPath: %r", xpath)
         yield from tree.xpath(xpath)

--- a/src/docbuild/models/doctype.py
+++ b/src/docbuild/models/doctype.py
@@ -35,6 +35,7 @@ class Doctype(BaseModel):
     >>> doctype = Doctype.from_str("sles/15-SP6@supported/en-us,de-de")
     >>> doctype.product
     <Product.sles: 'sles'>
+    <Product.sles: 'SUSE Linux Enterprise Server'>
     >>> doctype.docset
     ['15-SP6']
     >>> doctype.lifecycle.name
@@ -78,6 +79,7 @@ class Doctype(BaseModel):
         default=[LanguageCode(language="en-us")],
         description=(
             "The natural language containing language and country. "
+            "Values can be combined using commas. "
             "After validation, langs are sorted"
         ),
         examples=["en-us", "de-de"],
@@ -226,51 +228,29 @@ class Doctype(BaseModel):
             langs=langs,
         )
 
-    def xpath(self: Self) -> str:
+    def xpath(self: Self, absolute:bool=False) -> str:
         """Return an XPath expression for this Doctype to find all deliverables.
 
-        >>> result = Doctype.from_str("sles/15-SP6@supported/en-us,de-de").xpath()
+        >>> result = Doctype.from_str("sles/15-SP6@supported/en-us,de-de").xpath(absolute=True)
         >>> expected = (
-        ...     "product[@id='sles']/docset[@path='15-SP6']"
+        ...     "//product[@id='sles']/docset[@path='15-SP6']"
         ...     "[@lifecycle='supported']"
         ...     "/resources/locale[@lang='de-de' or @lang='en-us']"
+        ...     "/deliverable"
         ... )
         >>> result == expected
         True
 
-        :return: A relative XPath expression that can be used to find all
+        :return: An XPath expression that can be used to find all
             deliverables that match this Doctype.
         """
         # Example: /sles/15-SP6@supported/en-us,de-de
-        product = "product"
-        if self.product != Product.ALL:
-            product += f"[@id={self.product.acronym!r}]"
+        product = f"//{self.product_xpath_segment()}" if absolute else self.product_xpath_segment()
 
-        setids = [f"@path={d!r}" for d in self.docset if d != "*"]
-
-        setids_str = " or ".join(setids)
-        if setids_str:
-            docset = f"docset[{setids_str}]"
-        else:
-            docset = "docset"
-
-        lifecycle = " or ".join(
-            [
-                f"@lifecycle={lc.name!r}"
-                for lc in self.lifecycle
-                if lc != LifecycleFlag.unknown
-            ]
-        )
-        if lifecycle:
-            docset += f"[{lifecycle}]"
-
-        if "*" in self.langs:
-            language = "locale"
-        else:
-            language = " or ".join([f"@lang={lang.language!r}" for lang in self.langs])
-            language = f"locale[{language}]"
-
-        return f"{product}/{docset}/resources/{language}"
+        docset = self.docset_xpath_segment()
+        docset += self.lifecycle_xpath_segment()
+        locale = self.locale_xpath_segment()
+        return f"{product}/{docset}/resources/{locale}"
 
     def product_xpath_segment(self: Self) -> str:
         """Return the XPath segment for the product node.
@@ -281,11 +261,48 @@ class Doctype(BaseModel):
             return f"product[@id={self.product.acronym!r}]"
         return "product"
 
-    def docset_xpath_segment(self: Self, docset: str) -> str:
+    def docset_xpath_segment(self: Self, docset: str | None = None) -> str:
         """Return the XPath segment for the docset node.
 
         Example: "docset[@path='15-SP6']" or "docset"
         """
-        if docset != "*":
-            return f"docset[@path={docset!r}]"
+        if docset is not None:
+            if docset != "*":
+                return f"docset[@path={docset!r}]"
+            return "docset"
+
+        if self.docset and "*" not in self.docset:
+            setids = [f"@path={d!r}" for d in self.docset if d != "*"]
+            setids_str = " or ".join(setids)
+            return f"docset[{setids_str}]"
         return "docset"
+
+    def lifecycle_xpath_segment(self: Self) -> str:
+        """Return the XPath segment for the lifecycle node.
+
+        Example: "docset[@lifecycle='supported']" or "docset"
+        """
+        if self.lifecycle and self.lifecycle != LifecycleFlag.unknown:
+            lifecycle = " or ".join(
+                [
+                    f"@lifecycle={lc.name!r}"
+                    for lc in self.lifecycle
+                ]
+            )
+            return f"[{lifecycle}]"
+        return ""
+
+    def locale_xpath_segment(self: Self) -> str:
+        """Return the XPath segment for the language node.
+
+        Example: "resources/locale[@lang='en-us']" or "resources/locale"
+        """
+        language = "locale"
+        has_wildcard = any(lang.language == "*" for lang in self.langs)
+        if self.langs and not has_wildcard:
+            language = " or ".join([f"@lang={lang.language!r}" for lang in self.langs])
+            language = f"locale[{language}]"
+        elif not self.langs:
+            # Toms' Suggestion: Fallback to English if no language is specified
+            language += "[@lang='en-us']"
+        return language

--- a/tests/models/test_doctype.py
+++ b/tests/models/test_doctype.py
@@ -285,7 +285,7 @@ def test_sorted_langs_in_doctype_instantiation():
 
 
 @pytest.mark.parametrize(
-    "string,xpath",
+    "string_or_doctype,xpath",
     [
         # 1: product + one docset + a single language
         (
@@ -332,11 +332,24 @@ def test_sorted_langs_in_doctype_instantiation():
         ("//en-us", "product/docset/resources/locale[@lang='en-us']"),
         # 7: all products, docsets, lifecycles, and languages
         ("//*", "product/docset/resources/locale"),
+        # 8: fallback to English for empty language lists
+        (
+            Doctype(product="sles", docset=["15-SP6"], langs=[]),
+            "product[@id='sles']/docset[@path='15-SP6']/resources/locale[@lang='en-us']",
+        ),
+        # 9: explicit language plus wildcard means all languages
+        (
+            Doctype(product="sles", docset=["15-SP6"], langs=["en-us", "*"]),
+            "product[@id='sles']/docset[@path='15-SP6']/resources/locale",
+        ),
     ],
 )
-def test_xpath_in_doctype(string, xpath):
+def test_xpath_in_doctype(string_or_doctype, xpath):
     """Test the XPath extraction from a Doctype."""
-    doctype = Doctype.from_str(string)
+    if isinstance(string_or_doctype, str):
+        doctype = Doctype.from_str(string_or_doctype)
+    else:
+        doctype = string_or_doctype
     assert xpath == doctype.xpath()
 
 
@@ -347,8 +360,26 @@ def test_product_xpath_segment():
     assert dt_all.product_xpath_segment() == "product"
 
 
-def test_docset_xpath_segment():
+@pytest.mark.parametrize(
+    "string,xpath",
+    [
+        # 1
+        ("sles/*/en-us", "docset"),
+        # 2
+        ("sles/15-SP6/en-us", "docset[@path='15-SP6']"),
+        # 3
+        ("sles/15-SP6,15-SP7/en-us", "docset[@path='15-SP6' or @path='15-SP7']"),
+    ],
+)
+def test_docset_xpath_segment(string, xpath):
     """Test the docset_xpath_segment method."""
     # Test with all docsets (*)
-    dt_all = Doctype.from_str("sles/*/en-us")
-    assert dt_all.docset_xpath_segment("*") == "docset"
+    dt_all = Doctype.from_str(string)
+    assert dt_all.docset_xpath_segment() == xpath
+
+
+def test_docset_xpath_segment_with_argument():
+    """Test the docset_xpath_segment method with a specific argument."""
+    dt = Doctype.from_str("sles/15-SP6/en-us")
+    assert dt.docset_xpath_segment("16.0") == "docset[@path='16.0']"
+    assert dt.docset_xpath_segment("*") == "docset"


### PR DESCRIPTION
Collect all XPath related parts in Doctype and NOT spread it to other functions.

Changes:
* Function `list_all_deliverables` Refactor and avoid manually creating XPath expression. Better rely on `Doctype.xpath()`

* Class `Doctype`
  - Introduce lifecycle_xpath_segment() and locale_xpath_segment. The two returns the respective XPath expression for the lifecycle and the locale part
  - Refactor .xpath() and call the respective *_xpath_segment() methods internally
  - Add an optional absolute argument (default = False) to add "//" in front of the XPath