### PR TITLE
feat(utils): implement async rsync wrapper with RsyncOptions

### DIFF
--- a/changelog.d/452.feature.rst
+++ b/changelog.d/452.feature.rst
@@ -1,1 +1,1 @@
-Added an async ``rsync`` utility function and ``RsyncOptions`` dataclass for flexible directory synchronization, and registered ``rsync`` as a validated system dependency.
+Added an async :command:`rsync` utility function and ``RsyncOptions`` dataclass for flexible directory synchronization, and registered :command:`rsync` as a validated system dependency.

--- a/changelog.d/452.feature.rst
+++ b/changelog.d/452.feature.rst
@@ -1,0 +1,1 @@
+Added an async ``rsync`` utility function and ``RsyncOptions`` dataclass for flexible directory synchronization, and registered ``rsync`` as a validated system dependency.

--- a/src/docbuild/constants.py
+++ b/src/docbuild/constants.py
@@ -39,7 +39,7 @@ SERVER_ROLES_ALIASES: tuple[str, ...] = tuple(ServerRole.__members__.keys())
 DEFAULT_LIFECYCLE: str = "supported"
 """The default lifecycle state for a docset."""
 
-ALLOWED_LIFECYCLES: tuple[str, ...] = tuple(lc.name for lc in LifecycleFlag)
+ALLOWED_LIFECYCLES: tuple[str, ...] = tuple(str(lc.name) for lc in LifecycleFlag if lc.name)
 # ('supported', 'beta', 'hidden', 'unsupported')
 """The available lifecycle states for a docset (without 'unknown')."""
 
@@ -170,4 +170,5 @@ SYSTEM_DEPENDENCIES = {
     "daps": ">=4",
     "xmllint": None,
     "xsltproc": None,
+    "rsync": None,
 }

--- a/src/docbuild/utils/sync.py
+++ b/src/docbuild/utils/sync.py
@@ -1,0 +1,89 @@
+"""Synchronization utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import os
+from pathlib import Path
+import subprocess
+
+from .shell import run_command
+
+
+@dataclass(frozen=True, slots=True)
+class RsyncOptions:
+    """Configuration options for rsync execution."""
+
+    archive: bool = True
+    compress: bool = False
+    delete: bool = False
+    dry_run: bool = False
+    verbose: bool = False
+    partial: bool = False
+
+    # Acts as an escape hatch for the 100+ rsync options not explicitly modeled here.
+    # Users can pass arbitrary flags (e.g., ["--exclude=*.tmp", "--bwlimit=1000"]).
+    extra_args: list[str] = field(default_factory=list)
+
+    def to_args(self) -> list[str]:
+        """Convert the configured options into a list of command-line arguments.
+
+        :return: A list of string arguments formatted for the rsync command.
+        """
+        args: list[str] = []
+
+        if self.archive:
+            args.append("-a")
+        if self.compress:
+            args.append("-z")
+        if self.delete:
+            args.append("--delete")
+        if self.dry_run:
+            args.append("--dry-run")
+        if self.verbose:
+            args.append("-v")
+        if self.partial:
+            args.append("--partial")
+
+        args.extend(self.extra_args)
+
+        return args
+
+
+async def rsync(
+    source: str | os.PathLike[str],
+    target: str | os.PathLike[str],
+    *,
+    content_only: bool | None = None,
+    options: RsyncOptions | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Asynchronously execute the rsync command.
+
+    :param source: Path to the source file or directory.
+    :param target: Path to the target destination.
+    :param content_only: If True, appends a trailing slash to the source to sync contents.
+                         If None, infers the intent from the raw source string.
+    :param options: Configuration object containing the rsync flags.
+    :return: Process execution results containing stdout, stderr, and exit code.
+    """
+    options = options or RsyncOptions()
+
+    # Inspect the raw string for a trailing slash before pathlib normalizes it
+    source_str = str(source)
+    has_trailing_slash = source_str.endswith(("/", "\\"))
+
+    source_path = Path(source).expanduser()
+    target_path = Path(target).expanduser()
+
+    source_arg = str(source_path)
+    if content_only is True or (content_only is None and has_trailing_slash):
+        source_arg += "/"
+
+    command = [
+        "rsync",
+        *options.to_args(),
+        source_arg,
+        str(target_path),
+    ]
+
+    return await run_command(command)

--- a/src/docbuild/utils/sync.py
+++ b/src/docbuild/utils/sync.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 import os
 from pathlib import Path
 import subprocess
@@ -14,12 +14,17 @@ from .shell import run_command
 class RsyncOptions:
     """Configuration options for rsync execution."""
 
