### PR TITLE
Switch from weekly to monthly Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,10 @@ version: 2
 updates:
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 6
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     assignees:
       - "tomschr"
     cooldown:

--- a/changelog.d/445.infra.rst
+++ b/changelog.d/445.infra.rst
@@ -1,0 +1,1 @@
+Switched from weekly to monthly Dependabot version updates 


### PR DESCRIPTION
Weekly updates are becoming a bit annoying. :laughing:  Switching to a monthly schedule might migigate this.

Also raise the maximum pull request limit to 6.