### PR TITLE
Fix #432: Prepare pyrefly as type checker

### DIFF
--- a/changelog.d/436.infra.rst
+++ b/changelog.d/436.infra.rst
@@ -1,0 +1,3 @@
+Added dedicated :file:`pyrefly.toml` and :file:`pyrightconfig.json` configuration files in preparation for type checking with Pyrefly and Pyright.
+Both checkers now cover the ``src/`` directory only and target Python 3.12;
+tests are intentionally excluded.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ classifiers = [
 
 [dependency-groups]
 typing = [
+    "pyrefly>=1.2.0",
     "pyright>=1.1.411",
 ]
 formatting = [

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -1,0 +1,16 @@
+# Pyrefly configuration for docbuild
+# See https://pyrefly.org/en/docs/configuration/
+
+# Files to type check. Tests are intentionally excluded; they are exempt from
+# annotation rules (see the per-file-ignores in .ruff.toml).
+project-includes = ["src"]
+
+# Keep this in sync with "requires-python" in pyproject.toml: type check
+# against the oldest supported Python so newer-only stdlib APIs are flagged.
+python-version = "3.12"
+
+# Align with .ruff.toml, which already excludes "contrib".
+project-excludes = ["contrib"]
+
+# Respect .gitignore-based excludes (default, but explicit here for clarity).
+use-ignore-files = true

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,22 @@
+{
+  // Pyright configuration for docbuild
+  // See https://microsoft.github.io/pyright/#/configuration
+  //
+  // Mirrors pyrefly.toml so both type checkers see the same project scope.
+
+  // Files to type check. Tests are intentionally excluded; they are exempt
+  // from annotation rules (see the per-file-ignores in .ruff.toml).
+  "include": ["src"],
+
+  // Align with .ruff.toml, which already excludes "contrib".
+  "exclude": ["contrib"],
+
+  // Keep this in sync with "requires-python" in pyproject.toml: type check
+  // against the oldest supported Python so newer-only stdlib APIs are flagged.
+  "pythonVersion": "3.12",
+
+  // Point pyright at the uv-managed virtual environment so third-party
+  // imports (pydantic, semver, ...) resolve from the installed packages.
+  "venvPath": ".",
+  "venv": ".venv"
+}

--- a/uv.lock
+++ b/uv.lock
@@ -291,6 +291,7 @@ dev = [
     { name = "ipython" },
     { name = "myst-parser" },
     { name = "pydata-sphinx-theme" },
+    { name = "pyrefly" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -312,6 +313,7 @@ devel = [
     { name = "ipython" },
     { name = "myst-parser" },
     { name = "pydata-sphinx-theme" },
+    { name = "pyrefly" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -370,6 +372,7 @@ tests = [
     { name = "pytest-cov" },
 ]
 typing = [
+    { name = "pyrefly" },
     { name = "pyright" },
 ]
 
@@ -392,6 +395,7 @@ dev = [
     { name = "ipython", specifier = ">=9.16.1" },
     { name = "myst-parser", specifier = ">=5.1.0" },
     { name = "pydata-sphinx-theme", specifier = ">=0.20.0" },
+    { name = "pyrefly", specifier = ">=1.2.0" },
     { name = "pyright", specifier = ">=1.1.411" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
@@ -413,6 +417,7 @@ devel = [
     { name = "ipython", specifier = ">=9.16.1" },
     { name = "myst-parser", specifier = ">=5.1.0" },
     { name = "pydata-sphinx-theme", specifier = ">=0.20.0" },
+    { name = "pyrefly", specifier = ">=1.2.0" },
     { name = "pyright", specifier = ">=1.1.411" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
@@ -468,7 +473,10 @@ tests = [
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
 ]
-typing = [{ name = "pyright", specifier = ">=1.1.411" }]
+typing = [
+    { name = "pyrefly", specifier = ">=1.2.0" },
+    { name = "pyright", specifier = ">=1.1.411" },
+]
 
 [[package]]
 name = "docformatter"
@@ -1047,6 +1055,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyrefly"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/01/a86e9f24722b095c3f88e3616132b75a21b0df53804bdc6a45314dd4d93c/pyrefly-1.2.0.tar.gz", hash = "sha256:5485f960fc2481617068c918335c39ab1507ef90b6b5bd35bf57726e60e73185", size = 6243654, upload-time = "2026-08-01T02:56:27.592Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/9d/3c0ef1d4843987b22f996ed381ec9cf5a3b1273e29804db276252e4c95eb/pyrefly-1.2.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7f46d983ac49ddd2b043694960a01dc6a19a5cfd8eec609d6bd9c42866f91b4e", size = 14026305, upload-time = "2026-08-01T02:56:02.611Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/06/03bbb78fbea54cdc65b626619f3597d5611aca4fdef11e72a4e8360e7e63/pyrefly-1.2.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:756f669b5555090f5c1a4fef30db1785fabe657764f7e4e6dc88994dfb8ca82d", size = 13463880, upload-time = "2026-08-01T02:56:04.93Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5a/7d8bc00a38e93bbc9c3e7bd14d305f7948717e667c9bcddeab9dd42fd255/pyrefly-1.2.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3465812ce5ef4781fb592edbf2724547296f0a3124be115d73c7e8b2401862d", size = 13907329, upload-time = "2026-08-01T02:56:07.104Z" },
+    { url = "https://files.pythonhosted.org/packages/be/94/9e08b4bf799d0b8f36b55a2783c7ba5f51730cf0632a85a67b5b5ed876cd/pyrefly-1.2.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5de7b2ad2bba5c8055181681a84b74143eac2234a48ba5d1b7ed7e7a722b02bd", size = 15039020, upload-time = "2026-08-01T02:56:09.208Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/bd/bca5fd0c80f4daf8ee6903a29df9f3de1feb05ff0946b8f35ec8c5096b13/pyrefly-1.2.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:25822ea9505f589ea8a725e4268b475132fb89e038fbf092e446510443ac142a", size = 14986199, upload-time = "2026-08-01T02:56:11.924Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f7/f07087f3d185ad2eced0c56cef89ca5474dfb4ff25f146cd50a861c97553/pyrefly-1.2.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90efe75e17491ef5d636e10469e9278d7d0256b3b4c5e1f4750069bf3ae0f5d1", size = 14393715, upload-time = "2026-08-01T02:56:14.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/70/0d142c320e284b9e3ce35e9b1e58b8ce2ee1f578f2a7234bc30e5022b94f/pyrefly-1.2.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:368aaf7eee4f511ddc0f8e564cf14e01ab2f10b0db9105c6d5b153bf498d07bf", size = 13933008, upload-time = "2026-08-01T02:56:16.525Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e8/e84f11b6e1f63fd453ad3654213b9a0f6f4de8cef6b58038eef2d0d5955d/pyrefly-1.2.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d52d5da7bc65fb7675fbaa80eda879d4f8787c494f04cac21603330d3abbdbbe", size = 14431827, upload-time = "2026-08-01T02:56:18.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/06/810d31380f66c75e1c0779a408d3b16117b1b368b57894f6aa66bef21686/pyrefly-1.2.0-py3-none-win32.whl", hash = "sha256:8c90751de8506d938e8f802659c74cf35bd7a0036510ee6c634a38eebb280bfa", size = 13229447, upload-time = "2026-08-01T02:56:20.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/98/4dafa3c7a1caed2dc8cc708dde09ba27963c7736508f55b626fff3024113/pyrefly-1.2.0-py3-none-win_amd64.whl", hash = "sha256:8a8964c224ccc4882730130955815de21ff443c1ac3f0b90685b19bf63848170", size = 14087387, upload-time = "2026-08-01T02:56:23.188Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1c/df3cb0a2e5591660ded7a1836cd2f29dc48c91adb1c0a3a700a96f6d09e1/pyrefly-1.2.0-py3-none-win_arm64.whl", hash = "sha256:3a90bb8df39dfbac74b1f3b2e9d7c526b8f80568884c3944d955023a73ebf61e", size = 13430873, upload-time = "2026-08-01T02:56:25.425Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #432.

At the time of writing, pyrefly and pyright seems to be the most complete type checkers (although not perfect). We provide both in case we need to switch.

* Add config settings for pyrefly (`pyrefly.toml`)
* Add config settings for pyright (`pyrightconfig.json`)

Currently, we focus on the `src/` directory only. Tests aren't covered by these config files and are intentionally excluded.