-    archive: bool = True
-    compress: bool = False
-    delete: bool = False
-    dry_run: bool = False
-    verbose: bool = False
-    partial: bool = False
+    # Store the CLI flag directly in the field's metadata
+    archive: bool = field(default=True, metadata={"flag": "-a"})
+    compress: bool = field(default=False, metadata={"flag": "-z"})
+    delete: bool = field(default=False, metadata={"flag": "--delete"})
+    dry_run: bool = field(default=False, metadata={"flag": "--dry-run"})
+    verbose: bool = field(default=False, metadata={"flag": "-v"})
+    partial: bool = field(default=False, metadata={"flag": "--partial"})
+
+    exclude: list[str] | tuple[str, ...] = field(
+        default_factory=list, metadata={"flag": "--exclude"}
+    )
 
     # Acts as an escape hatch for the 100+ rsync options not explicitly modeled here.
     # Users can pass arbitrary flags (e.g., ["--exclude=*.tmp", "--bwlimit=1000"]).
@@ -32,21 +37,36 @@ class RsyncOptions:
         """
         args: list[str] = []
 
-        if self.archive:
-            args.append("-a")
-        if self.compress:
-            args.append("-z")
-        if self.delete:
-            args.append("--delete")
-        if self.dry_run:
-            args.append("--dry-run")
-        if self.verbose:
-            args.append("-v")
-        if self.partial:
-            args.append("--partial")
+        for f in fields(self):
+            # Retrieve the flag string from metadata (returns None if not present)
+            flag = f.metadata.get("flag")
+            if not flag:
+                continue
+
+            # Get the actual value the user provided for this instance
+            value = getattr(self, f.name)
+
+            match value:
+                # Append the flag if the boolean is True (e.g., archive=True -> "-a")
+                case True:
+                    args.append(flag)
+
+                # Skip the flag entirely if it is False or explicitly set to None
+                case False | None:
+                    pass
+
+                # Expand lists or tuples by repeating the flag for each item
+                # (e.g., ["*.tmp", ".git"] -> "--exclude", "*.tmp", "--exclude", ".git")
+                case list() | tuple():
+                    for item in value:
+                        args.extend([flag, str(item)])
+
+                # Catch-all for single configuration values like strings or integers
+                # (e.g., timeout=60 -> "--timeout", "60")
+                case _:
+                    args.extend([flag, str(value)])
 
         args.extend(self.extra_args)
-
         return args
 
 

--- a/tests/utils/test_sync.py
+++ b/tests/utils/test_sync.py
@@ -1,0 +1,70 @@
+"""Unit tests for docbuild.utils.sync."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from docbuild.utils.sync import RsyncOptions, rsync
+
+
+def test_rsync_options_defaults() -> None:
+    """Test default rsync options generation."""
+    options = RsyncOptions()
+    assert options.to_args() == ["-a"]
+
+
+def test_rsync_options_custom() -> None:
+    """Test custom rsync options generation."""
+    options = RsyncOptions(
+        archive=False,
+        compress=True,
+        delete=True,
+        dry_run=True,
+        verbose=True,
+        partial=True,
+        extra_args=["--exclude=*.tmp"]
+    )
+    assert options.to_args() == ["-z", "--delete", "--dry-run", "-v", "--partial", "--exclude=*.tmp"]
+
+
+@pytest.mark.asyncio
+@patch("docbuild.utils.sync.run_command", new_callable=AsyncMock)
+async def test_rsync_basic(mock_run_command: AsyncMock) -> None:
+    """Test rsync execution with basic paths."""
+    await rsync("source_dir", "target_dir")
+
+    mock_run_command.assert_called_once_with(["rsync", "-a", "source_dir", "target_dir"])
+
+
+@pytest.mark.asyncio
+@patch("docbuild.utils.sync.run_command", new_callable=AsyncMock)
+async def test_rsync_content_only_inferred(mock_run_command: AsyncMock) -> None:
+    """Test trailing slash inference."""
+    await rsync("source_dir/", "target_dir")
+
+    mock_run_command.assert_called_once_with(["rsync", "-a", "source_dir/", "target_dir"])
+
+
+@pytest.mark.asyncio
+@patch("docbuild.utils.sync.run_command", new_callable=AsyncMock)
+async def test_rsync_content_only_explicit(mock_run_command: AsyncMock) -> None:
+    """Test explicit content_only override."""
+    # Even without trailing slash in input, it should be appended
+    await rsync("source_dir", "target_dir", content_only=True)
+    mock_run_command.assert_called_once_with(["rsync", "-a", "source_dir/", "target_dir"])
+
+    mock_run_command.reset_mock()
+
+    # Even with trailing slash in input, if False, it should NOT append
+    await rsync("source_dir/", "target_dir", content_only=False)
+    mock_run_command.assert_called_once_with(["rsync", "-a", "source_dir", "target_dir"])
+
+
+@pytest.mark.asyncio
+@patch("docbuild.utils.sync.run_command", new_callable=AsyncMock)
+async def test_rsync_with_pathlib(mock_run_command: AsyncMock) -> None:
+    """Test execution using Path objects."""
+    await rsync(Path("src"), Path("dest"), content_only=True)
+
+    mock_run_command.assert_called_once_with(["rsync", "-a", "src/", "dest"])

--- a/tests/utils/test_sync.py
+++ b/tests/utils/test_sync.py
@@ -5,31 +5,39 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import docbuild.utils.sync as sync_mod
 from docbuild.utils.sync import RsyncOptions, rsync
 
 
