### PR TITLE
fix(metadata): expand docset wildcards

### DIFF
--- a/changelog.d/455.bugfix.rst
+++ b/changelog.d/455.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :func:`~docbuild.tasks.metadata.manifest.store_productdocset_json` not writing any product/docset JSON file when the doctype contained a docset wildcard (for example ``appliance/*/*``). Doctypes are now resolved with :meth:`~docbuild.models.doctype.Doctype.iter_doctypes` before the cached metadata files are collected.

--- a/src/docbuild/models/manifest.py
+++ b/src/docbuild/models/manifest.py
@@ -38,8 +38,16 @@ class Description(BaseModel):
     """
 
     lang: LanguageCode
-    default: bool
+    default: bool = Field(default=False)
     description: str = Field(default="")
+
+    @model_validator(mode="after")
+    def set_default_for_english(self: Self) -> Self:
+        """Auto-mark English descriptions as default when not explicitly set."""
+        if ("default" not in self.model_fields_set and
+            self.lang.language in DEFAULT_LANGS):
+            self.default = True
+        return self
 
     @field_serializer("lang")
     def serialize_lang(self: Self, value: LanguageCode, info: SerializationInfo) -> str:
@@ -59,7 +67,6 @@ class Description(BaseModel):
         """
         for n in node.xpath("descriptions/desc"):
             attrs: dict[str, Any] = dict(n.attrib)
-            attrs.setdefault("default", False)
             text = "".join(
                 f"<{child.tag}>{
                     ' '.join(

--- a/src/docbuild/tasks/metadata/manifest.py
+++ b/src/docbuild/tasks/metadata/manifest.py
@@ -196,12 +196,24 @@ def store_productdocset_json(
 ) -> None:
     """Collect all JSON files for product/docset and create a single file.
 
+    Wildcards in ``doctypes`` are resolved against the stitched config, as
+    :func:`collect_files_flat` matches docsets against literal path components.
+
     :param doctypes: Sequence of Doctype objects.
     :param stitchnode: The stitched XML tree.
     :param meta_cache_dir: Path to the metadata cache directory.
     :param json_cache_dir: Path to the JSON cache directory.
     """
-    for doctype, docset, files in collect_files_flat(doctypes, meta_cache_dir):
+    # iter_doctypes() yields one entry per docset/language, but JSON is per docset.
+    resolved = {
+        (dt.product.acronym, dt.docset[0]): dt
+        for doctype in doctypes
+        for dt in doctype.iter_doctypes(stitchnode.getroot())
+    }
+
+    for doctype, docset, files in collect_files_flat(
+        list(resolved.values()), meta_cache_dir
+    ):
         product = doctype.product.acronym
         version_str = str(docset)
 

--- a/tests/models/test_manifest.py
+++ b/tests/models/test_manifest.py
@@ -134,6 +134,18 @@ def test_description_serialize_lang() -> None:
     assert serialized["lang"] == "en-us"
 
 
+def test_description_default_for_english_when_missing() -> None:
+    """Auto-set default=True when lang is en-us and default is omitted."""
+    desc = Description(lang="en-us", description="Test description")
+    assert desc.default is True
+
+
+def test_description_explicit_default_is_preserved() -> None:
+    """Do not override an explicitly provided default value."""
+    desc = Description(lang="en-us", default=False, description="Test description")
+    assert desc.default is False
+
+
 def test_category_translation_serialize_lang() -> None:
     """Test serialization of LanguageCode in CategoryTranslation."""
     cat_trans = CategoryTranslation(lang="de-de", default=False, title="Test Titel")
@@ -258,6 +270,21 @@ def test_description_from_xml_node() -> None:
         "description": "<p>Hello Description</p>",
     }
     assert models[1].lang == LanguageCode(language="de-de")
+
+
+def test_description_from_xml_node_marks_english_default() -> None:
+    """Descriptions without a default attribute mark en-us as the default."""
+    doc = """<product>
+        <descriptions>
+            <desc lang="en-us"><p>English</p></desc>
+            <desc lang="de-de"><p>German</p></desc>
+            <desc default="0" lang="en-us"><p>Not default</p></desc>
+        </descriptions>
+    </product>
+    """
+    models = list(Description.from_xml_node(etree.fromstring(doc, parser=None)))
+
+    assert [m.default for m in models] == [True, False, False]
 
 
 def test_single_document_warn_missing_title(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/tasks/metadata/test_manifest.py
+++ b/tests/tasks/metadata/test_manifest.py
@@ -290,6 +290,77 @@ def test_store_productdocset_json_applies_docset_description_treatment(
     assert data["descriptions"][0]["description"] == "<p>Global</p><p>Local</p>"
 
 
+def test_store_productdocset_json_expands_docset_wildcard(tmp_path: Path) -> None:
+    """A wildcard doctype writes one JSON file per configured docset."""
+    xml_string = """
+    <docservconfig>
+      <product id="appliance">
+        <name>Appliance building</name>
+        <acronym>appliance</acronym>
+        <docset id="appliance.keg-2" path="keg-2" lifecycle="supported">
+          <resources>
+            <git remote="https://github.com/SUSE-Enceladus/keg.git"/>
+            <locale lang="en-us"/>
+          </resources>
+        </docset>
+        <docset id="appliance.kiwi-9" path="kiwi-9" lifecycle="supported">
+          <resources>
+            <git remote="https://github.com/OSInside/kiwi-suse-doc.git"/>
+            <locale lang="en-us"/>
+          </resources>
+        </docset>
+      </product>
+    </docservconfig>
+    """
+    stitchnode_local = etree.ElementTree(etree.fromstring(xml_string))
+
+    meta_cache_dir = tmp_path / "cache" / "metadata"
+    json_cache_dir = tmp_path / "cache" / "json"
+    json_cache_dir.mkdir(parents=True, exist_ok=True)
+
+    for docset, dcfile, title in (
+        ("keg-2", "DC-keg", "Keg"),
+        ("kiwi-9", "DC-kiwi", "KIWI"),
+    ):
+        outdir = meta_cache_dir / "en-us" / "appliance" / docset
+        outdir.mkdir(parents=True, exist_ok=True)
+        (outdir / dcfile).write_text(
+            json.dumps(
+                {
+                    "docs": [
+                        {
+                            "title": title,
+                            "dcfile": f"{dcfile}.xml",
+                            "lang": "en-us",
+                            "description": f"The {title} guide.",
+                            "dateModified": "2024-01-01",
+                            "format": {"html": "path/to/html"},
+                        }
+                    ],
+                    "category": "cat.administration",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    store_productdocset_json(
+        doctypes=[Doctype.from_str("appliance/*/*")],
+        stitchnode=stitchnode_local,
+        meta_cache_dir=meta_cache_dir,
+        json_cache_dir=json_cache_dir,
+    )
+
+    jsondir = json_cache_dir / "appliance"
+    assert sorted(p.name for p in jsondir.glob("*.json")) == [
+        "keg-2.json",
+        "kiwi-9.json",
+    ]
+
+    keg = json.loads((jsondir / "keg-2.json").read_text(encoding="utf-8"))
+    assert keg["productname"] == "Appliance building"
+    assert [doc["docs"][0]["title"] for doc in keg["documents"]] == ["Keg"]
+
+
 def test_configured_languages_from_docset_preserves_order_and_uniqueness() -> None:
     """Extract configured locale languages in order while removing duplicates."""
     docset_node = etree.fromstring(


### PR DESCRIPTION
A wildcard docset like 'appliance/*/*' produced no JSON output at all, because `collect_files_flat()` matches the docset against literal path components of the cached `DC-*` files and never sees a '*'.

* Resolve doctypes via `Doctype.iter_doctypes()` in `store_productdocset_json()`, keyed on (product, docset) so each docset is written once instead of once per language.
* Add a regression test that exercises the real `collect_files_flat()`; existing tests mock it and pass in pre-resolved docsets.
* Mark English descriptions as default again: Description now uses the same `set_default_for_english()` validator as `CategoryTranslation`, and `from_xml_node()` no longer forces `default=False` when the `<desc>` element has no default attribute.
