### PR TITLE
Extend doc about doctype syntax

### DIFF
--- a/changelog.d/453.doc.rst
+++ b/changelog.d/453.doc.rst
@@ -1,0 +1,3 @@
+Amended the documentation about doctype syntax and the class
+:class:`~docbuild.models.doctype.Doctype` to stay consistent. Also
+added some more examples and the fallback default value to English.

--- a/docs/source/user/build.rst
+++ b/docs/source/user/build.rst
@@ -10,6 +10,8 @@ The :command:`docbuild build` subcommand is used to build the deliverables from 
 
    docbuild build [OPTIONS] DOCTYPE [DOCTYPE ...]
 
+The syntax is modeled in the :class:`~docbuild.models.doctype.Doctype` class.
+
 
 The doctype syntax
 ------------------
@@ -21,29 +23,37 @@ describes the document to be built. The general syntax for a doctype is:
    :caption: Doctype syntax
    :name: doctype-syntax
 
-   [PRODUCT]/[DOCSET][@LIFECYCLES]/LANGS
+   [/]?[PRODUCT]/[DOCSET...][@LIFECYCLES...]/[LANGS...]
 
 The fields in the doctype have the following meanings:
 
 * **PRODUCT** (optional): The product name, such as ``sles``, ``smart`` etc.
   You can omit this field if the product is not relevant for the document or you can use ``*`` to match all products.
+  The acronym is checked against a pre-defined set of products.
 * **DOCSET** (optional): The docset, usually the version or release of a product such as ``15-SP6``, ``16-GA`` etc.
   You can omit this field if the docset is not relevant for the document or you can use ``*`` to match all docsets.
+  If you specify multiple docsets, separate them with commas (e.g., ``15-SP6,16-GA``).
 * **LIFECYCLES** (optional): The lifecycle of the document that can have the values of ``supported``, ``beta``, ``unsupported``, or ``hidden``.
-  You can omit this field if the lifecycle is not relevant for the document or you can use ``*`` to match all lifecycles. If you specify multiple lifecycles, separate them with commas (e.g., ``supported,beta``).
+  You can omit this field if the lifecycle is not relevant for the document or you can use ``*`` to match all lifecycles.
+  If you specify multiple lifecycles, separate them with commas (e.g., ``supported,beta``).
 * **LANGS** (optional): The language of the document, such as ``en-us``, ``de-de``, etc.
-  You can omit this field if the language is not relevant for the document or you can use ``*`` to match all languages. If you specify multiple languages, separate them with commas (e.g., ``en-us,de-de``).
+  You can omit this field if the language is not relevant for the document or you can use ``*`` to match all languages.
+  If you leave this field empty, it will default to English (``en-us``).
+  If you specify multiple languages, separate them with commas (e.g., ``en-us,de-de``).
 
 
 Some common examples of doctypes are:
 
-* ``sles/15-SP6/en-us``: Matches the English deliverables for SLES 15-SP6, regardless of the lifecycle.
+* ``sles/15-SP6/en-us`` or ``/sles/15-SP6/en-us``: Matches the English deliverables for SLES 15-SP6, regardless of the lifecycle.
 * ``*/*/de-de``: Matches all deliverables in German, regardless of the product, docset, or lifecycle.
 * ``//en-us``: Matches all deliverables in English, regardless of product, docset, or lifecycle. This is a shorter version of ``*/*/en-us``.
+* ``/@supported/``: Matches all supported English deliverables, regardless of the product, docset.
 * ``sles//en-us``: Matches all English SLES deliverables, regardless of the docset or lifecycle.
-* ``sle-ha//@unsupported/en-us,de-de``: Matches all SLE-HA deliverables in English and German that are in the unsupported lifecycle, regardless of the docset.
+* ``sle-ha/@unsupported/en-us,de-de``: Matches all SLE-HA deliverables in English and German that are in the unsupported lifecycle, regardless of the docset.
 * ``*/@beta,supported/de-de``: Matches all SLES deliverables in German that are in the beta or supported lifecycle, regardless of the product.
-* ``//``: Matches all deliverables in all languages, regardless of the product, docset, or lifecycle. This is the simplest doctype and matches everything.
+* ``//*``: Matches all deliverables in all languages, regardless of the product, docset, or lifecycle.
+* ``//``: Matches all English deliverables, regardless of the product, docset, or lifecycle. Same as ``*/*/en-us`` or ``//en-us``.
+
 
 
 Minimal set of doctypes

--- a/src/docbuild/models/doctype.py
+++ b/src/docbuild/models/doctype.py
@@ -22,7 +22,7 @@ class Doctype(BaseModel):
 
     .. code-block:: text
 
-       [/]?PRODUCT/DOCSETS[@LIFECYCLES]/[LANGS]
+       [/]?[PRODUCT]/[DOCSET...][@LIFECYCLES...]/[LANGS...]
 
     The placeholders mean the following:
 
@@ -45,6 +45,8 @@ class Doctype(BaseModel):
     'supported'
     >>> doctype.langs
     [LanguageCode(language='de-de'), LanguageCode(language='en-us')]
+
+    See also: :ref:`build-deliverables`
     """
 
     product: Product = Field(


### PR DESCRIPTION
In PRs #409, the doctype syntax was slightly revised: product, docsets, lifecycles, and languages are all optional.

Additionally, when the language was omitted, it falls back to English as default. Keep in mind the difference between these two notations:

* `//`  => The complete set in English (an abbreviation for `//en-us`)
* `//*` => The complete set for all languages

This distinction is described in this PR