-def test_rsync_options_defaults() -> None:
-    """Test default rsync options generation."""
-    options = RsyncOptions()
-    assert options.to_args() == ["-a"]
-
-
-def test_rsync_options_custom() -> None:
-    """Test custom rsync options generation."""
-    options = RsyncOptions(
-        archive=False,
-        compress=True,
-        delete=True,
-        dry_run=True,
-        verbose=True,
-        partial=True,
-        extra_args=["--exclude=*.tmp"]
-    )
-    assert options.to_args() == ["-z", "--delete", "--dry-run", "-v", "--partial", "--exclude=*.tmp"]
+@pytest.mark.parametrize(
+    ("options", "expected"),
+    [
+        (
+            RsyncOptions(),
+            ["-a"],
+        ),
+        (
+            RsyncOptions(
+                archive=False,
+                compress=True,
+                delete=True,
+                dry_run=True,
+                verbose=True,
+                partial=True,
+                extra_args=["--exclude=*.tmp"],
+            ),
+            ["-z", "--delete", "--dry-run", "-v", "--partial", "--exclude=*.tmp"],
+        ),
+    ],
+    ids=["defaults", "custom_flags"],
+)
+def test_rsync_options_to_args(options: RsyncOptions, expected: list[str]) -> None:
+    """Test rsync options generation."""
+    assert options.to_args() == expected
 
 
 @pytest.mark.asyncio
-@patch("docbuild.utils.sync.run_command", new_callable=AsyncMock)
+@patch.object(sync_mod, "run_command", new_callable=AsyncMock)
 async def test_rsync_basic(mock_run_command: AsyncMock) -> None:
     """Test rsync execution with basic paths."""
     await rsync("source_dir", "target_dir")
@@ -38,7 +46,7 @@ async def test_rsync_basic(mock_run_command: AsyncMock) -> None:
 
 
 @pytest.mark.asyncio
-@patch("docbuild.utils.sync.run_command", new_callable=AsyncMock)
+@patch.object(sync_mod, "run_command", new_callable=AsyncMock)
 async def test_rsync_content_only_inferred(mock_run_command: AsyncMock) -> None:
     """Test trailing slash inference."""
     await rsync("source_dir/", "target_dir")
@@ -47,7 +55,7 @@ async def test_rsync_content_only_inferred(mock_run_command: AsyncMock) -> None:
 
 
 @pytest.mark.asyncio
-@patch("docbuild.utils.sync.run_command", new_callable=AsyncMock)
+@patch.object(sync_mod, "run_command", new_callable=AsyncMock)
 async def test_rsync_content_only_explicit(mock_run_command: AsyncMock) -> None:
     """Test explicit content_only override."""
     # Even without trailing slash in input, it should be appended
@@ -62,7 +70,7 @@ async def test_rsync_content_only_explicit(mock_run_command: AsyncMock) -> None:
 
 
 @pytest.mark.asyncio
-@patch("docbuild.utils.sync.run_command", new_callable=AsyncMock)
+@patch.object(sync_mod, "run_command", new_callable=AsyncMock)
 async def test_rsync_with_pathlib(mock_run_command: AsyncMock) -> None:
     """Test execution using Path objects."""
     await rsync(Path("src"), Path("dest"), content_only=True)


### PR DESCRIPTION
Addresses #452

**What was done:**

* **Created RsyncOptions Dataclass:** Implemented a flexible configuration class in `docbuild.utils.sync` to handle common rsync flags (`archive`, `delete`, `dry_run`, etc.) alongside an `extra_args` list, preventing function signature bloat while maintaining full CLI flexibility.
* **Implemented Async `rsync` Wrapper:** Created an asynchronous `rsync()` function that wraps `docbuild.utils.shell.run_command` to execute synchronization tasks safely and concurrently.
* **Smart Trailing Slash Handling:** Added path inspection to automatically infer if the user intends to sync a directory or just its contents based on the presence of a trailing slash, with an explicit `content_only` override parameter.
* **Registered System Dependency:** Added `rsync` to the `SYSTEM_DEPENDENCIES` dictionary in `constants.py` so it is automatically verified by the `docbuild doctor` command.
* **Added Comprehensive Tests:** Wrote isolated unit tests verifying argument generation, trailing slash behavior, and `Path` object compatibility.
* **Resolved Type Warnings:** Fixed a pedantic Pylance strict-typing error regarding `Enum.name` types in `constants.py`.

@tomschr, as we discussed, I kept this PR strictly focused on the core `rsync` utility implementation to keep a clean separation of concerns. Once this is merged, I will open the next PR to actually integrate this into the `build` subcommand logic.

### Checklist

* [x] Code is properly formatted (`uvx ruff check --fix` and `uvx ruff format`)
* [x] Tests have been updated and are passing locally
* [x] A changelog entry was added to `changelog.d/`
* [ ] Documentation has been updated *(N/A for this PR)*